### PR TITLE
chore: Make deleting groups safer

### DIFF
--- a/graphiti_core/edges.py
+++ b/graphiti_core/edges.py
@@ -24,7 +24,7 @@ from uuid import uuid4
 from neo4j import AsyncDriver
 from pydantic import BaseModel, Field
 
-from graphiti_core.errors import EdgeNotFoundError
+from graphiti_core.errors import EdgeNotFoundError, GroupsEdgesNotFoundError
 from graphiti_core.helpers import parse_db_date
 from graphiti_core.llm_client.config import EMBEDDING_DIM
 from graphiti_core.nodes import Node
@@ -147,10 +147,9 @@ class EpisodicEdge(Edge):
         )
 
         edges = [get_episodic_edge_from_record(record) for record in records]
-        uuids = [edge.uuid for edge in edges]
 
         if len(edges) == 0:
-            raise EdgeNotFoundError(uuids[0])
+            raise GroupsEdgesNotFoundError(group_ids)
         return edges
 
 
@@ -293,10 +292,9 @@ class EntityEdge(Edge):
         )
 
         edges = [get_entity_edge_from_record(record) for record in records]
-        uuids = [edge.uuid for edge in edges]
 
         if len(edges) == 0:
-            raise EdgeNotFoundError(uuids[0])
+            raise GroupsEdgesNotFoundError(group_ids)
         return edges
 
 

--- a/graphiti_core/errors.py
+++ b/graphiti_core/errors.py
@@ -27,6 +27,14 @@ class EdgeNotFoundError(GraphitiError):
         super().__init__(self.message)
 
 
+class GroupsEdgesNotFoundError(GraphitiError):
+    """Raised when no edges are found for a list of group ids."""
+
+    def __init__(self, group_ids: list[str]):
+        self.message = f'no edges found for group ids {group_ids}'
+        super().__init__(self.message)
+
+
 class NodeNotFoundError(GraphitiError):
     """Raised when a node is not found."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "graphiti-core"
-version = "0.3.5"
+version = "0.3.6"
 description = "A temporal graph building library"
 authors = [
     "Paul Paliychuk <paul@getzep.com>",

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -39,20 +39,20 @@ class ZepGraphiti(Graphiti):
     async def delete_group(self, group_id: str):
         try:
             edges = await EntityEdge.get_by_group_ids(self.driver, [group_id])
-        except Exception as e:
-            logger.warning(f'Error fetching edges for group {group_id}: {str(e)}')
+        except EdgeNotFoundError:
+            logger.warning(f'No edges found for group {group_id}')
             edges = []
 
         try:
             nodes = await EntityNode.get_by_group_ids(self.driver, [group_id])
-        except Exception as e:
-            logger.warning(f'Error fetching nodes for group {group_id}: {str(e)}')
+        except NodeNotFoundError:
+            logger.warning(f'No nodes found for group {group_id}')
             nodes = []
 
         try:
             episodes = await EpisodicNode.get_by_group_ids(self.driver, [group_id])
-        except Exception as e:
-            logger.warning(f'Error fetching episodes for group {group_id}: {str(e)}')
+        except NodeNotFoundError:
+            logger.warning(f'No episodes found for group {group_id}')
             episodes = []
 
         for edge in edges:

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -4,7 +4,7 @@ from typing import Annotated
 from fastapi import Depends, HTTPException
 from graphiti_core import Graphiti  # type: ignore
 from graphiti_core.edges import EntityEdge  # type: ignore
-from graphiti_core.errors import EdgeNotFoundError, NodeNotFoundError  # type: ignore
+from graphiti_core.errors import EdgeNotFoundError, GroupsEdgesNotFoundError, NodeNotFoundError
 from graphiti_core.llm_client import LLMClient  # type: ignore
 from graphiti_core.nodes import EntityNode, EpisodicNode  # type: ignore
 
@@ -39,21 +39,13 @@ class ZepGraphiti(Graphiti):
     async def delete_group(self, group_id: str):
         try:
             edges = await EntityEdge.get_by_group_ids(self.driver, [group_id])
-        except EdgeNotFoundError:
+        except GroupsEdgesNotFoundError:
             logger.warning(f'No edges found for group {group_id}')
             edges = []
 
-        try:
-            nodes = await EntityNode.get_by_group_ids(self.driver, [group_id])
-        except NodeNotFoundError:
-            logger.warning(f'No nodes found for group {group_id}')
-            nodes = []
+        nodes = await EntityNode.get_by_group_ids(self.driver, [group_id])
 
-        try:
-            episodes = await EpisodicNode.get_by_group_ids(self.driver, [group_id])
-        except NodeNotFoundError:
-            logger.warning(f'No episodes found for group {group_id}')
-            episodes = []
+        episodes = await EpisodicNode.get_by_group_ids(self.driver, [group_id])
 
         for edge in edges:
             await edge.delete(self.driver)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances `delete_group()` in `zep_graphiti.py` with exception handling and logging, introduces `GroupsEdgesNotFoundError`, and updates version to `0.3.6`.
> 
>   - **Behavior**:
>     - `delete_group()` in `zep_graphiti.py` now logs warnings for `GroupsEdgesNotFoundError` instead of raising exceptions.
>     - Handles exceptions for fetching edges, nodes, and episodes, logging warnings if not found.
>   - **Errors**:
>     - Introduces `GroupsEdgesNotFoundError` in `errors.py` for missing group edges.
>   - **Versioning**:
>     - Updates version in `pyproject.toml` from `0.3.5` to `0.3.6`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for e469e4d41e3cdf70155500034aad27b470894042. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->