### PR TITLE
OpenAI RateLimitError

### DIFF
--- a/graphiti_core/llm_client/openai_client.py
+++ b/graphiti_core/llm_client/openai_client.py
@@ -28,6 +28,8 @@ from .client import LLMClient
 from .config import DEFAULT_MAX_TOKENS, LLMConfig
 from .errors import RateLimitError, RefusalError
 
+import asyncio
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL = 'gpt-4o-mini'
@@ -134,13 +136,33 @@ class OpenAIClient(LLMClient):
         retry_count = 0
         last_error = None
 
+        def _parse_retry_after(error_msg: str) -> float:
+            """Extract retry time from OpenAI error message"""
+            try:
+                # Find time in milliseconds (e.g., "Please try again in 479ms")
+                import re
+                match = re.search(r'Please try again in (\d+)ms', error_msg)
+                if match:
+                    return float(match.group(1)) / 1000  # Convert ms to seconds
+                
+                # Fallback to exponential backoff if no time found
+                return min(5 * (2 ** retry_count), max_delay)
+            except:
+                return 5.0  # Default fallback delay
+
         while retry_count <= self.MAX_RETRIES:
             try:
                 response = await self._generate_response(messages, response_model, max_tokens)
                 return response
-            except (RateLimitError, RefusalError):
+            except RefusalError as e:
                 # These errors should not trigger retries
                 raise
+            # Handle rate limits with backoff
+            except RateLimitError as e:
+                retry_after = _parse_retry_after(e)
+                logger.warning(f"Rate limit hit. Retrying in {retry_after}s (attempt {retry_count + 1}/{self.MAX_RETRIES})")
+                await asyncio.sleep(retry_after)
+                retry_count += 1
             except (openai.APITimeoutError, openai.APIConnectionError, openai.InternalServerError):
                 # Let OpenAI's client handle these retries
                 raise


### PR DESCRIPTION
It wasn't possible to run this tutorial https://help.getzep.com/graphiti/graphiti/lang-graph-agent consistently without adding this rate limiting API.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds rate limiting handling with exponential backoff to `generate_response()` in `openai_client.py`.
> 
>   - **Behavior**:
>     - Adds rate limiting handling in `generate_response()` in `openai_client.py` using exponential backoff.
>     - Implements `_parse_retry_after()` to extract retry time from error messages or fallback to exponential backoff.
>     - Logs rate limit hits and retry attempts.
>   - **Error Handling**:
>     - Catches `RateLimitError` and retries with delay.
>     - Continues to raise `RefusalError` without retry.
>     - Handles other OpenAI errors by deferring to OpenAI's client retry logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 1511121fb273fb24323db957adafbe013e2419b4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->