### PR TITLE
fix: Make groupIds option in search query dto

### DIFF
--- a/server/graph_service/dto/retrieve.py
+++ b/server/graph_service/dto/retrieve.py
@@ -6,7 +6,7 @@ from graph_service.dto.common import Message
 
 
 class SearchQuery(BaseModel):
-    group_ids: list[str] = Field(description='The group ids for the memories to search')
+    group_ids: list[str] | None = Field(None, description='The group ids for the memories to search')
     query: str
     max_facts: int = Field(default=10, description='The maximum number of facts to retrieve')
 

--- a/server/graph_service/dto/retrieve.py
+++ b/server/graph_service/dto/retrieve.py
@@ -6,7 +6,9 @@ from graph_service.dto.common import Message
 
 
 class SearchQuery(BaseModel):
-    group_ids: list[str] | None = Field(None, description='The group ids for the memories to search')
+    group_ids: list[str] | None = Field(
+        None, description='The group ids for the memories to search'
+    )
     query: str
     max_facts: int = Field(default=10, description='The maximum number of facts to retrieve')
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Make `group_ids` optional in `SearchQuery` class in `retrieve.py`.
> 
>   - **Behavior**:
>     - `group_ids` in `SearchQuery` class in `retrieve.py` now accepts `None`, making it optional.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 74791f53f1903fbd3d0ba3987598d2a38af8fe0d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->