### PR TITLE
set content to empty after episode extractions have happened

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -86,13 +86,13 @@ class AddEpisodeResults(BaseModel):
 
 class Graphiti:
     def __init__(
-        self,
-        uri: str,
-        user: str,
-        password: str,
-        llm_client: LLMClient | None = None,
-        embedder: EmbedderClient | None = None,
-        store_raw_episode_content: bool = True,
+            self,
+            uri: str,
+            user: str,
+            password: str,
+            llm_client: LLMClient | None = None,
+            embedder: EmbedderClient | None = None,
+            store_raw_episode_content: bool = True,
     ):
         """
         Initialize a Graphiti instance.
@@ -210,10 +210,10 @@ class Graphiti:
         await build_indices_and_constraints(self.driver, delete_existing)
 
     async def retrieve_episodes(
-        self,
-        reference_time: datetime,
-        last_n: int = EPISODE_WINDOW_LEN,
-        group_ids: list[str] | None = None,
+            self,
+            reference_time: datetime,
+            last_n: int = EPISODE_WINDOW_LEN,
+            group_ids: list[str] | None = None,
     ) -> list[EpisodicNode]:
         """
         Retrieve the last n episodic nodes from the graph.
@@ -243,15 +243,15 @@ class Graphiti:
         return await retrieve_episodes(self.driver, reference_time, last_n, group_ids)
 
     async def add_episode(
-        self,
-        name: str,
-        episode_body: str,
-        source_description: str,
-        reference_time: datetime,
-        source: EpisodeType = EpisodeType.message,
-        group_id: str = '',
-        uuid: str | None = None,
-        update_communities: bool = False,
+            self,
+            name: str,
+            episode_body: str,
+            source_description: str,
+            reference_time: datetime,
+            source: EpisodeType = EpisodeType.message,
+            group_id: str = '',
+            uuid: str | None = None,
+            update_communities: bool = False,
     ) -> AddEpisodeResults:
         """
         Process an episode and update the graph.
@@ -319,8 +319,6 @@ class Graphiti:
                 valid_at=reference_time,
             )
             episode.uuid = uuid if uuid is not None else episode.uuid
-            if not self.store_raw_episode_content:
-                episode.content = ''
 
             # Extract entities as nodes
 
@@ -442,6 +440,9 @@ class Graphiti:
             episode.entity_edges = [edge.uuid for edge in entity_edges]
 
             # Future optimization would be using batch operations to save nodes and edges
+            if not self.store_raw_episode_content:
+                episode.content = ''
+                
             await episode.save(self.driver)
             await asyncio.gather(*[node.save(self.driver) for node in nodes])
             await asyncio.gather(*[edge.save(self.driver) for edge in episodic_edges])
@@ -601,11 +602,11 @@ class Graphiti:
         return community_nodes
 
     async def search(
-        self,
-        query: str,
-        center_node_uuid: str | None = None,
-        group_ids: list[str] | None = None,
-        num_results=DEFAULT_SEARCH_LIMIT,
+            self,
+            query: str,
+            center_node_uuid: str | None = None,
+            group_ids: list[str] | None = None,
+            num_results=DEFAULT_SEARCH_LIMIT,
     ) -> list[EntityEdge]:
         """
         Perform a hybrid search on the knowledge graph.
