### PR TITLE
Improve node distance reranker speed

### DIFF
--- a/examples/podcast/podcast_runner.py
+++ b/examples/podcast/podcast_runner.py
@@ -63,7 +63,7 @@ async def main(use_bulk: bool = True):
     messages = parse_podcast_messages()
 
     if not use_bulk:
-        for i, message in enumerate(messages[3:14]):
+        for i, message in enumerate(messages[3:130]):
             await client.add_episode(
                 name=f'Message {i}',
                 episode_body=f'{message.speaker_name} ({message.role}): {message.content}',

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -496,34 +496,41 @@ async def node_distance_reranker(
     sorted_uuids = rrf(results)
     scores: dict[str, float] = {}
 
-    for uuid in sorted_uuids:
-        # Find the shortest path to center node
-        records, _, _ = await driver.execute_query(
-            """  
+    # Find the shortest path to center node
+    query = Query("""  
         MATCH (source:Entity)-[r:RELATES_TO {uuid: $edge_uuid}]->(target:Entity)
-        MATCH p = SHORTEST 1 (center:Entity)-[:RELATES_TO*1..10]->(n:Entity)
-        WHERE center.uuid = $center_uuid AND n.uuid IN [source.uuid, target.uuid]
-        RETURN min(length(p)) AS score, source.uuid AS source_uuid, target.uuid AS target_uuid
-        """,
-            edge_uuid=uuid,
-            center_uuid=center_node_uuid,
-        )
-        distance = 0.01
+        MATCH p = SHORTEST 1 (center:Entity {uuid: $center_uuid})-[:RELATES_TO]-+(n:Entity {uuid: source.uuid})
+        RETURN length(p) AS source_length, source.uuid AS source_uuid, target.uuid AS target_uuid
+        """)
 
-        for record in records:
-            if (
-                record['source_uuid'] == center_node_uuid
-                or record['target_uuid'] == center_node_uuid
-            ):
-                continue
-            distance = record['score']
+    results = await asyncio.gather(
+        *[
+            driver.execute_query(
+                query,
+                edge_uuid=uuid,
+                center_uuid=center_node_uuid,
+            )
+            for uuid in sorted_uuids
+        ]
+    )
+
+    for uuid, result in zip(sorted_uuids, results):
+        records = result[0]
+        record = records[0] if len(records) > 0 else None
+        distance = float('inf')
+        if record is not None:
+            distance = record['source_length']
+        if record is not None and (
+            record['source_uuid'] == center_node_uuid or record['target_uuid'] == center_node_uuid
+        ):
+            distance = 0
 
         if uuid in scores:
-            scores[uuid] = min(1 / distance, scores[uuid])
+            scores[uuid] = min(distance, scores[uuid])
         else:
-            scores[uuid] = 1 / distance
+            scores[uuid] = distance
 
     # rerank on shortest distance
-    sorted_uuids.sort(reverse=True, key=lambda cur_uuid: scores[cur_uuid])
+    sorted_uuids.sort(key=lambda cur_uuid: scores[cur_uuid])
 
     return sorted_uuids

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -36,12 +36,12 @@ async def get_mentioned_nodes(driver: AsyncDriver, episodes: list[EpisodicNode])
 
 
 async def edge_similarity_search(
-        driver: AsyncDriver,
-        search_vector: list[float],
-        source_node_uuid: str | None,
-        target_node_uuid: str | None,
-        group_ids: list[str | None] | None = None,
-        limit: int = RELEVANT_SCHEMA_LIMIT,
+    driver: AsyncDriver,
+    search_vector: list[float],
+    source_node_uuid: str | None,
+    target_node_uuid: str | None,
+    group_ids: list[str | None] | None = None,
+    limit: int = RELEVANT_SCHEMA_LIMIT,
 ) -> list[EntityEdge]:
     group_ids = group_ids if group_ids is not None else [None]
     # vector similarity search over embedded facts
@@ -145,10 +145,10 @@ async def edge_similarity_search(
 
 
 async def entity_similarity_search(
-        search_vector: list[float],
-        driver: AsyncDriver,
-        group_ids: list[str | None] | None = None,
-        limit=RELEVANT_SCHEMA_LIMIT,
+    search_vector: list[float],
+    driver: AsyncDriver,
+    group_ids: list[str | None] | None = None,
+    limit=RELEVANT_SCHEMA_LIMIT,
 ) -> list[EntityNode]:
     group_ids = group_ids if group_ids is not None else [None]
 
@@ -177,10 +177,10 @@ async def entity_similarity_search(
 
 
 async def entity_fulltext_search(
-        query: str,
-        driver: AsyncDriver,
-        group_ids: list[str | None] | None = None,
-        limit=RELEVANT_SCHEMA_LIMIT,
+    query: str,
+    driver: AsyncDriver,
+    group_ids: list[str | None] | None = None,
+    limit=RELEVANT_SCHEMA_LIMIT,
 ) -> list[EntityNode]:
     group_ids = group_ids if group_ids is not None else [None]
 
@@ -211,12 +211,12 @@ async def entity_fulltext_search(
 
 
 async def edge_fulltext_search(
-        driver: AsyncDriver,
-        query: str,
-        source_node_uuid: str | None,
-        target_node_uuid: str | None,
-        group_ids: list[str | None] | None = None,
-        limit=RELEVANT_SCHEMA_LIMIT,
+    driver: AsyncDriver,
+    query: str,
+    source_node_uuid: str | None,
+    target_node_uuid: str | None,
+    group_ids: list[str | None] | None = None,
+    limit=RELEVANT_SCHEMA_LIMIT,
 ) -> list[EntityEdge]:
     group_ids = group_ids if group_ids is not None else [None]
 
@@ -323,11 +323,11 @@ async def edge_fulltext_search(
 
 
 async def hybrid_node_search(
-        queries: list[str],
-        embeddings: list[list[float]],
-        driver: AsyncDriver,
-        group_ids: list[str | None] | None = None,
-        limit: int = RELEVANT_SCHEMA_LIMIT,
+    queries: list[str],
+    embeddings: list[list[float]],
+    driver: AsyncDriver,
+    group_ids: list[str | None] | None = None,
+    limit: int = RELEVANT_SCHEMA_LIMIT,
 ) -> list[EntityNode]:
     """
     Perform a hybrid search for nodes using both text queries and embeddings.
@@ -391,8 +391,8 @@ async def hybrid_node_search(
 
 
 async def get_relevant_nodes(
-        nodes: list[EntityNode],
-        driver: AsyncDriver,
+    nodes: list[EntityNode],
+    driver: AsyncDriver,
 ) -> list[EntityNode]:
     """
     Retrieve relevant nodes based on the provided list of EntityNodes.
@@ -429,11 +429,11 @@ async def get_relevant_nodes(
 
 
 async def get_relevant_edges(
-        driver: AsyncDriver,
-        edges: list[EntityEdge],
-        source_node_uuid: str | None,
-        target_node_uuid: str | None,
-        limit: int = RELEVANT_SCHEMA_LIMIT,
+    driver: AsyncDriver,
+    edges: list[EntityEdge],
+    source_node_uuid: str | None,
+    target_node_uuid: str | None,
+    limit: int = RELEVANT_SCHEMA_LIMIT,
 ) -> list[EntityEdge]:
     start = time()
     relevant_edges: list[EntityEdge] = []
@@ -490,7 +490,7 @@ def rrf(results: list[list[str]], rank_const=1) -> list[str]:
 
 
 async def node_distance_reranker(
-        driver: AsyncDriver, results: list[list[str]], center_node_uuid: str
+    driver: AsyncDriver, results: list[list[str]], center_node_uuid: str
 ) -> list[str]:
     # use rrf as a preliminary ranker
     sorted_uuids = rrf(results)
@@ -503,7 +503,7 @@ async def node_distance_reranker(
         RETURN length(p) AS score, source.uuid AS source_uuid, target.uuid AS target_uuid
         """)
 
-    results = await asyncio.gather(
+    path_results = await asyncio.gather(
         *[
             driver.execute_query(
                 query,
@@ -514,12 +514,12 @@ async def node_distance_reranker(
         ]
     )
 
-    for uuid, result in zip(sorted_uuids, results):
+    for uuid, result in zip(sorted_uuids, path_results):
         records = result[0]
         record = records[0] if len(records) > 0 else None
-        distance = record['score'] if record is not None else float('inf')
+        distance: float = record['score'] if record is not None else float('inf')
         if record is not None and (
-                record['source_uuid'] == center_node_uuid or record['target_uuid'] == center_node_uuid
+            record['source_uuid'] == center_node_uuid or record['target_uuid'] == center_node_uuid
         ):
             distance = 0
 

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -36,12 +36,12 @@ async def get_mentioned_nodes(driver: AsyncDriver, episodes: list[EpisodicNode])
 
 
 async def edge_similarity_search(
-    driver: AsyncDriver,
-    search_vector: list[float],
-    source_node_uuid: str | None,
-    target_node_uuid: str | None,
-    group_ids: list[str | None] | None = None,
-    limit: int = RELEVANT_SCHEMA_LIMIT,
+        driver: AsyncDriver,
+        search_vector: list[float],
+        source_node_uuid: str | None,
+        target_node_uuid: str | None,
+        group_ids: list[str | None] | None = None,
+        limit: int = RELEVANT_SCHEMA_LIMIT,
 ) -> list[EntityEdge]:
     group_ids = group_ids if group_ids is not None else [None]
     # vector similarity search over embedded facts
@@ -145,10 +145,10 @@ async def edge_similarity_search(
 
 
 async def entity_similarity_search(
-    search_vector: list[float],
-    driver: AsyncDriver,
-    group_ids: list[str | None] | None = None,
-    limit=RELEVANT_SCHEMA_LIMIT,
+        search_vector: list[float],
+        driver: AsyncDriver,
+        group_ids: list[str | None] | None = None,
+        limit=RELEVANT_SCHEMA_LIMIT,
 ) -> list[EntityNode]:
     group_ids = group_ids if group_ids is not None else [None]
 
@@ -177,10 +177,10 @@ async def entity_similarity_search(
 
 
 async def entity_fulltext_search(
-    query: str,
-    driver: AsyncDriver,
-    group_ids: list[str | None] | None = None,
-    limit=RELEVANT_SCHEMA_LIMIT,
+        query: str,
+        driver: AsyncDriver,
+        group_ids: list[str | None] | None = None,
+        limit=RELEVANT_SCHEMA_LIMIT,
 ) -> list[EntityNode]:
     group_ids = group_ids if group_ids is not None else [None]
 
@@ -211,12 +211,12 @@ async def entity_fulltext_search(
 
 
 async def edge_fulltext_search(
-    driver: AsyncDriver,
-    query: str,
-    source_node_uuid: str | None,
-    target_node_uuid: str | None,
-    group_ids: list[str | None] | None = None,
-    limit=RELEVANT_SCHEMA_LIMIT,
+        driver: AsyncDriver,
+        query: str,
+        source_node_uuid: str | None,
+        target_node_uuid: str | None,
+        group_ids: list[str | None] | None = None,
+        limit=RELEVANT_SCHEMA_LIMIT,
 ) -> list[EntityEdge]:
     group_ids = group_ids if group_ids is not None else [None]
 
@@ -323,11 +323,11 @@ async def edge_fulltext_search(
 
 
 async def hybrid_node_search(
-    queries: list[str],
-    embeddings: list[list[float]],
-    driver: AsyncDriver,
-    group_ids: list[str | None] | None = None,
-    limit: int = RELEVANT_SCHEMA_LIMIT,
+        queries: list[str],
+        embeddings: list[list[float]],
+        driver: AsyncDriver,
+        group_ids: list[str | None] | None = None,
+        limit: int = RELEVANT_SCHEMA_LIMIT,
 ) -> list[EntityNode]:
     """
     Perform a hybrid search for nodes using both text queries and embeddings.
@@ -391,8 +391,8 @@ async def hybrid_node_search(
 
 
 async def get_relevant_nodes(
-    nodes: list[EntityNode],
-    driver: AsyncDriver,
+        nodes: list[EntityNode],
+        driver: AsyncDriver,
 ) -> list[EntityNode]:
     """
     Retrieve relevant nodes based on the provided list of EntityNodes.
@@ -429,11 +429,11 @@ async def get_relevant_nodes(
 
 
 async def get_relevant_edges(
-    driver: AsyncDriver,
-    edges: list[EntityEdge],
-    source_node_uuid: str | None,
-    target_node_uuid: str | None,
-    limit: int = RELEVANT_SCHEMA_LIMIT,
+        driver: AsyncDriver,
+        edges: list[EntityEdge],
+        source_node_uuid: str | None,
+        target_node_uuid: str | None,
+        limit: int = RELEVANT_SCHEMA_LIMIT,
 ) -> list[EntityEdge]:
     start = time()
     relevant_edges: list[EntityEdge] = []
@@ -490,7 +490,7 @@ def rrf(results: list[list[str]], rank_const=1) -> list[str]:
 
 
 async def node_distance_reranker(
-    driver: AsyncDriver, results: list[list[str]], center_node_uuid: str
+        driver: AsyncDriver, results: list[list[str]], center_node_uuid: str
 ) -> list[str]:
     # use rrf as a preliminary ranker
     sorted_uuids = rrf(results)
@@ -500,7 +500,7 @@ async def node_distance_reranker(
     query = Query("""  
         MATCH (source:Entity)-[r:RELATES_TO {uuid: $edge_uuid}]->(target:Entity)
         MATCH p = SHORTEST 1 (center:Entity {uuid: $center_uuid})-[:RELATES_TO]-+(n:Entity {uuid: source.uuid})
-        RETURN length(p) AS source_length, source.uuid AS source_uuid, target.uuid AS target_uuid
+        RETURN length(p) AS score, source.uuid AS source_uuid, target.uuid AS target_uuid
         """)
 
     results = await asyncio.gather(
@@ -517,11 +517,9 @@ async def node_distance_reranker(
     for uuid, result in zip(sorted_uuids, results):
         records = result[0]
         record = records[0] if len(records) > 0 else None
-        distance = float('inf')
-        if record is not None:
-            distance = record['source_length']
+        distance = record['score'] if record is not None else float('inf')
         if record is not None and (
-            record['source_uuid'] == center_node_uuid or record['target_uuid'] == center_node_uuid
+                record['source_uuid'] == center_node_uuid or record['target_uuid'] == center_node_uuid
         ):
             distance = 0
 

--- a/tests/test_graphiti_int.py
+++ b/tests/test_graphiti_int.py
@@ -73,11 +73,6 @@ def format_context(facts):
 async def test_graphiti_init():
     logger = setup_logging()
     graphiti = Graphiti(NEO4J_URI, NEO4j_USER, NEO4j_PASSWORD)
-    await graphiti.build_communities()
-
-    edges = await graphiti.search('Freakenomics guest', group_ids=['1'])
-
-    logger.info('\nQUERY: Freakenomics guest\n' + format_context([edge.fact for edge in edges]))
 
     edges = await graphiti.search('tania tetlow', group_ids=['1'])
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 71920a98c773d0ede625ffe9d9ac58d322006d9c  | 
|--------|--------|

perf: optimize node distance reranker and update podcast example

### Summary:
Optimize `node_distance_reranker()`, update `podcast_runner.py`, and clean up `test_graphiti_int.py`.

**Key points**:
- Optimize `node_distance_reranker()` in `search_utils.py` using `asyncio.gather` for parallel execution.
- Update `podcast_runner.py` to process messages from 11 to 127 when `use_bulk` is `False`.
- Remove unused test code in `test_graphiti_int.py` related to `build_communities()` and initial search query.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->