### PR TITLE
Fix missing default None for add_episode_bulk

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -412,7 +412,7 @@ class Graphiti:
         except Exception as e:
             raise e
 
-    async def add_episode_bulk(self, bulk_episodes: list[RawEpisode], group_id: str | None):
+    async def add_episode_bulk(self, bulk_episodes: list[RawEpisode], group_id: str | None = None):
         """
         Process multiple episodes in bulk and update the graph.
 


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/getzep/graphiti?shareId=3eff0a42-911e-4d9f-b520-d6111bf10b46).
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 591fc49ea484e55348331f5b2c804c6221d385a1  | 
|--------|--------|

### Summary:
Adds default `None` to `group_id` parameter in `add_episode_bulk` method in `graphiti_core/graphiti.py` for consistency.

**Key points**:
- Adds default `None` to `group_id` parameter in `add_episode_bulk` method in `graphiti_core/graphiti.py`.
- Ensures consistency with `add_episode` method which already has `group_id: str | None = None`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->