### PR TITLE
Node Distance Reranker: Limit max hops (and cleanup prints)

### DIFF
--- a/graphiti_core/llm_client/openai_client.py
+++ b/graphiti_core/llm_client/openai_client.py
@@ -60,6 +60,5 @@ class OpenAIClient(LLMClient):
             result = response.choices[0].message.content or ''
             return json.loads(result)
         except Exception as e:
-            print(openai_messages)
             logger.error(f'Error in generating LLM response: {e}')
             raise

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -424,7 +424,7 @@ async def node_distance_reranker(
         records, _, _ = await driver.execute_query(
             """  
         MATCH (source:Entity)-[r:RELATES_TO {uuid: $edge_uuid}]->(target:Entity)
-        MATCH p = SHORTEST 1 (center:Entity)-[:RELATES_TO]-+(n:Entity)
+        MATCH p = SHORTEST 1 (center:Entity)-[:RELATES_TO*1..10]->(n:Entity)
         WHERE center.uuid = $center_uuid AND n.uuid IN [source.uuid, target.uuid]
         RETURN min(length(p)) AS score, source.uuid AS source_uuid, target.uuid AS target_uuid
         """,

--- a/graphiti_core/utils/maintenance/edge_operations.py
+++ b/graphiti_core/utils/maintenance/edge_operations.py
@@ -70,7 +70,6 @@ async def extract_edges(
     }
 
     llm_response = await llm_client.generate_response(prompt_library.extract_edges.v2(context))
-    print(llm_response)
     edges_data = llm_response.get('edges', [])
 
     end = time()


### PR DESCRIPTION
This pull request includes two changes. First, it limits the maximum number of hops in the node distance reranker. Second, it cleans up unnecessary print statements in the code. These changes improve the efficiency and readability of the code.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b9f43bf1ef3c2a3870b6c9c84b17a824f7a2cdbb  | 
|--------|--------|

### Summary:
Limits max hops in `node_distance_reranker` and removes unnecessary print statements for improved efficiency and readability.

**Key points**:
- `graphiti_core/search/search_utils.py`: Limits max hops to 10 in `node_distance_reranker` for optimized search.
- `graphiti_core/llm_client/openai_client.py`: Removes print statement in `_generate_response`.
- `graphiti_core/utils/maintenance/edge_operations.py`: Removes print statement in `extract_edges`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->