### PR TITLE
feat: Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release to PyPI
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+env:
+  POETRY_VERSION: "1.8.3"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    environment:
+      name: release
+      url: https://pypi.org/p/zep-cloud
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install poetry
+        run: pipx install poetry==$POETRY_VERSION
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "poetry"
+      - name: Compare pyproject version with tag
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/}
+          if [ "$TAG_VERSION" != "v$(poetry version --short)" ]; then
+            echo "Tag version $TAG_VERSION does not match the project version $(poetry version --short)"
+            exit 1
+          fi
+      - name: Build project for distribution
+        run: poetry build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ad79a480e05efb9a65cd02df114e680d44cf081a  | 
|--------|--------|

### Summary:
Adds a GitHub Actions workflow to automate Python package releases to PyPI, triggered by version tag pushes.

**Key points**:
- Adds `.github/workflows/release.yml` for automated PyPI releases.
- Triggers on tag pushes matching `v*.*.*`.
- Sets up Python 3.10 environment and installs Poetry 1.8.3.
- Compares tag version with `pyproject.toml` version for consistency.
- Builds the package using Poetry.
- Publishes the package to PyPI using `pypa/gh-action-pypi-publish@release/v1`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->