### PR TITLE
In memory label propagation community detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 <img width="350" alt="Graphiti-ts-small" src="https://github.com/user-attachments/assets/bbd02947-e435-4a05-b25a-bbbac36d52c8">
 
-
 ## Temporal Knowledge Graphs for Agentic Applications
 
 <br />
@@ -80,7 +79,6 @@ Requirements:
 
 - Python 3.10 or higher
 - Neo4j 5.21 or higher
-- Neo4j GraphDataScience Plugin (required for community flows)
 - OpenAI API key (for LLM inference and embedding)
 
 Optional:

--- a/examples/podcast/podcast_runner.py
+++ b/examples/podcast/podcast_runner.py
@@ -63,7 +63,7 @@ async def main(use_bulk: bool = True):
     messages = parse_podcast_messages()
 
     if not use_bulk:
-        for i, message in enumerate(messages[3:14]):
+        for i, message in enumerate(messages[3:4]):
             await client.add_episode(
                 name=f'Message {i}',
                 episode_body=f'{message.speaker_name} ({message.role}): {message.content}',
@@ -76,15 +76,15 @@ async def main(use_bulk: bool = True):
         await client.build_communities()
 
         # add additional messages to update communities
-        for i, message in enumerate(messages[14:20]):
-            await client.add_episode(
-                name=f'Message {i}',
-                episode_body=f'{message.speaker_name} ({message.role}): {message.content}',
-                reference_time=message.actual_timestamp,
-                source_description='Podcast Transcript',
-                group_id='1',
-                update_communities=True,
-            )
+        # for i, message in enumerate(messages[14:20]):
+        #     await client.add_episode(
+        #         name=f'Message {i}',
+        #         episode_body=f'{message.speaker_name} ({message.role}): {message.content}',
+        #         reference_time=message.actual_timestamp,
+        #         source_description='Podcast Transcript',
+        #         group_id='1',
+        #         update_communities=True,
+        #     )
 
         return
 

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -78,12 +78,12 @@ load_dotenv()
 
 class Graphiti:
     def __init__(
-            self,
-            uri: str,
-            user: str,
-            password: str,
-            llm_client: LLMClient | None = None,
-            store_raw_episode_content: bool = True,
+        self,
+        uri: str,
+        user: str,
+        password: str,
+        llm_client: LLMClient | None = None,
+        store_raw_episode_content: bool = True,
     ):
         """
         Initialize a Graphiti instance.
@@ -194,10 +194,10 @@ class Graphiti:
         await build_indices_and_constraints(self.driver)
 
     async def retrieve_episodes(
-            self,
-            reference_time: datetime,
-            last_n: int = EPISODE_WINDOW_LEN,
-            group_ids: list[str | None] | None = None,
+        self,
+        reference_time: datetime,
+        last_n: int = EPISODE_WINDOW_LEN,
+        group_ids: list[str | None] | None = None,
     ) -> list[EpisodicNode]:
         """
         Retrieve the last n episodic nodes from the graph.
@@ -227,15 +227,15 @@ class Graphiti:
         return await retrieve_episodes(self.driver, reference_time, last_n, group_ids)
 
     async def add_episode(
-            self,
-            name: str,
-            episode_body: str,
-            source_description: str,
-            reference_time: datetime,
-            source: EpisodeType = EpisodeType.message,
-            group_id: str | None = None,
-            uuid: str | None = None,
-            update_communities: bool = False,
+        self,
+        name: str,
+        episode_body: str,
+        source_description: str,
+        reference_time: datetime,
+        source: EpisodeType = EpisodeType.message,
+        group_id: str | None = None,
+        uuid: str | None = None,
+        update_communities: bool = False,
     ):
         """
         Process an episode and update the graph.
@@ -574,11 +574,11 @@ class Graphiti:
         await asyncio.gather(*[edge.save(self.driver) for edge in community_edges])
 
     async def search(
-            self,
-            query: str,
-            center_node_uuid: str | None = None,
-            group_ids: list[str | None] | None = None,
-            num_results=DEFAULT_SEARCH_LIMIT,
+        self,
+        query: str,
+        center_node_uuid: str | None = None,
+        group_ids: list[str | None] | None = None,
+        num_results=DEFAULT_SEARCH_LIMIT,
     ) -> list[EntityEdge]:
         """
         Perform a hybrid search on the knowledge graph.
@@ -630,22 +630,22 @@ class Graphiti:
         return edges
 
     async def _search(
-            self,
-            query: str,
-            config: SearchConfig,
-            group_ids: list[str | None] | None = None,
-            center_node_uuid: str | None = None,
+        self,
+        query: str,
+        config: SearchConfig,
+        group_ids: list[str | None] | None = None,
+        center_node_uuid: str | None = None,
     ) -> SearchResults:
         return await search(
             self.driver, self.llm_client.get_embedder(), query, group_ids, config, center_node_uuid
         )
 
     async def get_nodes_by_query(
-            self,
-            query: str,
-            center_node_uuid: str | None = None,
-            group_ids: list[str | None] | None = None,
-            limit: int = DEFAULT_SEARCH_LIMIT,
+        self,
+        query: str,
+        center_node_uuid: str | None = None,
+        group_ids: list[str | None] | None = None,
+        limit: int = DEFAULT_SEARCH_LIMIT,
     ) -> list[EntityNode]:
         """
         Retrieve nodes from the graph database based on a text query.

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -78,12 +78,12 @@ load_dotenv()
 
 class Graphiti:
     def __init__(
-        self,
-        uri: str,
-        user: str,
-        password: str,
-        llm_client: LLMClient | None = None,
-        store_raw_episode_content: bool = True,
+            self,
+            uri: str,
+            user: str,
+            password: str,
+            llm_client: LLMClient | None = None,
+            store_raw_episode_content: bool = True,
     ):
         """
         Initialize a Graphiti instance.
@@ -194,10 +194,10 @@ class Graphiti:
         await build_indices_and_constraints(self.driver)
 
     async def retrieve_episodes(
-        self,
-        reference_time: datetime,
-        last_n: int = EPISODE_WINDOW_LEN,
-        group_ids: list[str | None] | None = None,
+            self,
+            reference_time: datetime,
+            last_n: int = EPISODE_WINDOW_LEN,
+            group_ids: list[str | None] | None = None,
     ) -> list[EpisodicNode]:
         """
         Retrieve the last n episodic nodes from the graph.
@@ -227,15 +227,15 @@ class Graphiti:
         return await retrieve_episodes(self.driver, reference_time, last_n, group_ids)
 
     async def add_episode(
-        self,
-        name: str,
-        episode_body: str,
-        source_description: str,
-        reference_time: datetime,
-        source: EpisodeType = EpisodeType.message,
-        group_id: str | None = None,
-        uuid: str | None = None,
-        update_communities: bool = False,
+            self,
+            name: str,
+            episode_body: str,
+            source_description: str,
+            reference_time: datetime,
+            source: EpisodeType = EpisodeType.message,
+            group_id: str | None = None,
+            uuid: str | None = None,
+            update_communities: bool = False,
     ):
         """
         Process an episode and update the graph.
@@ -574,12 +574,12 @@ class Graphiti:
         await asyncio.gather(*[edge.save(self.driver) for edge in community_edges])
 
     async def search(
-        self,
-        query: str,
-        center_node_uuid: str | None = None,
-        group_ids: list[str | None] | None = None,
-        num_results=DEFAULT_SEARCH_LIMIT,
-    ):
+            self,
+            query: str,
+            center_node_uuid: str | None = None,
+            group_ids: list[str | None] | None = None,
+            num_results=DEFAULT_SEARCH_LIMIT,
+    ) -> list[EntityEdge]:
         """
         Perform a hybrid search on the knowledge graph.
 
@@ -630,22 +630,22 @@ class Graphiti:
         return edges
 
     async def _search(
-        self,
-        query: str,
-        config: SearchConfig,
-        group_ids: list[str | None] | None = None,
-        center_node_uuid: str | None = None,
+            self,
+            query: str,
+            config: SearchConfig,
+            group_ids: list[str | None] | None = None,
+            center_node_uuid: str | None = None,
     ) -> SearchResults:
         return await search(
             self.driver, self.llm_client.get_embedder(), query, group_ids, config, center_node_uuid
         )
 
     async def get_nodes_by_query(
-        self,
-        query: str,
-        center_node_uuid: str | None = None,
-        group_ids: list[str | None] | None = None,
-        limit: int = DEFAULT_SEARCH_LIMIT,
+            self,
+            query: str,
+            center_node_uuid: str | None = None,
+            group_ids: list[str | None] | None = None,
+            limit: int = DEFAULT_SEARCH_LIMIT,
     ) -> list[EntityNode]:
         """
         Retrieve nodes from the graph database based on a text query.

