### PR TITLE
use default value for return exceptions

### DIFF
--- a/graphiti_core/helpers.py
+++ b/graphiti_core/helpers.py
@@ -86,16 +86,11 @@ def normalize_l2(embedding: list[float]) -> list[float]:
 
 
 # Use this instead of asyncio.gather() to bound coroutines
-async def semaphore_gather(
-    *coroutines: Coroutine, max_coroutines: int = SEMAPHORE_LIMIT, return_exceptions=True
-):
+async def semaphore_gather(*coroutines: Coroutine, max_coroutines: int = SEMAPHORE_LIMIT):
     semaphore = asyncio.Semaphore(max_coroutines)
 
     async def _wrap_coroutine(coroutine):
         async with semaphore:
             return await coroutine
 
-    return await asyncio.gather(
-        *(_wrap_coroutine(coroutine) for coroutine in coroutines),
-        return_exceptions=return_exceptions,
-    )
+    return await asyncio.gather(*(_wrap_coroutine(coroutine) for coroutine in coroutines))


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `return_exceptions` parameter from `semaphore_gather()` in `helpers.py`, changing exception handling behavior.
> 
>   - **Behavior**:
>     - Removed `return_exceptions` parameter from `semaphore_gather()` in `helpers.py`, changing exception handling to propagate exceptions instead of returning them.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for e2ea0078429586245cf43f0252ed3883d0d1e30c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->