### PR TITLE
feat: Fix bug in dedupe_node_list function

### DIFF
--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -272,9 +272,12 @@ async def dedupe_node_list(
     unique_nodes = []
     uuid_map: dict[str, str] = {}
     for node_data in nodes_data:
-        node = node_map[node_data['uuids'][0]]
-        node.summary = node_data['summary']
-        unique_nodes.append(node)
+        node_instance: EntityNode | None = node_map.get(node_data['uuids'][0])
+        if node_instance is None:
+            logger.warning(f'Node {node_data["uuids"][0]} not found in node map')
+            continue
+        node_instance.summary = node_data['summary']
+        unique_nodes.append(node_instance)
 
         for uuid in node_data['uuids'][1:]:
             uuid_value = node_map[node_data['uuids'][0]].uuid


### PR DESCRIPTION
The code changes fix a bug in the `dedupe_node_list` function where a node instance was not found in the node map. The bug is now handled by logging a warning message and skipping the iteration. This ensures that the function continues to execute without any errors.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `dedupe_node_list` by handling missing node instances with a warning and skipping iteration.
> 
>   - **Bug Fix**:
>     - In `dedupe_node_list` function, handle missing node instances in `node_map` by logging a warning and skipping the iteration.
>     - Ensures function execution continues without errors when a node is not found.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 1544425ade744e5c6707ecf50e171f61b61d6947. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->