--- a/graphiti_core/utils/maintenance/community_operations.py
+++ b/graphiti_core/utils/maintenance/community_operations.py
@@ -95,7 +95,7 @@ def label_propagation(projection: dict[str, list[Neighbor]]) -> list[list[str]]:
         for uuid, neighbors in projection.items():
             curr_community = community_map[uuid]
 
-            community_candidates = defaultdict(int)
+            community_candidates: dict[str, int] = defaultdict(int)
             for neighbor in neighbors:
                 community_candidates[community_map[neighbor.node_uuid]] += neighbor.edge_count
 

--- a/graphiti_core/utils/maintenance/community_operations.py
+++ b/graphiti_core/utils/maintenance/community_operations.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from datetime import datetime
 
 from neo4j import AsyncDriver
+from pydantic import BaseModel
 
 from graphiti_core.edges import CommunityEdge
 from graphiti_core.llm_client import LLMClient
@@ -12,6 +13,11 @@ from graphiti_core.prompts import prompt_library
 from graphiti_core.utils.maintenance.edge_operations import build_community_edges
 
 logger = logging.getLogger(__name__)
+
+
+class Neighbor(BaseModel):
+    node_uuid: str
+    edge_count: int
 
 
 async def build_community_projection(driver: AsyncDriver) -> str:
