### PR TITLE
WIP add episode bulk

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -481,6 +481,7 @@ class Graphiti:
         except Exception as e:
             raise e
 
+    #### WIP: USE AT YOUR OWN RISK ####
     async def add_episode_bulk(self, bulk_episodes: list[RawEpisode], group_id: str = ''):
         """
         Process multiple episodes in bulk and update the graph.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `add_episode_bulk()` method in `Graphiti` class for bulk processing of episodes, marked as work-in-progress.
> 
>   - **New Functionality**:
>     - Adds `add_episode_bulk()` method in `Graphiti` class in `graphiti.py` for processing multiple episodes in bulk.
>     - Handles saving episodes, extracting nodes and edges, generating embeddings, deduplicating nodes and edges, and saving to the knowledge graph.
>   - **Limitations**:
>     - Does not perform edge invalidation or date extraction; use `add_episode()` for these operations.
>   - **Misc**:
>     - Method is marked as "WIP: USE AT YOUR OWN RISK" indicating it's a work-in-progress.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 9078f634a52b48d079c0ef4b7ef83345d5d19792. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->