### PR TITLE
feat: async close and multi-group search support

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -129,7 +129,7 @@ class Graphiti:
         else:
             self.llm_client = OpenAIClient()
 
-    def close(self):
+    async def close(self):
         """
         Close the connection to the Neo4j database.
 
@@ -159,7 +159,7 @@ class Graphiti:
             finally:
                 graphiti.close()
         """
-        self.driver.close()
+        await self.driver.close()
 
     async def build_indices_and_constraints(self):
         """

--- a/graphiti_core/utils/maintenance/community_operations.py
+++ b/graphiti_core/utils/maintenance/community_operations.py
@@ -154,7 +154,7 @@ async def generate_summary_description(llm_client: LLMClient, summary: str) -> s
 
 
 async def build_community(
-        llm_client: LLMClient, community_cluster: list[EntityNode]
+    llm_client: LLMClient, community_cluster: list[EntityNode]
 ) -> tuple[CommunityNode, list[CommunityEdge]]:
     summaries = [entity.summary for entity in community_cluster]
     length = len(summaries)
@@ -168,7 +168,7 @@ async def build_community(
                 *[
                     summarize_pair(llm_client, (str(left_summary), str(right_summary)))
                     for left_summary, right_summary in zip(
-                        summaries[: int(length / 2)], summaries[int(length / 2):]
+                        summaries[: int(length / 2)], summaries[int(length / 2) :]
                     )
                 ]
             )
@@ -196,7 +196,7 @@ async def build_community(
 
 
 async def build_communities(
-        driver: AsyncDriver, llm_client: LLMClient
+    driver: AsyncDriver, llm_client: LLMClient
 ) -> tuple[list[CommunityNode], list[CommunityEdge]]:
     community_clusters = await get_community_clusters(driver)
 
@@ -227,7 +227,7 @@ async def remove_communities(driver: AsyncDriver):
 
 
 async def determine_entity_community(
-        driver: AsyncDriver, entity: EntityNode
+    driver: AsyncDriver, entity: EntityNode
 ) -> tuple[CommunityNode | None, bool]:
     # Check if the node is already part of a community
     records, _, _ = await driver.execute_query(
@@ -288,7 +288,7 @@ async def determine_entity_community(
 
 
 async def update_community(
-        driver: AsyncDriver, llm_client: LLMClient, embedder, entity: EntityNode
+    driver: AsyncDriver, llm_client: LLMClient, embedder, entity: EntityNode
 ):
     community, is_new = await determine_entity_community(driver, entity)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "graphiti-core"
-version = "0.3.4"
+version = "0.3.5"
 description = "A temporal graph building library"
 authors = [
     "Paul Paliychuk <paul@getzep.com>",

--- a/server/graph_service/dto/retrieve.py
+++ b/server/graph_service/dto/retrieve.py
@@ -6,7 +6,7 @@ from graph_service.dto.common import Message
 
 
 class SearchQuery(BaseModel):
-    group_id: str = Field(..., description='The group id of the memory to get')
+    group_ids: list[str] = Field(description='The group ids for the memories to search')
     query: str
     max_facts: int = Field(default=10, description='The maximum number of facts to retrieve')
 

--- a/server/graph_service/routers/retrieve.py
+++ b/server/graph_service/routers/retrieve.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import List, Optional, cast
 
 from fastapi import APIRouter, status
 
@@ -17,7 +18,9 @@ router = APIRouter()
 @router.post('/search', status_code=status.HTTP_200_OK)
 async def search(query: SearchQuery, graphiti: ZepGraphitiDep):
     relevant_edges = await graphiti.search(
-        group_ids=query.group_ids,
+        group_ids=cast(
+            Optional[List[Optional[str]]], query.group_ids
+        ),  # Cast query.group_ids to match the expected type in graphiti.search
         query=query.query,
         num_results=query.max_facts,
     )

--- a/server/graph_service/routers/retrieve.py
+++ b/server/graph_service/routers/retrieve.py
@@ -17,7 +17,7 @@ router = APIRouter()
 @router.post('/search', status_code=status.HTTP_200_OK)
 async def search(query: SearchQuery, graphiti: ZepGraphitiDep):
     relevant_edges = await graphiti.search(
-        group_ids=[query.group_id],
+        group_ids=query.group_ids,
         query=query.query,
         num_results=query.max_facts,
     )

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -79,7 +79,7 @@ async def get_graphiti(settings: ZepEnvDep):
     try:
         yield client
     finally:
-        client.close()
+        await client.close()
 
 
 async def initialize_graphiti(settings: ZepEnvDep):


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> The PR makes `close()` in `Graphiti` asynchronous, updates search for multiple group IDs, and bumps version to `0.3.5`.
> 
>   - `close()` in `Graphiti` is now asynchronous, improving resource management.
>   - `SearchQuery` in `retrieve.py` accepts `group_ids` as a list for multi-group searches.
>   - `search()` in `retrieve.py` updated for enhanced search flexibility.
>   - Minor updates in `zep_graphiti.py` for async `close()`.
>   - Version bump in `pyproject.toml` from `0.3.4` to `0.3.5`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 70f64d07b2c56334b4ebd6438d82c532fd2ef83d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->