### PR TITLE
remove core properties from attribute list

### DIFF
--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -514,7 +514,7 @@ def get_episodic_node_from_record(record: Any) -> EpisodicNode:
 
 
 def get_entity_node_from_record(record: Any) -> EntityNode:
-    return EntityNode(
+    entity_node = EntityNode(
         uuid=record['uuid'],
         name=record['name'],
         group_id=record['group_id'],
@@ -524,6 +524,15 @@ def get_entity_node_from_record(record: Any) -> EntityNode:
         summary=record['summary'],
         attributes=record['attributes'],
     )
+
+    del entity_node.attributes['uuid']
+    del entity_node.attributes['name']
+    del entity_node.attributes['group_id']
+    del entity_node.attributes['name_embedding']
+    del entity_node.attributes['summary']
+    del entity_node.attributes['created_at']
+
+    return entity_node
 
 
 def get_community_node_from_record(record: Any) -> CommunityNode:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove core properties from `attributes` in `get_entity_node_from_record` in `nodes.py`.
> 
>   - **Functionality**:
>     - In `get_entity_node_from_record` in `nodes.py`, core properties (`uuid`, `name`, `group_id`, `name_embedding`, `summary`, `created_at`) are removed from `attributes` of `EntityNode`.
>   - **Purpose**:
>     - Ensures core properties are not duplicated in `attributes` dictionary, maintaining separation between core properties and additional attributes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 3840f422ef50443d617f6f6bd20cf7cf64a300b7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->