### PR TITLE
move podcast to examples

### DIFF
--- a/examples/podcast/podcast_runner.py
+++ b/examples/podcast/podcast_runner.py
@@ -1,0 +1,70 @@
+from core import Graphiti
+from core.utils.bulk_utils import BulkEpisode
+from core.utils.maintenance.graph_data_operations import clear_data
+from dotenv import load_dotenv
+import os
+import asyncio
+import logging
+import sys
+from transcript_parser import parse_podcast_messages
+
+load_dotenv()
+
+neo4j_uri = os.environ.get("NEO4J_URI") or "bolt://localhost:7687"
+neo4j_user = os.environ.get("NEO4J_USER") or "neo4j"
+neo4j_password = os.environ.get("NEO4J_PASSWORD") or "password"
+
+
+def setup_logging():
+    # Create a logger
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)  # Set the logging level to INFO
+
+    # Create console handler and set level to INFO
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(logging.INFO)
+
+    # Create formatter
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+
+    # Add formatter to console handler
+    console_handler.setFormatter(formatter)
+
+    # Add console handler to logger
+    logger.addHandler(console_handler)
+
+    return logger
+
+
+async def main(use_bulk: bool = True):
+    setup_logging()
+    client = Graphiti(neo4j_uri, neo4j_user, neo4j_password)
+    await clear_data(client.driver)
+    messages = parse_podcast_messages()
+
+    if not use_bulk:
+        for i, message in enumerate(messages[3:14]):
+            await client.add_episode(
+                name=f"Message {i}",
+                episode_body=f"{message.speaker_name} ({message.role}): {message.content}",
+                reference_time=message.actual_timestamp,
+                source_description="Podcast Transcript",
+            )
+
+    episodes: list[BulkEpisode] = [
+        BulkEpisode(
+            name=f"Message {i}",
+            content=f"{message.speaker_name} ({message.role}): {message.content}",
+            source_description="Podcast Transcript",
+            episode_type="string",
+            reference_time=message.actual_timestamp,
+        )
+        for i, message in enumerate(messages[3:7])
+    ]
+
+    await client.add_episode_bulk(episodes)
+
+
+asyncio.run(main())

