### PR TITLE
fix: Update integration tests with correct embedding generation

### DIFF
--- a/tests/test_graphiti_int.py
+++ b/tests/test_graphiti_int.py
@@ -100,6 +100,7 @@ async def test_graph_integration():
         source_description='conversation message',
         content='Alice likes Bob',
         entity_edges=[],
+        group_id='test_graphiti_group',
     )
 
     alice_node = EntityNode(
@@ -107,16 +108,27 @@ async def test_graph_integration():
         labels=[],
         created_at=now,
         summary='Alice summary',
+        group_id='test_graphiti_group',
     )
+    await alice_node.generate_name_embedding(embedder)
 
-    bob_node = EntityNode(name='Bob', labels=[], created_at=now, summary='Bob summary')
+    bob_node = EntityNode(
+        name='Bob', labels=[], created_at=now, summary='Bob summary', group_id='test_graphiti_group'
+    )
+    await bob_node.generate_name_embedding(embedder)
 
     episodic_edge_1 = EpisodicEdge(
-        source_node_uuid=episode.uuid, target_node_uuid=alice_node.uuid, created_at=now
+        source_node_uuid=episode.uuid,
+        target_node_uuid=alice_node.uuid,
+        created_at=now,
+        group_id='test_graphiti_group',
     )
 
     episodic_edge_2 = EpisodicEdge(
-        source_node_uuid=episode.uuid, target_node_uuid=bob_node.uuid, created_at=now
+        source_node_uuid=episode.uuid,
+        target_node_uuid=bob_node.uuid,
+        created_at=now,
+        group_id='test_graphiti_group',
     )
 
     entity_edge = EntityEdge(
@@ -129,6 +141,7 @@ async def test_graph_integration():
         expired_at=now,
         valid_at=now,
         invalid_at=now,
+        group_id='test_graphiti_group',
     )
 
     await entity_edge.generate_embedding(embedder)


### PR DESCRIPTION
## Changes
- Use generate_name_embedding for EntityNode instances
- Add group_id field to all nodes and edges

## Testing
- All integration tests are now passing
- Verified correct embedding generation
- Confirmed proper Neo4j transaction handling

## Additional Notes
- No breaking changes introduced
- Maintains compatibility with existing codebase
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update integration tests in `test_graphiti_int.py` to use `generate_name_embedding` and add `group_id` field to nodes and edges.
> 
>   - **Integration Tests**:
>     - Use `generate_name_embedding` for `EntityNode` instances in `test_graphiti_int.py`.
>     - Add `group_id` field to `EntityNode`, `EpisodicEdge`, and `EntityEdge` instances in `test_graphiti_int.py`.
>   - **Testing**:
>     - All integration tests now pass.
>     - Verified correct embedding generation and Neo4j transaction handling.
>   - **Misc**:
>     - No breaking changes introduced.
>     - Maintains compatibility with existing codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 16aeb3f028afaf9234fef9fd2077e24bb9d61684. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->