@@ -657,20 +658,20 @@ class Graphiti:
         return edges
 
     async def _search(
-        self,
-        query: str,
-        config: SearchConfig,
-        group_ids: list[str] | None = None,
-        center_node_uuid: str | None = None,
+            self,
+            query: str,
+            config: SearchConfig,
+            group_ids: list[str] | None = None,
+            center_node_uuid: str | None = None,
     ) -> SearchResults:
         return await search(self.driver, self.embedder, query, group_ids, config, center_node_uuid)
 
     async def get_nodes_by_query(
-        self,
-        query: str,
-        center_node_uuid: str | None = None,
-        group_ids: list[str] | None = None,
-        limit: int = DEFAULT_SEARCH_LIMIT,
+            self,
+            query: str,
+            center_node_uuid: str | None = None,
+            group_ids: list[str] | None = None,
+            limit: int = DEFAULT_SEARCH_LIMIT,
     ) -> list[EntityNode]:
         """
         Retrieve nodes from the graph database based on a text query.

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -86,13 +86,13 @@ class AddEpisodeResults(BaseModel):
 
 class Graphiti:
     def __init__(
-            self,
-            uri: str,
-            user: str,
-            password: str,
-            llm_client: LLMClient | None = None,
-            embedder: EmbedderClient | None = None,
-            store_raw_episode_content: bool = True,
+        self,
+        uri: str,
+        user: str,
+        password: str,
+        llm_client: LLMClient | None = None,
+        embedder: EmbedderClient | None = None,
+        store_raw_episode_content: bool = True,
     ):
         """
         Initialize a Graphiti instance.
@@ -210,10 +210,10 @@ class Graphiti:
         await build_indices_and_constraints(self.driver, delete_existing)
 
     async def retrieve_episodes(
-            self,
-            reference_time: datetime,
-            last_n: int = EPISODE_WINDOW_LEN,
-            group_ids: list[str] | None = None,
+        self,
+        reference_time: datetime,
+        last_n: int = EPISODE_WINDOW_LEN,
+        group_ids: list[str] | None = None,
     ) -> list[EpisodicNode]:
         """
         Retrieve the last n episodic nodes from the graph.
@@ -243,15 +243,15 @@ class Graphiti:
         return await retrieve_episodes(self.driver, reference_time, last_n, group_ids)
 
     async def add_episode(
-            self,
-            name: str,
-            episode_body: str,
-            source_description: str,
-            reference_time: datetime,
-            source: EpisodeType = EpisodeType.message,
-            group_id: str = '',
-            uuid: str | None = None,
-            update_communities: bool = False,
+        self,
+        name: str,
+        episode_body: str,
+        source_description: str,
+        reference_time: datetime,
+        source: EpisodeType = EpisodeType.message,
+        group_id: str = '',
+        uuid: str | None = None,
+        update_communities: bool = False,
     ) -> AddEpisodeResults:
         """
         Process an episode and update the graph.
@@ -442,7 +442,7 @@ class Graphiti:
             # Future optimization would be using batch operations to save nodes and edges
             if not self.store_raw_episode_content:
                 episode.content = ''
-                
+
             await episode.save(self.driver)
             await asyncio.gather(*[node.save(self.driver) for node in nodes])
             await asyncio.gather(*[edge.save(self.driver) for edge in episodic_edges])
@@ -602,11 +602,11 @@ class Graphiti:
         return community_nodes
 
     async def search(
-            self,
-            query: str,
-            center_node_uuid: str | None = None,
-            group_ids: list[str] | None = None,
-            num_results=DEFAULT_SEARCH_LIMIT,
+        self,
+        query: str,
+        center_node_uuid: str | None = None,
+        group_ids: list[str] | None = None,
+        num_results=DEFAULT_SEARCH_LIMIT,
     ) -> list[EntityEdge]:
         """
         Perform a hybrid search on the knowledge graph.
@@ -658,20 +658,20 @@ class Graphiti:
         return edges
 
     async def _search(
-            self,
-            query: str,
-            config: SearchConfig,
-            group_ids: list[str] | None = None,
-            center_node_uuid: str | None = None,
+        self,
+        query: str,
+        config: SearchConfig,
+        group_ids: list[str] | None = None,
+        center_node_uuid: str | None = None,
     ) -> SearchResults:
         return await search(self.driver, self.embedder, query, group_ids, config, center_node_uuid)
 
     async def get_nodes_by_query(
-            self,
-            query: str,
-            center_node_uuid: str | None = None,
-            group_ids: list[str] | None = None,
-            limit: int = DEFAULT_SEARCH_LIMIT,
+        self,
+        query: str,
+        center_node_uuid: str | None = None,
+        group_ids: list[str] | None = None,
+        limit: int = DEFAULT_SEARCH_LIMIT,
     ) -> list[EntityNode]:
         """
         Retrieve nodes from the graph database based on a text query.

