### PR TITLE
depot + cleanup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   ruff:
     environment: development
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04
     environment:
       name: development
     steps:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ format:
 # Lint code
 lint:
 	$(RUFF) check
-	$(MYPY) --install-types --non-interactive .
 	$(MYPY) . --show-column-numbers --show-error-codes --pretty 
 
 # Run tests


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit eb74de35d5f1c51167d3c2fad00eb500e8e09d72  | 
|--------|--------|

### Summary:
This PR updates GitHub Actions workflows to use `depot-ubuntu-22.04` runner and removes redundant `mypy` options in `Makefile`.

**Key points**:
- Updated `.github/workflows/lint.yml` to use `depot-ubuntu-22.04` runner.
- Updated `.github/workflows/unit_tests.yml` to use `depot-ubuntu-22.04` runner.
- Removed `--install-types --non-interactive` options from `mypy` command in `Makefile`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->