### PR TITLE
add unicode escape

### DIFF
--- a/graphiti_core/prompts/lib.py
+++ b/graphiti_core/prompts/lib.py
@@ -74,6 +74,7 @@ from .invalidate_edges import (
     versions as invalidate_edges_versions,
 )
 from .models import Message, PromptFunction
+from .prompt_helpers import DO_NOT_ESCAPE_UNICODE
 from .summarize_nodes import Prompt as SummarizeNodesPrompt
 from .summarize_nodes import Versions as SummarizeNodesVersions
 from .summarize_nodes import versions as summarize_nodes_versions
@@ -106,7 +107,10 @@ class VersionWrapper:
         self.func = func
 
     def __call__(self, context: dict[str, Any]) -> list[Message]:
-        return self.func(context)
+        messages = self.func(context)
+        for message in messages:
+            message.content += DO_NOT_ESCAPE_UNICODE if message.role == 'system' else ''
+        return messages
 
 
 class PromptTypeWrapper:

--- a/graphiti_core/prompts/prompt_helpers.py
+++ b/graphiti_core/prompts/prompt_helpers.py
@@ -1,0 +1,1 @@
+DO_NOT_ESCAPE_UNICODE = '\nDo not escape unicode characters.\n'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "graphiti-core"
-version = "0.4.2"
+version = "0.4.3"
 description = "A temporal graph building library"
 authors = [
     "Paul Paliychuk <paul@getzep.com>",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `DO_NOT_ESCAPE_UNICODE` to prevent unicode escaping in system messages and updates version to 0.4.3.
> 
>   - **Behavior**:
>     - Appends `DO_NOT_ESCAPE_UNICODE` to `Message.content` in `VersionWrapper.__call__()` in `lib.py` if `message.role` is 'system'.
>   - **Constants**:
>     - Adds `DO_NOT_ESCAPE_UNICODE` in `prompt_helpers.py` to indicate unicode characters should not be escaped.
>   - **Versioning**:
>     - Updates version in `pyproject.toml` from `0.4.2` to `0.4.3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 4422d75825a5ac06ade04b988845fd94cc8594cd. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->