### PR TITLE
Add text episode type

### DIFF
--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -46,10 +46,13 @@ class EpisodeType(Enum):
         or "assistant: I'm doing well, thank you for asking."
     json : str
         Represents an episode containing a JSON string object with structured data.
+    text : str
+        Represents a plain text episode.
     """
 
     message = 'message'
     json = 'json'
+    text = 'text'
 
     @staticmethod
     def from_str(episode_type: str):
@@ -57,6 +60,8 @@ class EpisodeType(Enum):
             return EpisodeType.message
         if episode_type == 'json':
             return EpisodeType.json
+        if episode_type == 'text':
+            return EpisodeType.text
         logger.error(f'Episode type: {episode_type} not implemented')
         raise NotImplementedError
 

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -72,7 +72,7 @@ async def extract_nodes(
 ) -> list[EntityNode]:
     start = time()
     extracted_node_data: list[dict[str, Any]] = []
-    if episode.source == EpisodeType.message:
+    if episode.source in [EpisodeType.message, EpisodeType.text]:
         extracted_node_data = await extract_message_nodes(llm_client, episode, previous_episodes)
     elif episode.source == EpisodeType.json:
         extracted_node_data = await extract_json_nodes(llm_client, episode)


### PR DESCRIPTION
Add a new `text` episode type and update the `extract_nodes` function to handle it.

* **EpisodeType Enum:**
  - Add `text` to the `EpisodeType` enum in `graphiti_core/nodes.py`.
  - Update the `from_str` method to handle the `text` episode type.

* **extract_nodes Function:**
  - Update the `extract_nodes` function in `graphiti_core/utils/maintenance/node_operations.py` to handle the `text` episode type.
  - Use the `message` type prompt for both `message` and `text` episodes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/getzep/graphiti?shareId=d852651f-5900-4126-b3f1-443641565396).
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2905dde474a5d5066a46e40d448e31e0864cf304  | 
|--------|--------|

### Summary:
Add `text` episode type to `EpisodeType` enum and update `extract_nodes` to handle it like `message` episodes.

**Key points**:
- Add `text` to `EpisodeType` enum in `graphiti_core/nodes.py`.
- Update `from_str` method in `EpisodeType` to handle `text`.
- Modify `extract_nodes` in `graphiti_core/utils/maintenance/node_operations.py` to process `text` episodes like `message` episodes.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->