### PR TITLE
feat: add health checks and dependencies to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
           "CMD",
           "python",
           "-c",
-          "import urllib.request; urllib.request.urlopen('http://localhost:8003/healthcheck')",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthcheck')",
         ]
       interval: 10s
       timeout: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,20 @@ services:
     image: zepai/graphiti:latest
     ports:
       - "8000:8000"
-    
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8003/healthcheck')",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    depends_on:
+      neo4j:
+        condition: service_healthy
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - NEO4J_URI=bolt://neo4j:${NEO4J_PORT}
@@ -14,7 +27,12 @@ services:
       - PORT=8000
   neo4j:
     image: neo4j:5.22.0
-    
+    healthcheck:
+      test: wget "http://localhost:${NEO4J_PORT}" || exit 1
+      interval: 1s
+      timeout: 10s
+      retries: 20
+      start_period: 3s
     ports:
       - "7474:7474"  # HTTP
       - "${NEO4J_PORT}:${NEO4J_PORT}"  # Bolt


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add health checks and service dependencies to `docker-compose.yml` for `graph` and `neo4j` services.
> 
>   - **Health Checks**:
>     - Added `healthcheck` for `graph` service using a Python command to check `http://localhost:8000/healthcheck`.
>     - Added `healthcheck` for `neo4j` service using `wget` to check `http://localhost:${NEO4J_PORT}`.
>   - **Dependencies**:
>     - `graph` service now depends on `neo4j` service being healthy before starting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for fed3e8841685ad5221fb44ff8e605fe87c2960a7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->