### PR TITLE
feat: add FastAPI lifespan and healthcheck endpoint

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -158,8 +158,8 @@ class Graphiti:
                 # Use graphiti...
             finally:
                 graphiti.close()
-        self.driver.close()
         """
+        self.driver.close()
 
     async def build_indices_and_constraints(self):
         """

--- a/server/graph_service/main.py
+++ b/server/graph_service/main.py
@@ -13,6 +13,8 @@ async def lifespan(_: FastAPI):
     settings = get_settings()
     await initialize_graphiti(settings)
     yield
+    # Shutdown
+    # No need to close Graphiti here, as it's handled per-request
 
 
 app = FastAPI(lifespan=lifespan)

--- a/server/graph_service/main.py
+++ b/server/graph_service/main.py
@@ -1,14 +1,27 @@
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 
+from graph_service.config import get_settings
 from graph_service.routers import ingest, retrieve
+from graph_service.zep_graphiti import initialize_graphiti
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    settings = get_settings()
+    await initialize_graphiti(settings)
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 app.include_router(retrieve.router)
 app.include_router(ingest.router)
 
 
-@app.get('/')
-def read_root():
-    return {'Hello': 'World'}
+@app.get('/healthcheck')
+async def healthcheck():
+    return JSONResponse(content={'status': 'healthy'}, status_code=200)

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -82,6 +82,15 @@ async def get_graphiti(settings: ZepEnvDep):
         client.close()
 
 
+async def initialize_graphiti(settings: ZepEnvDep):
+    client = ZepGraphiti(
+        uri=settings.neo4j_uri,
+        user=settings.neo4j_user,
+        password=settings.neo4j_password,
+    )
+    await client.build_indices_and_constraints()
+
+
 def get_fact_result_from_edge(edge: EntityEdge):
     return FactResult(
         uuid=edge.uuid,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add FastAPI lifespan for `graphiti` initialization, a `/healthcheck` endpoint, and `initialize_graphiti` function for index setup.
> 
>   - **FastAPI Lifespan**: Added `lifespan` async context manager in `main.py` for `graphiti` initialization.
>   - **Endpoints**: Replaced root endpoint with `/healthcheck` in `main.py`, returning JSON status.
>   - **Graphiti Initialization**: Added `initialize_graphiti()` in `zep_graphiti.py` for index and constraint setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for f65113284627f291f639a0862520f5a56eff79a0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->