--- a/examples/podcast/podcast_transcript.txt
+++ b/examples/podcast/podcast_transcript.txt
@@ -1,0 +1,419 @@
+0 (3s):
+So let's talk a little bit about what you see as the purpose of college. I've heard you say that some people use it for chasing status was your phrase, while others use it to prepare themselves to improve not just themselves and their families, but society. So what do you see as the mission?
+
+1 (23s):
+Well, part of the ethos of Jesuit institutions from the beginning is that we want our students to learn and get all the tools they need to flourish. And we wanna give them opportunity, but we also want them to have all of that, not just for them, but for the world. That we have this enormous force multiplier of sending them out with the desire to matter and the skills to really do that. And they will choose how, but we really need for them to understand that the saccharine high of just getting the job that pays the most or seeking status for themselves, that's not what will make them happy, and that is not the point of their lives. And so they can do that and still be happy.
+
+1 (1m 3s):
+But what really drives you is knowing, looking back on your deathbed at your life. How did I matter?
+
+0 (1m 11s):
+I'd like to introduce our guest for today,
+
+1 (1m 13s):
+Tania Tetlow, president of Fordham University.
+
+0 (1m 17s):
+Fordham is a well-regarded private university in New York City, founded in 1841 and run for most of its history by the Jesuits, the Roman Catholic religious order that dates to the 16th century. Tetlow is the first female president of Fordham, as well as the first layperson.
+
+1 (1m 34s):
+There's a very daunting hall of portraits outside of my office. You know, all of these priests going back to 1841,
+
+0 (1m 41s):
+Tet, LO's own father was in fact a priest. But while getting his psychology PhD at Fordham, he met his Wouldbe wife, another graduate student, so he left the priesthood. Tanya was born in New York not long before the family moved to New Orleans, so Fordham is in her genes.
+
+1 (2m 0s):
+A good way to recruit me is they can tell me you exist because of us.
+
+0 (2m 4s):
+Fordham did recruit her and she returned as president in 2022. Before that, Tetlow was president of Loyola University in New Orleans, another Jesuit school, one of 27 in the us, and about 130 globally. The Jesuits have always been big on educating as well as evangelizing. Tetlow is a lawyer by training and taught law for a while at Tulane. And before that she was a federal prosecutor in New Orleans. What does it say about the state of higher education that Fordham chose as its president? Not only a non priest, but a former prosecutor?
+
+1 (2m 44s):
+We spent our time, all of us in these jobs playing defense and navigating crises. Everything from the protest movements to efforts from those who work here to make sure that they're paid well and fairly and how to balance that against remaining affordable to students and bridging that gap just gets harder and harder
+
+0 (3m 6s):
+Today on Freakonomics. Radio. Another conversation in our ongoing look at what college is really for. With higher ed under attack from multiple angles, Tetlow sees an urgency in turning things around
+
+1 (3m 20s):
+The countries against whom the US competes. None of them are disinvesting from education right now.
+
+0 (3m 26s):
+We talk about the difference between religious and secular universities.
+
+1 (3m 30s):
+I don't have to be afraid to talk about values in my out loud voice.
+
+0 (3m 34s):
+And we talk about why despite all the trouble and controversy, the enterprise is worth defending.
+
+1 (3m 41s):
+If you want a great city, build a university and wait 200 years.
+
+4 (3m 59s):
+This is Freakonomics Radio, the podcast that explores the hidden side of everything with your host Steven Dubner. Woo,
+
+0 (4m 15s):
+Kamala Harris. Before serving as Vice president and US Senator was a prosecutor, the district attorney for San Francisco and the California Attorney General. Now that she's running for President Harris is leaning into her experience as a prosecutor.
+
+5 (4m 33s):
+So in those roles, I took on perpetrators of all kinds. So hear me when I say I know Donald Trump's type.
+
+1 (4m 47s):
+As a fellow former prosecutor, I really admire that background in her.
+
+0 (4m 52s):
+Can you imagine ways in which that background can be useful as perhaps president of the United States?
+
+1 (4m 59s):
+Well, in a funny way, you have such ultimate power as a prosecutor over your one single case. I found that really good preparation for having power in other settings.
+
+0 (5m 13s):
+What did you learn from being a prosecutor that helps you in your role as a college president?
+
+1 (5m 18s):
+It's the only kind of lawyer where your ethical duty is not to represent a client but to do justice. That is what you're charged with. And so I spent as much time talking to witnesses or defendants who are cooperating about how they ended up there and what their lives were like, and really learning who they were as people in ways that I don't know is typical of people in that job. But I really loved,
+
+0 (5m 40s):
+Tell me maybe your most memorable case.
+
+1 (5m 43s):
+I had a case where a high school teacher helped an old buddy who was in prison collect some packages.
+
+0 (5m 54s):
+This isn't gonna end well. No.
+
+1 (5m 57s):
+And it was just one of the most fascinating cases about human beings and how we dilute ourselves. A high school teacher whose old buddy from high school, the popular kid who would never talk to him in high school, finally reached out from prison to see if they could be friends. And he, out of so many high school drama kind of psychology, decided, oh, sure, I will accept these packages coming in the mail without knowing what they are. And got dragged into this whole drug scheme. So the teacher who got dragged into it cooperated, no one else would've been brave enough to do it because he was up against the major kingpins.
+
+0 (6m 33s):
+He's your witness then
+
+1 (6m 34s):
+He's my witness. And we were going against the person who was running a heroin scheme from jail. But it took a long time to just get him to admit his real emotions rather than have bravado on the stand. I finally, after berating him and prep got him to admit I was afraid.
+
+0 (6m 52s):
+I mean, I don't blame him. Did you win that case? Yes. So when I think of the Jesuit tradition, I think of inquiry and intellectualism and I think especially of the concept of discernment, which I gather is very important within the tradition. And it, it strikes me that discernment is fairly absent these days, at least in the public square. And that's one reason I wanted to speak with you today because I figured you could teach me and all of us a little bit about how to get in touch with that, maybe apply it. So I'd like you to define discernment as you see it and describe how you try to spread that as a president of a Jesuit university,
+
+1 (7m 35s):
+It is basically the opposite of social media in shorthand. So discernment means to take time to consider a big decision and not to jump to conclusions. It means being open and curious. It means assuming good intentions of the person you're disagreeing with, which we are all very bad at right now. And it means being self-aware enough of your own biases and filters that you realize what will prevent you from seeing the truth. And right now, I think we're all feeling the pressure to teach those skills to our students, especially this fall as we approach the election and all the turmoil that society's going through.
+
+1 (8m 19s):
+How do we double down on teaching those skills when they have become so countercultural?
+
+0 (8m 23s):
+Yeah, but I would imagine that you are recruiting for students who already buy into the notion of discernment. No,
+
+1 (8m 30s):
+It's chicken and egg, right? The students who are attracted to us tend to have this sense of purpose, and I will say the two Jesuit institutions I've led have student communities who don't lean into self-righteousness in quite the same way that young people are tempted by right now.
+
+0 (8m 47s):
+What do you think would happen if you could play some version of Freaky Friday and bring the entire educational architecture of Fordham to a place like Harvard or Penn for a week and apply all the layers of discernment in education there? How would that go over with those student bodies do you think? Well,
+
+1 (9m 10s):
+There is a freedom I find in being in a religious institution where I don't have to be afraid to talk about values in my out loud voice in quite the same way that in a secular institution we were just so afraid of offending by having any reference to religion at all.
+
+0 (9m 28s):
+Can you give an example of some kind of conversation you might've liked to have at Tulane where you felt it wouldn't be accepted?
+
+1 (9m 38s):
+When we would talk about diversity there, we were left to some of the more tepid values of hospitality and welcome. And when I talk about it at a Jesuit institution, I'm able to really lean into the fact that our faith believes profoundly in the equality and human dignity of every single person, that we believe that we owe people more when they need more.
+
+0 (10m 5s):
+Pope Francis, who's the first Jesuit pope, has said that some universities I know in America are too liberal and he accused them of training technicians and specialists instead of whole people. I'm curious for your take on that.
+
+1 (10m 18s):
+Well, it's interesting because this parallel attack in this country on the value of liberal arts, and for us as Catholic institutions, we clinging to our core curriculums fiercely in this country. It's not really a liberal problem, it's more from the other side, this mocking of English majors as if much of the powerhouse of this country didn't major in English, right? And when we talk to employers, they're desperate for us to teach those kind of emotional intelligence, communication, critical thinking skills that you learn in philosophy in English and all of those kinds of courses because that's really hard to teach on the job. They can teach technical skills on the job, and frankly, the technical skills we teach are often defunct by the time the kids graduate.
+
+1 (11m 6s):
+Right? Those change too much.
+
+0 (11m 9s):
+So Fordham is a Catholic university, but the share of students who describe themselves as Catholic surprised me. Can you talk about that?
+
+1 (11m 17s):
+It's about 40%. We became religiously plurals in a way that's kind of a hidden story of American higher ed Catholic students were not always welcome in the first half of the 20th century and before at elite institutions, which we sometimes forget, were founded as Protestant institutions and had attitudes towards really immigrants, Irish, Italians, others coming in off the ships and not wanting them there in the same way they created quotas and caps for Jewish students. And so Catholic schools when they were founded were full of Catholics who did not have other options. And we welcome Jewish students who often did not have other options. When those doors opened, we had some of the same dilemmas of women's colleges and HBCUs of what do we do?
+
+1 (12m 3s):
+And so we very much welcome students from all face and it changed who we are. We became very ecumenical. But now far more of our student body is just secular. They were raised with no religious tradition whatsoever.
+
+0 (12m 17s):
+When I look at the student population at Fordham, I see that it's got about 40% of what are called underrepresented populations, 17% Hispanic Latino, 13% Asian, 5.5% black. It strikes me that you are significantly more diverse than a lot of the very liberal schools that talk about diversity a lot. How does that happen?
+
+1 (12m 41s):
+Well, partly success begets success. To come to a school that is already diverse means you have strength in numbers where you won't be alone. and I think it really helps to be in New York a place that is already so diverse. We get to recruit in our backyard, we get to attract people to a city that has everyone in the world here.
+
+0 (13m 2s):
+I'm curious how the Jesuit tradition and Catholicism generally intersect with the politics of this moment. Many of my Catholic friends and family members are really torn because they don't like Donald Trump as a person or a candidate for a variety of reasons. But they do really like the fact that he's created a Supreme court that has put much stricter limits on abortion. And I'm curious how that plays out at Fordham.
+
+1 (13m 29s):
+Well, Catholic doctrine does not neatly fit in either political party because in many ways it's the opposite of libertarianism, which also doesn't neatly fit in either party. So you know, Catholic teaching would be somewhat more conservative, restrictive on social issues, but far more Progressive on economic issues than the Republican party. Right? Catholic social teaching to many more conservative Catholics seems incredibly radical, but it is in fact the doctrine we've had for a very long time and the church, and it's pretty clearly what's in the gospels.
+
+0 (14m 1s):
+Give an example of that for those who don't know.
+
+1 (14m 4s):
+You know, the Catholic Church believes profoundly in caring for the poor is a priority of caring about the right to organize labor, racial justice, all of those kinds of issues that don't neatly fit with a Republican party that does care about restricting abortion and other things. In American society, we've always had a balance that was critical between individual rights and a sense of community and responsibility. That balance is really out of whack right now. We've leaned so heavily into individual rights, which are crucial, but if they're unmoored from the idea of community of what we owe each other, they're really quite dangerous if we're all in it for ourselves, Who, Are, We.
+
+1 (14m 48s):
+And so what Catholic teachings really offer is a reminder that we do have to care about community. That we have not just rights, but responsibilities
+
+0 (14m 58s):
+After the break. The friction between rights and responsibilities and how it played out at Fordham this past spring.
+
+1 (15m 4s):
+You don't point bullhorns at the library during study session.
+
+0 (15m 7s):
+I'm Steven Dubner, you're listening to Freakonomics Radio. We will be right back As president of Fordham University. Tania Tetlow oversees roughly 17,000 students and 750 faculty. The biggest majors are in finance, psychology, and government. Fordham also has several prestigious graduate programs in business and law education and social work, and even some theology still. The school is split between two main campuses, both in New York City, one in the Rose Hills section of the Bronx, the other at Lincoln Center in Manhattan.
+
+0 (15m 48s):
+Those two campuses are about nine miles apart. If you walked from one Fordham campus to the other, you would pass right through Columbia University. This past spring as pro-Palestinian demonstrators set up encampments at many schools. Columbia had some of the most intense protests, which led to more than a hundred arrests. So what was happening at Fordham, I asked Tetlow to describe it.
+
+1 (16m 14s):
+We have students who are from Palestine who are very worried about parents and grandparents they can't get in touch with. They're going through all the stages of grief and trauma, and they've been extraordinary. And I've also felt, you know, if yelling at me will make you feel better for even half a minute, go for it. It is my honor, because they're feeling so powerless. We also have members of our community who are Jewish and Israeli and who lost family members on October 7th. And so it made me realize how close New York is to the Middle East and of how profound that pain is for part of our community.
+
+1 (16m 57s):
+And so what was really impressive this year is student activists did prayer vigils and they did teach-ins and they talked and they listened and they engaged with complexity and they really tried to do the work of expressing outrage at that which they're outraged by, but without just yelling at the nearest authority figure or trying to disrupt the right of their fellow students to learn. That got ratcheted up when the clearing out of Hamilton Hall at Columbia happened
+
+0 (17m 29s):
+By the police. We should say
+
+1 (17m 31s):
+By the police. Yeah. And so the next morning students who told us later were really upset by that came and started a little encampment in a classroom building in our Manhattan campus. We persuaded most of them to leave, but we did end up having the police arrest on minor misdemeanors, about 15 mostly students. So that was painful because you know, how do you navigate the rights of our 17,000 students to learn on the cusp of finals with the rights of those dozen students to express themselves and to protest? And it was really hard.
+
+0 (18m 8s):
+And what happened then? Did it deescalate after those arrests? Yes. I've read that when you were a kid, your father who was a psychologist and professor and also counseled prisoners that he had a sign on his desk that said question authority, but politely and with respect. How do you feel that slogan relates to, let's say, the campus politics around this particular issue at Fordham? Was authority questioned politely with respect and fruitfully or not really? I think
+
+1 (18m 42s):
+For the most part it was, we met with student activists and they have been profound and persuasive and respectful and thus very effective, right? Going to people and saying, I think that you are an evil, awful person and I'm gonna scream at you until you agree with me doesn't work. It feels good. It's venting, but it is not the same as activism. We have always authorized any request to protest on our campus that students bring us. We're at a hundred percent with that. But what we navigate with them is, you know, you don't point bullhorns at the library during study session. You find ways to make your ability to express yourself, not have to disrupt the education of your fellow students.
+
+1 (19m 23s):
+And so when we think about those restrictions, we need to think about them both for protests we agree with and those we don't. You can't just imagine that the protestors are expressing a cause that you believe in. You also have to imagine one that you might find repugnant because the rules have to be the same for both or we lose credibility.
+
+0 (19m 40s):
+I know that back in 2016, which predates your presidency by quite a few years, there was a movement by Fordham students to start a chapter of Students for Justice in Palestine, which is a national organization, and that was at the center of many of the campus protests last year. And that was denied. I believe that there was a court case around that and the court upheld the Fordham decision, if I've got that correct. Yes. and I also know that according to the foundation for individual rights and expression fire, which looks at free speech on campuses, Fordham ranks in the bottom 10 for colleges or universities across the country. So how do you as a president try to create a balance where you're not liming free speech, but also not churning your campus into a hotbed where it can't accomplish the central purpose?
+
+1 (20m 30s):
+First of all, those fire rankings, we don't really understand how they come to them. It is always tricky, right? At Fordham, we famously, and it got litigated suspended. A student who after a verbal argument with fellow students, went and bought an assault rifle and then posted that on social media. If he had shot up the campus, we would've been reamed If. We had not done anything, was so obvious a warning. But by suspending him, we got really attacked by some free speech purist groups saying, how dare you? It's just because you're against guns, right? So those are the kinds of lines we have to navigate every day. And what I find really a shame right now is those who push for more speech on campus have suddenly flip flopped on a lot of those issues.
+
+1 (21m 15s):
+Right now they're yelling at us because we don't suppress speech more. This would've been a moment to really stand up and say, we find some of these protests to be anathema and disturbing, but this is what it looks like to put up with speech that you disagree with. But instead we're just being called hypocrites because we don't suppress it and they're being hypocrites in accusing us of hypocrisy. So it's very head spinning because what remains is the question of are you for this freedom or are you not?
+
+0 (21m 43s):
+Do you have any evidence that discernment, as we discussed earlier, can help fight polarization or these kind of standoffs in the moment?
+
+1 (21m 55s):
+I know from our faculty that every day in the classroom they try to not just teach knowledge, but the skills of discernment of what it means to have reflective practices where we're gonna really think about what we learned and stop and take time. This is something that as a law professor, as part of our ethos, I need for you to articulate the other side of the argument. Not because we're morally relativist, but because you can't know the strength of your belief until you're willing to think about the other side.
+
+0 (22m 24s):
+And as a lawyer, your job is to argue the best case for whoever you end up representing, which I guess is a way to train in seeing the other side. Yeah,
+
+1 (22m 33s):
+Right. I mean, legal education has a leg up in this because we've always done this work. and I think our faculty do a brilliant job of navigating how to take the temperature down when people disagree, how to say, okay, you are attacking the other student who you disagree with. You're attacking them personally. You're assuming they have bad intentions, you're not listening to them.
+
+0 (22m 53s):
+Are you sure this is the job you want? I mean, it's a hard job.
+
+1 (22m 57s):
+It is a very hard job, but I do love it because it matters. And sometimes things are hard because they're important.
+
+0 (23m 4s):
+So one way universities are important, or at least supposed to be, is as an institution that can build social trust. Researchers who study this argue that universities and the military and even sports teams or places that do this well because in each case you've got a bunch of individuals from different backgrounds coming together with a common goal, or at least as part of a community. And I'm really curious how you think about, I mean this is an absurd and large question, but how you think about the rights and role of the individual in a community or society today with Fordham as the microcosm of that?
+
+1 (23m 43s):
+Well, universities are one of the places of great hope. We do bring people together. And that's not just the obvious demographics, it's also rural and urban. It's different backgrounds economically, it's just different upbringings. And we've leaned into that from a Progressive point hard, but also that they find commonality that they have so much more in common when they least expect it. I think that our job is to express both and to treat diversity as we used to be allowed to do before the Supreme Court banned it, but about that quality of community and what it means. And so the court has continued to allow that in the military academies 'cause they understand exactly how valuable it is there.
+
+1 (24m 24s):
+They've now forbidden us from overtly considering that in admissions. But regardless, we have the opportunity in our communities to really encourage, nudge, persuade students to know each other, to lean into that. For example, Greek life can be wonderful, but it can also divide. So we don't have that here. We try to find ways to get students to bond that aren't the obvious, finding people from exactly your tribe, but really reaching out across that. But it is,
+
+0 (24m 56s):
+What's it for instance of that, of
+
+1 (24m 58s):
+Kind of making student organizations really more about interest than about identity or self-selection and exclusivity? One of the most important places we teach is in the residence halls, right, of how we use peer mentoring because we have RAs who are just a little bit older than the students that they're mentoring and thus have credibility that we don't and of how they're on the front lines of navigating that profound loneliness that modern society has created. Social media sort of buries them in connection that is empty, especially after Covid when they were literally isolated. They have to learn the skills of how to really be with each other.
+
+1 (25m 38s):
+And we're now having to teach that in ways that we didn't 10, 20 years ago.
+
+0 (25m 46s):
+After the break, Tania Tetlow on university finances and pricing we're
+
+1 (25m 52s):
+Stuck in a really stupid pricing model.
+
+0 (25m 55s):
+I'm Steven Dubner. This is Freakonomics Radio. We'll be right back. Tell me a little bit about the finances of Fordham, maybe operating budget, and I'm just curious to know how things are looking.
+
+1 (26m 16s):
+It's going well. We're not on the kind of crisis that most of higher ed is in right now financially, but it's still a squeeze. Every year we're hitting the ceiling of what American families can afford to pay in a world where we very much want to have normal and fair and generous pay increases for all of our employees. We're basically a service industry. So most of our budget goes to our people. And so those pressures are hard because we're pretty tuition dependent to pay for that. Our budget's about 700 million. Most of that is for the people we hire. It's very labor intensive work to teach and serve and then maintain a campus.
+
+1 (26m 56s):
+What's
+
+0 (26m 57s):
+Your endowment of Fordham?
+
+1 (26m 58s):
+It is just about a billion.
+
+0 (27m 1s):
+Okay, so that sounds like a lot of money to the average person except Harvard's is 50 billion.
+
+1 (27m 5s):
+Exactly. It's hard fought for a school that mostly taught first generation students for so many decades, almost two centuries. It's sort of like a museum endowment that that interest on that is what supports us. And in our case very specifically supports primarily scholarships. And for us it's you know, maybe 5% of our budget. It's not like an Ivy League that's no longer dependent on tuition because they get so much revenue from their endowment.
+
+0 (27m 33s):
+What would you do if you had a $50 billion endowment at Fordham? Well,
+
+1 (27m 37s):
+We'd be able to fully meet need for all of our students, first and foremost, which would be a joy. And you know, we'd invest in everything that we wanna do and our ambitions, like
+
+0 (27m 47s):
+What would that be?
+
+1 (27m 48s):
+It would be research, but it really matters to keep that in balance with the quality of our teaching. So you know, research prowess, that also means those faculty are in the classroom every day teaching students. We are so strong in the humanities and law and business and to really be relevant and at the table, we need to connect with what's going on in AI with how to wake people up about climate change and find answers to the threats to democracy all over the world.
+
+0 (28m 17s):
+College is just absurdly expensive. Fordham is in the $60,000 a year range tuition, is that right? Yeah. So talk about how you deal with financial aid, whether it's need-based and also merit aid. So
+
+1 (28m 31s):
+We are need blind and admissions, but we are not one of the handful of schools wealthy enough to fully meet need. And so that is our biggest priority. The biggest part of our budget is making ourselves affordable. We're starting to try to shift more of our money from merit aid to financial need. The advantage of merit aid is you attract top students, you make them feel more special because of the scholarship. The disadvantage is of course some of those students who are the top students also have need, but some of them don't. And so you're spending money that you'd rather spend on those who can't afford to be there. But we're stuck in higher ed in a really stupid pricing model.
+
+1 (29m 11s):
+The part that we know about is the price discrimination, where we charge the wealthy, what they can afford to pay and thus supplement those who can't. But the part that I think is hidden is that the market really drives sticker price being high because sticker price signals quality. The elite schools tend to have more of the barbell, the very wealthy, and those really struggling. Most of us have far more of the middle class who often frankly get squeezed out of the elite schools when schools like ours reduce our sticker price to what we tend to actually charge. On average, those schools have tended to fail because the consumer is suspicious that that school is not as good because it does not charge as much.
+
+0 (29m 54s):
+So what is your actual average price that let's say an incoming freshman will pay this year with a sticker price of around 60 K. What will the actual average be?
+
+1 (30m 2s):
+30.
+
+0 (30m 3s):
+Wow. Well, there have been accusations that colleges and universities have colluded in the past. Sometimes they've been busted for it. There are others who argue that they should collude more and I would think that this would be a case where collusion would be good to fight this very problem that you're talking about. Has there been any progress toward that?
+
+1 (30m 20s):
+So there's a world where we would all say, okay, let's all lower our prices to what we really charge because that sticker price is so disheartening and so scary to those without the sophistication to understand it's not real, but we're not allowed to do that. We can't collude on price. So this is where the market is. You know, it sounds silly except that when you go to buy, you know a jacket and there's one jacket that's a hundred dollars, that's 50% off and one jacket that's $50. Even if they're the same jacket, you're gonna go for the first one, right? This is human psychology. This is how we all behave. And if you get the 50% off because you are special because you earned the scholarship, it makes you feel even better about it.
+
+1 (31m 1s):
+And so it is very hard for us to break out of this system.
+
+0 (31m 5s):
+Let's talk a little bit about growing the size of student populations. Historically, the college population in the US rows and rows and rows and rows and rows. But then it hit what looked to be a bit of a ceiling and it's come back down a little bit. There are some schools, however, who just don't like to grow. There's research by these two economists, Peter Blair and Kent s Smithers that finds that elite colleges have mostly capped their enrollment numbers since the 1980s. Their argument is that those caps have to do with mostly universities wanting to maintain their prestige, protect their reputations, and they argue in a kind of quiet voice that this is a shame. The idea being that if these universities are so good and so elite at educating people, they should educate more people.
+
+0 (31m 48s):
+Just like any firm that successful wants more customers, not the same number. So let's just start with that. Your thoughts on the notion that elite schools keep their populations about the same. Why they do that and why you're not thinking like that?
+
+1 (32m 5s):
+When you look at when elite schools stopped growing, it was exactly the same time US News introduced the rankings and those rankings until very recently encouraged a major category of selectivity. It created these profound incentives for all of us. But you know, the elites who battle with each other for top dog to reject as many students as possible, that's how you were measured. The elites get status and prestige and very specifically rankings by virtue of how low that acceptance rate is. My favorite satirical headline once was, Stanford achieved 0% emission rate. It was a joke, but it was something very real.
+
+0 (32m 44s):
+Just barely. Yep.
+
+1 (32m 45s):
+Yes, exactly. That's where we've landed. The idea that the solution to this is to get a few thousand more students into those elite schools, I think begs the question of why they are the answer. Because what the rankings also did is it took a higher ed system of glorious complexity and variety, about 4,000 nonprofit schools, and it put us in line order when really we're in clumps of ties. And it was never true that you could only get a good education at a handful of schools. I think to buy into that, to say that that should be the focus really ignores the fact that there are probably a hundred universities in this country that provide the same kind of academic excellence, and we need to remind ourselves of that because the more we just play into the rankings game of chasing status, the more alumni get status from giving to those universities.
+
+1 (33m 35s):
+We've really ratcheted up the cleaving between the haves and have nots and that gets worse and worse.
+
+0 (33m 41s):
+So Fordham, I believe, has increased enrollment by about 10% over the past 10 years. Does that sound about right?
+
+1 (33m 48s):
+I think so, yeah.
+
+0 (33m 49s):
+So talk to me about that. When you're trying to grow, especially in a city like New York, what are the big challenges? Are there enough good professors? What does it mean for facilities? Are there enough students that you want and so on?
+
+1 (34m 1s):
+The biggest challenge is students because right now we have a demographic downturn in the number of 18 year olds generally, and that will peak 18 years after the 2008 recession started. People dramatically had fewer children, but we also have a drop in the percentage of Americans going to college, and that has been rather dramatic. It's a mix of covid and then most recently of the FAFSA formed debacle. So you may have seen in the news, but the Department of Ed stumbled for all sorts of reasons to redo the FAFSA form.
+
+0 (34m 40s):
+In case you haven't seen the FAFSA debacle in the news, FAFSA stands for free application for federal Student aid. It is administered by the federal government. This past admission season, there were technical problems that meant FAFSA came online three months late and then sent inaccurate financial aid offers to around a million applicants.
+
+1 (35m 3s):
+What it means is that for most schools, they're looking at a decline in their populations and in community colleges, especially a quite dramatic one. So for any school other than the very, very elites to grow is not possible. Right now what I worry about is that for most of higher ed, they're just not gonna be able to make it anymore and the country will suffer so bunch from that. We understand still as a society that K through 12 is a right, is not seen as some kind of calming experiment, but somehow higher ed is not seen as a right anymore. After World War II was the last time the economy really shuttered to a halt because we weren't building weapons anymore and Congress made the brilliant decision to invest in all those millions of veterans coming home from the war who would not have jobs to say, we will pay for your education.
+
+1 (35m 53s):
+And it fueled so many Nobel prizes and Pulitzers and the rise of the middle class in the fifties and global economic dominance in the world. It was such a smart thing to do. And yet now we're doing the opposite. The Pell Grants, which when they were unveiled in the seventies, were enough to cover tuition. Room and board for most schools now are a pittance and states are disinvesting from their public institutions. China's not doing that.
+
+0 (36m 20s):
+The public's perception of academia has fallen a lot. It began on the right, but now the left is catching up. There are many perceptions out there, one of which is that college campuses can be hostile to young men. Fordham is now majority female. I was surprised to see there's another perception that colleges are hostile to anyone who leans even a little bit conservative in any dimension. Students and faculty, there's the perception that it's too expensive, it's too exclusive, it's not useful enough in the real world. So how are you reckoning with that general perception of decline?
+
+1 (36m 56s):
+Well, it's hard because there's great political benefit to tearing down trust in institutions. It's easy to do, it resonates with people who are understandably cynical. And once you've done it, it's done. And it's very hard to rebuild. You know, all of higher ed has become majority female and that's a much deeper topic to grapple with than what I worry about as well.
+
+0 (37m 17s):
+You worry because there are all those men who are not getting involved in that kind of system.
+
+1 (37m 22s):
+Exactly. I think men are, are opting out of the opportunities that they need in an increasingly knowledge based economy and we will all suffer as a result of that. And so I worry about that. So the return on investment is sort of laughable because when you look at the data, it is so clear the financial return on investment, right, which just proves that you can make things up and they stick. and I would say that part of what I find really offensive are politicians saying that it's not worth it to go to college. None of whom say that to their own children,
+
+0 (37m 53s):
+None of whom didn't go to college either. Exactly. And law school on top of that
+
+1 (37m 58s):
+And graduate school. So you know, we've become a political football of late in ways that make us really vulnerable. But what's so sad about that is, you know, the countries against whom the US competes, none of them are disinvesting from education right now. We are shooting ourselves in the foot in profound ways. When we decide for political points, we will take away one of the great higher education systems in the world that's been the envy of the world for so long. We're going to keep pulling back from it, pulling funds, pulling credibility and trust, all for scoring political points in a temporary way.
+
+0 (38m 37s):
+If we're going to talk about the attacks on institutions generally, let's not ignore the one that you're associated with, which is the Catholic church. That's a case where it mostly revolved around the priest sex scandals that have been revealed and the coverups really of the past 30 or 40 years. I haven't seen numbers lately on the perception of the Catholic church as an institution, but I'm guessing it's fallen very similarly to the way the reputation of colleges and universities have.
+
+1 (39m 5s):
+The trust in religious institutions generally plummeted a while back. And then of course trust in the Catholic church given the scandals deservedly plummeted. What I know from having spent much of my career fighting against sexual abuse is that that denial, those cover ups, the level of abuse still exists in all other institutions that have trusting relationships over children. And my worry is we're not learning the painful lessons the church learned.
+
+0 (39m 35s):
+What other institutions do you mean?
+
+1 (39m 37s):
+We're seeing scandals emerge from Boy Scouts, from other religious institutions, but also the vast majority of child sex abuse happens within families. What I used to do every day was to go into court and beg judges to care about that. And they found it so depressing that they just decided it was made up most of the time. You know, that's a whole other episode. But the reality is again, these problems weren't unique to the church. The church really messed it up and my hope is that everyone else will stop being in denial about where we still have a crisis.
+
+0 (40m 11s):
+Do you have much a relationship with the cardinal of the Archdiocese of New York?
+
+1 (40m 15s):
+Yes. Cardinal Dolan and I get together at least once a year, if not more often. It's not that Catholic universities report to the church, nor do we get funding from them. But we exist in relationship and I'm lucky in that it's a very friendly and cordial relationship.
+
+0 (40m 34s):
+Do you think it makes sense that academic institutions like Fordham have such big tax advantages in a city like New York? You know, if you look at the biggest landowners in New York, two of them are universities, Columbia and NYU, and then the Catholic church is another big one and they're all tax exempt and you at for mer, kind of at the sweet spot of those two. Does that make sense to you in a 21st century tax environment?
+
+1 (41m 4s):
+Here's why it does. When you are taxing a for-profit entity, you are creating a business expense. You're taking off a profit margin to fund city institutions. The idea in general is that if you are a nonprofit civic organization doing good for the world, we'd rather you spend your money doing that. We are huge economic engines for cities. Senator Moynihan a great quote that if you want a great city, build a university and wait 200 years. So if you were to design what will make an economy flourish, it would not just be the infrastructure taxes, pay for it would be great universities,
+
+0 (41m 44s):
+If, We, were looking ahead to Fordham, let's say 20 or maybe even 50 years from now. In what significant ways would you like it to be very different than it is today? You can keep all the good stuff, but what would you like to change?
+
+1 (41m 58s):
+I think when I look ahead deep down that what I would like us to do is to not chase status. It's just to do good for the world. And that has become ever more crucial because the problems of the world just seem so urgent and full of despair. And so that we look back on our careers here at Fordham and know that we mattered and not about silliness, that doesn't matter, but we have hundreds of thousands of living alumni and they matter every day in ways we'll never see. And did we have a profound impact on the kind of ethics and empathy and work that they do every day?
+
+0 (42m 39s):
+I'd like to thank Tania Tetlow, president of Fordham University for a conversation that was much meatier than many conversations I hear these days with people in positions of authority. So I appreciate her forthrightness and her courage in saying how she really sees things, or at least what I think is how she really sees things. Maybe I've been the target of a massive con job, but I don't think so. One reason I wanted you to hear this conversation today is because next week we are going to start playing for you an updated version of one of the most important series we've ever made about the economics of higher education, the supply and the demand, the controversies and the hypocrisies, the answers and the questions.
+
+6 (43m 22s):
+Why are more women going to college than men?
+
+7 (43m 25s):
+What happens when black and Hispanic students lose admissions advantages?
+
+8 (43m 29s):
+How does the marketplace for higher education operate?
+
+0 (43m 34s):
+Hi, tell you something. It's
+
+1 (43m 35s):
+A darn good question.
+
+0 (43m 37s):
+That's next time on the show. Until then, take care of yourself and if you can someone else too. Free Economics Radio is produced by Stitcher and BU Radio. You can find our entire archive on any podcast app also@freakonomics.com, where we publish transcripts and show notes. This episode was produced by Zach Lapinski, with help from Dalvin Aji. Our staff also includes Alina Coleman, Augusta Chapman, Eleanor Osborne, Elsa Hernandez, Gabriel Roth, Greg Rippin, Jasmine Klinger, Jeremy Johnston, John nars, Julie Canford, lyric bdi, Morgan Levy, Neil Carruth, Rebecca Lee Douglas, Sarah Lilly, and Teo Jacobs. Our theme song is Mr. Fortune by the Hitchhikers. Our composer is Luis Gura.
+
+0 (44m 19s):
+As always, thanks for listening.
+
+1 (44m 25s):
+We have always, sorry, trying to think of the word,
+
+4 (44m 35s):
+The Freakonomics Radio Network, the hidden side of everything.
+
+10 (44m 42s):
+Stitcher.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 36398c08482dbaf3d31b315c7c8ffae0396f9e46  | 
|--------|--------|

### Summary:
Moves podcast example files to `examples` directory, adding `podcast_runner.py` for Neo4j operations and `podcast_transcript.txt` for transcript storage.

**Key points**:
- Added `examples/podcast/podcast_runner.py` to set up Neo4j client, clear data, parse messages, and add episodes.
- Added `examples/podcast/podcast_transcript.txt` containing a podcast transcript.
- Organizes podcast example under `examples` directory for better structure.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->