--- a/graphiti_core/search/search.py
+++ b/graphiti_core/search/search.py
@@ -53,12 +53,12 @@ logger = logging.getLogger(__name__)
 
 
 async def search(
-        driver: AsyncDriver,
-        embedder: EmbedderClient,
-        query: str,
-        group_ids: list[str] | None,
-        config: SearchConfig,
-        center_node_uuid: str | None = None,
+    driver: AsyncDriver,
+    embedder: EmbedderClient,
+    query: str,
+    group_ids: list[str] | None,
+    config: SearchConfig,
+    center_node_uuid: str | None = None,
 ) -> SearchResults:
     start = time()
     query = query.replace('\n', ' ')
@@ -107,13 +107,13 @@ async def search(
 
 
 async def edge_search(
-        driver: AsyncDriver,
-        embedder: EmbedderClient,
-        query: str,
-        group_ids: list[str] | None,
-        config: EdgeSearchConfig | None,
-        center_node_uuid: str | None = None,
-        limit=DEFAULT_SEARCH_LIMIT,
+    driver: AsyncDriver,
+    embedder: EmbedderClient,
+    query: str,
+    group_ids: list[str] | None,
+    config: EdgeSearchConfig | None,
+    center_node_uuid: str | None = None,
+    limit=DEFAULT_SEARCH_LIMIT,
 ) -> list[EntityEdge]:
     if config is None:
         return []
@@ -176,13 +176,13 @@ async def edge_search(
 
 
 async def node_search(
-        driver: AsyncDriver,
-        embedder: EmbedderClient,
-        query: str,
-        group_ids: list[str] | None,
-        config: NodeSearchConfig | None,
-        center_node_uuid: str | None = None,
-        limit=DEFAULT_SEARCH_LIMIT,
+    driver: AsyncDriver,
+    embedder: EmbedderClient,
+    query: str,
+    group_ids: list[str] | None,
+    config: NodeSearchConfig | None,
+    center_node_uuid: str | None = None,
+    limit=DEFAULT_SEARCH_LIMIT,
 ) -> list[EntityNode]:
     if config is None:
         return []
@@ -230,12 +230,12 @@ async def node_search(
 
 
 async def community_search(
-        driver: AsyncDriver,
-        embedder: EmbedderClient,
-        query: str,
-        group_ids: list[str] | None,
-        config: CommunitySearchConfig | None,
-        limit=DEFAULT_SEARCH_LIMIT,
+    driver: AsyncDriver,
+    embedder: EmbedderClient,
+    query: str,
+    group_ids: list[str] | None,
+    config: CommunitySearchConfig | None,
+    limit=DEFAULT_SEARCH_LIMIT,
 ) -> list[CommunityNode]:
     if config is None:
         return []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "graphiti-core"
-version = "0.3.10"
+version = "0.3.11"
 description = "A temporal graph building library"
 authors = [
     "Paul Paliychuk <paul@getzep.com>",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Move `episode.content` clearing in `add_episode()` to post-extraction and adjust method indentations in `graphiti.py` and `search.py`.
> 
>   - **Behavior**:
>     - In `graphiti.py`, moved setting `episode.content` to empty in `add_episode()` after entity extraction if `store_raw_episode_content` is false.
>   - **Misc**:
>     - Adjusted indentation in `__init__()`, `retrieve_episodes()`, `add_episode()`, `search()`, `_search()`, and `get_nodes_by_query()` methods in `graphiti.py`.
>     - Adjusted indentation in `search()`, `edge_search()`, `node_search()`, and `community_search()` functions in `search.py`.
>     - Updated version in `pyproject.toml` from `0.3.10` to `0.3.11`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 52791c005679e1d7a75570a1ca6b085f4e723b30. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->