### PR TITLE
Override default max tokens for Anthropic and Groq clients

### DIFF
--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -30,6 +30,7 @@ from .errors import RateLimitError
 logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL = 'claude-3-5-sonnet-20240620'
+DEFAULT_MAX_TOKENS = 8192
 
 
 class AnthropicClient(LLMClient):
@@ -37,6 +38,10 @@ class AnthropicClient(LLMClient):
         if config is None:
             config = LLMConfig()
         super().__init__(config, cache)
+
+        # Override the default max tokens for Anthropic
+        self.max_tokens = DEFAULT_MAX_TOKENS
+
         self.client = AsyncAnthropic(
             api_key=config.api_key,
             # we'll use tenacity to retry

--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -36,12 +36,10 @@ DEFAULT_MAX_TOKENS = 8192
 class AnthropicClient(LLMClient):
     def __init__(self, config: LLMConfig | None = None, cache: bool = False):
         if config is None:
-            config = LLMConfig()
+            config = LLMConfig(max_tokens=DEFAULT_MAX_TOKENS)
+        elif config.max_tokens is None:
+            config.max_tokens = DEFAULT_MAX_TOKENS
         super().__init__(config, cache)
-
-        # Override the default max tokens for Anthropic
-        if self.max_tokens is None:
-            self.max_tokens = DEFAULT_MAX_TOKENS
 
         self.client = AsyncAnthropic(
             api_key=config.api_key,

--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -40,7 +40,8 @@ class AnthropicClient(LLMClient):
         super().__init__(config, cache)
 
         # Override the default max tokens for Anthropic
-        self.max_tokens = DEFAULT_MAX_TOKENS
+        if self.max_tokens is None:
+            self.max_tokens = DEFAULT_MAX_TOKENS
 
         self.client = AsyncAnthropic(
             api_key=config.api_key,

--- a/graphiti_core/llm_client/groq_client.py
+++ b/graphiti_core/llm_client/groq_client.py
@@ -31,6 +31,7 @@ from .errors import RateLimitError
 logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL = 'llama-3.1-70b-versatile'
+DEFAULT_MAX_TOKENS = 2048
 
 
 class GroqClient(LLMClient):
@@ -38,6 +39,10 @@ class GroqClient(LLMClient):
         if config is None:
             config = LLMConfig()
         super().__init__(config, cache)
+
+        # Override the default max tokens for Groq
+        self.max_tokens = DEFAULT_MAX_TOKENS
+
         self.client = AsyncGroq(api_key=config.api_key)
 
     def get_embedder(self) -> typing.Any:

--- a/graphiti_core/llm_client/groq_client.py
+++ b/graphiti_core/llm_client/groq_client.py
@@ -41,7 +41,8 @@ class GroqClient(LLMClient):
         super().__init__(config, cache)
 
         # Override the default max tokens for Groq
-        self.max_tokens = DEFAULT_MAX_TOKENS
+        if self.max_tokens is None:
+            self.max_tokens = DEFAULT_MAX_TOKENS
 
         self.client = AsyncGroq(api_key=config.api_key)
 

--- a/graphiti_core/llm_client/groq_client.py
+++ b/graphiti_core/llm_client/groq_client.py
@@ -37,12 +37,10 @@ DEFAULT_MAX_TOKENS = 2048
 class GroqClient(LLMClient):
     def __init__(self, config: LLMConfig | None = None, cache: bool = False):
         if config is None:
-            config = LLMConfig()
+            config = LLMConfig(max_tokens=DEFAULT_MAX_TOKENS)
+        elif config.max_tokens is None:
+            config.max_tokens = DEFAULT_MAX_TOKENS
         super().__init__(config, cache)
-
-        # Override the default max tokens for Groq
-        if self.max_tokens is None:
-            self.max_tokens = DEFAULT_MAX_TOKENS
 
         self.client = AsyncGroq(api_key=config.api_key)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Override default max tokens for Anthropic and Groq clients, updating `__init__` to apply defaults when not provided.
> 
>   - Override default max tokens for Anthropic and Groq clients.
>   - Set `DEFAULT_MAX_TOKENS` to 8192 in `anthropic_client.py`.
>   - Set `DEFAULT_MAX_TOKENS` to 2048 in `groq_client.py`.
>   - Update `__init__` in `AnthropicClient` and `GroqClient` to apply `DEFAULT_MAX_TOKENS` when `config.max_tokens` is not provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for ebd7d4bc5da6f1a1d7256c741b06bd51a52b4614. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->