@@ -39,24 +45,78 @@ async def destroy_projection(driver: AsyncDriver, projection_name: str):
 
 
 async def get_community_clusters(
-    driver: AsyncDriver, projection_name: str
+        driver: AsyncDriver
 ) -> list[list[EntityNode]]:
-    records, _, _ = await driver.execute_query("""
-    CALL gds.leiden.stream("communities")
-    YIELD nodeId, communityId
-    RETURN gds.util.asNode(nodeId).uuid AS entity_uuid, communityId
-    """)
-    community_map: dict[int, list[str]] = defaultdict(list)
-    for record in records:
-        community_map[record['communityId']].append(record['entity_uuid'])
+    community_clusters: list[list[EntityNode]] = []
 
-    community_clusters: list[list[EntityNode]] = list(
-        await asyncio.gather(
-            *[EntityNode.get_by_uuids(driver, cluster) for cluster in community_map.values()]
+    group_id_values, _, _ = await driver.execute_query("""
+    MATCH (n:Entity WHERE n.group_id IS NOT NULL)
+    RETURN 
+        collect(DISTINCT n.group_id) AS group_ids
+    """)
+
+    group_ids = group_id_values[0]['group_ids']
+    for group_id in group_ids:
+        projection: dict[str, list[Neighbor]] = {}
+        nodes = await EntityNode.get_by_group_ids(driver, [group_id])
+        for node in nodes:
+            records, _, _ = await driver.execute_query("""
+            MATCH (n:Entity {group_id: $group_id, uuid: $uuid})-[r:RELATES_TO]-(m: Entity {group_id: $group_id})
+            WITH count(r) AS count, m.uuid AS uuid
+            RETURN
+                uuid,
+                count
+            """, uuid=node.uuid, group_id=group_id)
+
+            projection[node.uuid] = [Neighbor(node_uuid=record['uuid'], edge_count=record['count']) for record in
+                                     records]
+
+        cluster_uuids = label_propagation(projection)
+
+        community_clusters = list(
+            await asyncio.gather(
+                *[EntityNode.get_by_uuids(driver, cluster) for cluster in cluster_uuids]
+            )
         )
-    )
 
     return community_clusters
+
+
+def label_propagation(projection: dict[str, list[Neighbor]]) -> list[list[str]]:
+    community_map = {uuid: i for i, uuid in enumerate(projection.keys())}
+
+    while True:
+        no_change = True
+        new_community_map: dict[str, int] = {}
+
+        for uuid, neighbors in projection.items():
+            curr_community = community_map[uuid]
+
+            community_candidates = defaultdict(int)
+            for neighbor in neighbors:
+                community_candidates[community_map[neighbor.node_uuid]] += neighbor.edge_count
+
+            community_lst = [(count, community) for community, count in community_candidates.items()]
+
+            community_lst.sort(reverse=True)
+
+            new_community = max(community_lst[0][1], curr_community)
+
+            if new_community != curr_community:
+                no_change = False
+                new_community_map[uuid] = new_community
+
+        if no_change:
+            break
+
+        community_map = new_community_map
+
+        community_cluster_map = defaultdict(list)
+        for uuid, community in community_map.items():
+            community_cluster_map[community].append(uuid)
+
+        clusters = [cluster for cluster in community_cluster_map.values()]
+        return clusters
 
 
 async def summarize_pair(llm_client: LLMClient, summary_pair: tuple[str, str]) -> str:
@@ -85,7 +145,7 @@ async def generate_summary_description(llm_client: LLMClient, summary: str) -> s
 
 
 async def build_community(
-    llm_client: LLMClient, community_cluster: list[EntityNode]
+        llm_client: LLMClient, community_cluster: list[EntityNode]
 ) -> tuple[CommunityNode, list[CommunityEdge]]:
     summaries = [entity.summary for entity in community_cluster]
     length = len(summaries)
@@ -99,7 +159,7 @@ async def build_community(
                 *[
                     summarize_pair(llm_client, (str(left_summary), str(right_summary)))
                     for left_summary, right_summary in zip(
-                        summaries[: int(length / 2)], summaries[int(length / 2) :]
+                        summaries[: int(length / 2)], summaries[int(length / 2):]
                     )
                 ]
             )
@@ -127,10 +187,9 @@ async def build_community(
 
 
 async def build_communities(
-    driver: AsyncDriver, llm_client: LLMClient
+        driver: AsyncDriver, llm_client: LLMClient
 ) -> tuple[list[CommunityNode], list[CommunityEdge]]:
-    projection = await build_community_projection(driver)
-    community_clusters = await get_community_clusters(driver, projection)
+    community_clusters = await get_community_clusters(driver)
 
     communities: list[tuple[CommunityNode, list[CommunityEdge]]] = list(
         await asyncio.gather(
@@ -144,7 +203,6 @@ async def build_communities(
         community_nodes.append(community[0])
         community_edges.extend(community[1])
 
-    await destroy_projection(driver, projection)
     return community_nodes, community_edges
 
 
@@ -156,7 +214,7 @@ async def remove_communities(driver: AsyncDriver):
 
 
 async def determine_entity_community(
-    driver: AsyncDriver, entity: EntityNode
+        driver: AsyncDriver, entity: EntityNode
 ) -> tuple[CommunityNode | None, bool]:
     # Check if the node is already part of a community
     records, _, _ = await driver.execute_query(
@@ -217,7 +275,7 @@ async def determine_entity_community(
 
 
 async def update_community(
-    driver: AsyncDriver, llm_client: LLMClient, embedder, entity: EntityNode
+        driver: AsyncDriver, llm_client: LLMClient, embedder, entity: EntityNode
 ):
     community, is_new = await determine_entity_community(driver, entity)
 

--- a/graphiti_core/utils/maintenance/community_operations.py
+++ b/graphiti_core/utils/maintenance/community_operations.py
@@ -103,8 +103,9 @@ def label_propagation(projection: dict[str, list[Neighbor]]) -> list[list[str]]:
             ]
 
             community_lst.sort(reverse=True)
+            community_candidate = community_lst[0][1] if len(community_lst) > 0 else -1
 
-            new_community = max(community_lst[0][1], curr_community)
+            new_community = max(community_candidate, curr_community)
 
             new_community_map[uuid] = new_community
 
@@ -150,7 +151,7 @@ async def generate_summary_description(llm_client: LLMClient, summary: str) -> s
 
 
 async def build_community(
-    llm_client: LLMClient, community_cluster: list[EntityNode]
+        llm_client: LLMClient, community_cluster: list[EntityNode]
 ) -> tuple[CommunityNode, list[CommunityEdge]]:
     summaries = [entity.summary for entity in community_cluster]
     length = len(summaries)
@@ -164,7 +165,7 @@ async def build_community(
                 *[
                     summarize_pair(llm_client, (str(left_summary), str(right_summary)))
                     for left_summary, right_summary in zip(
-                        summaries[: int(length / 2)], summaries[int(length / 2) :]
+                        summaries[: int(length / 2)], summaries[int(length / 2):]
                     )
                 ]
             )
@@ -192,7 +193,7 @@ async def build_community(
 
 
 async def build_communities(
-    driver: AsyncDriver, llm_client: LLMClient
+        driver: AsyncDriver, llm_client: LLMClient
 ) -> tuple[list[CommunityNode], list[CommunityEdge]]:
     community_clusters = await get_community_clusters(driver)
 
@@ -219,7 +220,7 @@ async def remove_communities(driver: AsyncDriver):
 
 
 async def determine_entity_community(
-    driver: AsyncDriver, entity: EntityNode
+        driver: AsyncDriver, entity: EntityNode
 ) -> tuple[CommunityNode | None, bool]:
     # Check if the node is already part of a community
     records, _, _ = await driver.execute_query(
@@ -280,7 +281,7 @@ async def determine_entity_community(
 
 
 async def update_community(
-    driver: AsyncDriver, llm_client: LLMClient, embedder, entity: EntityNode
+        driver: AsyncDriver, llm_client: LLMClient, embedder, entity: EntityNode
 ):
     community, is_new = await determine_entity_community(driver, entity)
 

--- a/tests/test_graphiti_int.py
+++ b/tests/test_graphiti_int.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import asyncio
+import json
 import logging
 import os
 import sys
@@ -74,6 +75,7 @@ def format_context(facts):
 async def test_graphiti_init():
     logger = setup_logging()
     graphiti = Graphiti(NEO4J_URI, NEO4j_USER, NEO4j_PASSWORD)
+    await graphiti.build_communities()
 
     edges = await graphiti.search('tania tetlow', group_ids=['1'])
 

--- a/tests/test_graphiti_int.py
+++ b/tests/test_graphiti_int.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 import asyncio
-import json
 import logging
 import os
 import sys


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replaces Neo4j GraphDataScience Plugin with in-memory label propagation for community detection, updating functions and tests accordingly.
> 
>   - **Community Detection**: Replaces Neo4j GraphDataScience Plugin with in-memory label propagation in `get_community_clusters()` in `community_operations.py`. Introduces `Neighbor` class to support label propagation.
>   - **Function Updates**: Updates `build_communities()` in `graphiti.py` to use the modified `get_community_clusters()`.
>   - **Testing**: Updates `test_graphiti_int.py` to call `build_communities()` during tests.
>   - **Misc**: Removes Neo4j GraphDataScience Plugin requirement from `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 3d600568951d0efb432f686f7e9fb5fb02de0629. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->