### PR TITLE
limit community building concurrency

### DIFF
--- a/graphiti_core/utils/maintenance/community_operations.py
+++ b/graphiti_core/utils/maintenance/community_operations.py
@@ -11,7 +11,7 @@ from graphiti_core.nodes import CommunityNode, EntityNode, get_community_node_fr
 from graphiti_core.prompts import prompt_library
 from graphiti_core.utils.maintenance.edge_operations import build_community_edges
 
-MAX_COMMMUNITY_BUILD_CONCURRENCY = 10
+MAX_COMMUNITY_BUILD_CONCURRENCY = 10
 
 
 logger = logging.getLogger(__name__)
@@ -135,7 +135,7 @@ async def build_communities(
     projection = await build_community_projection(driver)
     community_clusters = await get_community_clusters(driver, projection)
 
-    semaphore = asyncio.Semaphore(MAX_COMMMUNITY_BUILD_CONCURRENCY)
+    semaphore = asyncio.Semaphore(MAX_COMMUNITY_BUILD_CONCURRENCY)
 
     async def limited_build_community(cluster):
         async with semaphore:

--- a/graphiti_core/utils/maintenance/community_operations.py
+++ b/graphiti_core/utils/maintenance/community_operations.py
@@ -11,6 +11,9 @@ from graphiti_core.nodes import CommunityNode, EntityNode, get_community_node_fr
 from graphiti_core.prompts import prompt_library
 from graphiti_core.utils.maintenance.edge_operations import build_community_edges
 
+MAX_COMMMUNITY_BUILD_CONCURRENCY = 10
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -132,10 +135,14 @@ async def build_communities(
     projection = await build_community_projection(driver)
     community_clusters = await get_community_clusters(driver, projection)
 
+    semaphore = asyncio.Semaphore(MAX_COMMMUNITY_BUILD_CONCURRENCY)
+
+    async def limited_build_community(cluster):
+        async with semaphore:
+            return await build_community(llm_client, cluster)
+
     communities: list[tuple[CommunityNode, list[CommunityEdge]]] = list(
-        await asyncio.gather(
-            *[build_community(llm_client, cluster) for cluster in community_clusters]
-        )
+        await asyncio.gather(*[limited_build_community(cluster) for cluster in community_clusters])
     )
 
     community_nodes: list[CommunityNode] = []


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Limits concurrency in `build_communities()` to 10 using `asyncio.Semaphore` in `community_operations.py`.
> 
>   - **Concurrency Limiting**:
>     - Introduces `MAX_COMMMUNITY_BUILD_CONCURRENCY` constant set to 10 in `community_operations.py`.
>     - Adds `asyncio.Semaphore` to `build_communities()` to limit concurrency to 10.
>     - Wraps `build_community()` calls in `limited_build_community()` to enforce concurrency limit.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 4b3a0d93adc069a4e3b32bfd82777e98a737d154. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->