### PR TITLE
feat: support switching LLM providers and embedding providers through…

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Requirements:
 Optional:
 
 - Anthropic or Groq API key (for alternative LLM providers)
+- Voyage API key (for alternative embedding providers)
 
 > [!TIP]
 > The simplest way to install Neo4j is via [Neo4j Desktop](https://neo4j.com/download/). It provides a user-friendly
@@ -103,7 +104,8 @@ poetry add graphiti-core
 
 > [!IMPORTANT]
 > Graphiti uses OpenAI for LLM inference and embedding. Ensure that an `OPENAI_API_KEY` is set in your environment.
-> Support for Anthropic and Groq LLM inferences is available, too.
+> Alternatively, Graphiti also supports Anthropic and Groq for LLM inferences.
+> Voyage embedding support is also available.
 
 ```python
 from graphiti_core import Graphiti

--- a/server/graph_service/config.py
+++ b/server/graph_service/config.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import Depends
 from pydantic import Field
@@ -7,10 +7,19 @@ from pydantic_settings import BaseSettings, SettingsConfigDict  # type: ignore
 
 
 class Settings(BaseSettings):
-    openai_api_key: str
+    openai_api_key: str | None = Field(None)
     openai_base_url: str | None = Field(None)
+    
+    groq_api_key: str | None = Field(None)
+    anthropic_api_key: str | None = Field(None)
+    voyage_api_key: str | None = Field(None)
+
+    llm_provider: Literal['openai', 'groq', 'anthropic'] | None = Field(None)
     model_name: str | None = Field(None)
+    
+    embedding_provider: Literal['openai', 'voyage'] | None = Field(None)
     embedding_model_name: str | None = Field(None)
+
     neo4j_uri: str
     neo4j_user: str
     neo4j_password: str

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -4,8 +4,9 @@ from typing import Annotated
 from fastapi import Depends, HTTPException
 from graphiti_core import Graphiti  # type: ignore
 from graphiti_core.edges import EntityEdge  # type: ignore
+from graphiti_core.embedder import EmbedderClient  # type: ignore
 from graphiti_core.errors import EdgeNotFoundError, GroupsEdgesNotFoundError, NodeNotFoundError
-from graphiti_core.llm_client import LLMClient  # type: ignore
+from graphiti_core.llm_client import LLMClient, LLMConfig  # type: ignore
 from graphiti_core.nodes import EntityNode, EpisodicNode  # type: ignore
 
 from graph_service.config import ZepEnvDep
@@ -15,8 +16,8 @@ logger = logging.getLogger(__name__)
 
 
 class ZepGraphiti(Graphiti):
-    def __init__(self, uri: str, user: str, password: str, llm_client: LLMClient | None = None):
-        super().__init__(uri, user, password, llm_client)
+    def __init__(self, uri: str, user: str, password: str, llm_client: LLMClient | None = None, embedder: EmbedderClient | None = None):
+        super().__init__(uri, user, password, llm_client, embedder)
 
     async def save_entity_node(self, name: str, uuid: str, group_id: str, summary: str = ''):
         new_node = EntityNode(
@@ -72,17 +73,44 @@ class ZepGraphiti(Graphiti):
 
 
 async def get_graphiti(settings: ZepEnvDep):
+    llm_client: LLMClient | None = None
+    embedder: EmbedderClient | None = None
+
+    llm_config = LLMConfig(model=settings.model_name)
+
+    if settings.llm_provider == 'groq':
+        from graphiti_core.llm_client.groq_client import GroqClient
+        llm_config.api_key = settings.groq_api_key
+        llm_client = GroqClient(config=llm_config)
+    elif settings.llm_provider == 'anthropic':
+        from graphiti_core.llm_client.anthropic_client import AnthropicClient
+        llm_config.api_key = settings.anthropic_api_key
+        llm_client = AnthropicClient(config=llm_config)
+    else:
+        # fallback to openai
+        from graphiti_core.llm_client.openai_client import OpenAIClient
+        llm_config.api_key = settings.openai_api_key
+        llm_config.base_url = settings.openai_base_url
+        llm_client = OpenAIClient(config=llm_config)
+
+    if settings.embedding_provider == 'voyage':
+        from graphiti_core.embedder.voyage import VoyageAIEmbedder, VoyageAIEmbedderConfig
+        embedder = VoyageAIEmbedder(config=VoyageAIEmbedderConfig(api_key=settings.voyage_api_key))
+    else:
+        # fallback to openai
+        from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig
+        embedder = OpenAIEmbedder(config=OpenAIEmbedderConfig(api_key=settings.openai_api_key, base_url=settings.openai_base_url))
+
+    if settings.embedding_model_name is not None:
+        embedder.config.embedding_model = settings.embedding_model_name
+
     client = ZepGraphiti(
         uri=settings.neo4j_uri,
         user=settings.neo4j_user,
         password=settings.neo4j_password,
+        llm_client=llm_client,
+        embedder = embedder
     )
-    if settings.openai_base_url is not None:
-        client.llm_client.config.base_url = settings.openai_base_url
-    if settings.openai_api_key is not None:
-        client.llm_client.config.api_key = settings.openai_api_key
-    if settings.model_name is not None:
-        client.llm_client.model = settings.model_name
 
     try:
         yield client


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for switching LLM and embedding providers, including Groq, Anthropic, and Voyage, with corresponding configuration and documentation updates.
> 
>   - **Behavior**:
>     - Adds support for switching LLM providers (`openai`, `groq`, `anthropic`) and embedding providers (`openai`, `voyage`) in `zep_graphiti.py`.
>     - Updates `get_graphiti()` to initialize `LLMClient` and `EmbedderClient` based on `Settings`.
>   - **Configuration**:
>     - Adds `llm_provider` and `embedding_provider` fields to `Settings` in `config.py`.
>     - Adds API key fields for `groq`, `anthropic`, and `voyage` in `Settings`.
>   - **Documentation**:
>     - Updates `README.md` to include information about new LLM and embedding providers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 0f70eedaadbde007ff99787f198e6d8a9c704d1e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->