### PR TITLE
fix embedding_model_name not work

### DIFF
--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -84,9 +84,9 @@ async def get_graphiti(settings: ZepEnvDep):
     if settings.model_name is not None:
         client.llm_client.model = settings.model_name
     if settings.embedding_model_name is not None and \
-        hasattr(client.embedder, 'config') and  \
-        hasattr(client.embedder.config, 'embedding_model'):
-            client.embedder.config.embedding_model = settings.embedding_model_name
+            hasattr(client.embedder, 'config') and  \
+            hasattr(client.embedder.config, 'embedding_model'):
+        client.embedder.config.embedding_model = settings.embedding_model_name
 
     try:
         yield client

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -83,6 +83,10 @@ async def get_graphiti(settings: ZepEnvDep):
         client.llm_client.config.api_key = settings.openai_api_key
     if settings.model_name is not None:
         client.llm_client.model = settings.model_name
+    if settings.embedding_model_name is not None and \
+        hasattr(client.embedder, 'config') and  \
+        hasattr(client.embedder.config, 'embedding_model'):
+            client.embedder.config.embedding_model = settings.embedding_model_name
 
     try:
         yield client


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes issue in `zep_graphiti.py` where `embedding_model_name` was not being set in `get_graphiti()`.
> 
>   - **Behavior**:
>     - Fixes issue where `embedding_model_name` was not being set in `get_graphiti()` in `zep_graphiti.py`.
>     - Adds condition to set `client.embedder.config.embedding_model` if `settings.embedding_model_name` is provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 28348bc36fabd4815c038e6115fb4599850ae1ee. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->