### PR TITLE
feat: Add delete group endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "graphiti-core"
-version = "0.3.3"
+version = "0.3.4"
 description = "A temporal graph building library"
 authors = [
     "Paul Paliychuk <paul@getzep.com>",

--- a/server/graph_service/routers/ingest.py
+++ b/server/graph_service/routers/ingest.py
@@ -90,6 +90,12 @@ async def delete_entity_edge(uuid: str, graphiti: ZepGraphitiDep):
     return Result(message='Entity Edge deleted', success=True)
 
 
+@router.delete('/group/{group_id}', status_code=status.HTTP_200_OK)
+async def delete_group(group_id: str, graphiti: ZepGraphitiDep):
+    await graphiti.delete_group(group_id)
+    return Result(message='Group deleted', success=True)
+
+
 @router.delete('/episode/{uuid}', status_code=status.HTTP_200_OK)
 async def delete_episode(uuid: str, graphiti: ZepGraphitiDep):
     await graphiti.delete_episodic_node(uuid)

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -33,6 +33,20 @@ class ZepGraphiti(Graphiti):
         except EdgeNotFoundError as e:
             raise HTTPException(status_code=404, detail=e.message) from e
 
+    async def delete_group(self, group_id: str):
+        try:
+            edges = await EntityEdge.get_by_group_ids(self.driver, [group_id])
+            nodes = await EntityNode.get_by_group_ids(self.driver, [group_id])
+            episodes = await EpisodicNode.get_by_group_ids(self.driver, [group_id])
+            for edge in edges:
+                await edge.delete(self.driver)
+            for node in nodes:
+                await node.delete(self.driver)
+            for episode in episodes:
+                await episode.delete(self.driver)
+        except EdgeNotFoundError as e:
+            raise HTTPException(status_code=404, detail=e.message) from e
+
     async def delete_entity_edge(self, uuid: str):
         try:
             edge = await EntityEdge.get_by_uuid(self.driver, uuid)

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -46,6 +46,8 @@ class ZepGraphiti(Graphiti):
                 await episode.delete(self.driver)
         except EdgeNotFoundError as e:
             raise HTTPException(status_code=404, detail=e.message) from e
+        except NodeNotFoundError as e:
+            raise HTTPException(status_code=404, detail=e.message) from e
 
     async def delete_entity_edge(self, uuid: str):
         try:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `delete_group` endpoint and method, handle errors, and update version.
> 
>   - Add `delete_group` endpoint in `ingest.py` to delete a group by `group_id`.
>   - Implement `delete_group` method in `ZepGraphiti` class in `zep_graphiti.py` to delete all edges, nodes, and episodes associated with a group.
>   - Handle `EdgeNotFoundError` and `NodeNotFoundError` by raising `HTTPException` with status 404.
>   - Update version in `pyproject.toml` from `0.3.3` to `0.3.4`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep/graphiti#132)<sup> for cc9eb9fa34b150bda8b4f9cf65f358bab0c844ed. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->