### PR TITLE
refactor: remove unnecessary type casting in `search()` function

### DIFF
--- a/server/graph_service/routers/retrieve.py
+++ b/server/graph_service/routers/retrieve.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import List, Optional, cast
 
 from fastapi import APIRouter, status
 
@@ -18,9 +17,7 @@ router = APIRouter()
 @router.post('/search', status_code=status.HTTP_200_OK)
 async def search(query: SearchQuery, graphiti: ZepGraphitiDep):
     relevant_edges = await graphiti.search(
-        group_ids=cast(
-            Optional[List[Optional[str]]], query.group_ids
-        ),  # Cast query.group_ids to match the expected type in graphiti.search
+        group_ids=query.group_ids,
         query=query.query,
         num_results=query.max_facts,
     )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove unnecessary type casting in `search()` function in `retrieve.py`.
> 
>   - **Code Simplification**:
>     - Removed unnecessary type casting of `query.group_ids` in `search()` function in `retrieve.py`.
>     - Eliminated import of `List`, `Optional`, and `cast` from `typing` in `retrieve.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for faa74e883b6a06bbade029de9c14f508362614c8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->