### PR TITLE
Allow usage of different openai compatible clients in embedder and encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ from openai import AsyncAzureOpenAI
 from graphiti_core import Graphiti
 from graphiti_core.llm_client import OpenAIClient
 from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig
+from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient
 
 # Azure OpenAI configuration
 api_key = "<your-api-key>"
@@ -230,6 +231,10 @@ graphiti = Graphiti(
         config=OpenAIEmbedderConfig(
             embedding_model="text-embedding-3-small"  # Use your Azure deployed embedding model name
         ),
+        client=azure_openai_client
+    ),
+    # Optional: Configure the OpenAI cross encoder with Azure OpenAI
+    cross_encoder=OpenAIRerankerClient(
         client=azure_openai_client
     )
 )

--- a/graphiti_core/cross_encoder/__init__.py
+++ b/graphiti_core/cross_encoder/__init__.py
@@ -1,0 +1,21 @@
+"""
+Copyright 2025, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from .bge_reranker_client import BGERerankerClient
+from .client import CrossEncoderClient
+from .openai_reranker_client import OpenAIRerankerClient
+
+__all__ = ['CrossEncoderClient', 'BGERerankerClient', 'OpenAIRerankerClient']

--- a/graphiti_core/cross_encoder/openai_reranker_client.py
+++ b/graphiti_core/cross_encoder/openai_reranker_client.py
@@ -36,7 +36,11 @@ class BooleanClassifier(BaseModel):
 
 
 class OpenAIRerankerClient(CrossEncoderClient):
-    def __init__(self, config: LLMConfig | None = None):
+    def __init__(
+        self,
+        config: LLMConfig | None = None,
+        client: Any = None,
+    ):
         """
         Initialize the OpenAIClient with the provided configuration, cache setting, and client.
 
@@ -44,13 +48,15 @@ class OpenAIRerankerClient(CrossEncoderClient):
             config (LLMConfig | None): The configuration for the LLM client, including API key, model, base URL, temperature, and max tokens.
             cache (bool): Whether to use caching for responses. Defaults to False.
             client (Any | None): An optional async client instance to use. If not provided, a new AsyncOpenAI client is created.
-
         """
         if config is None:
             config = LLMConfig()
 
         self.config = config
-        self.client = AsyncOpenAI(api_key=config.api_key, base_url=config.base_url)
+        if client is None:
+            self.client = AsyncOpenAI(api_key=config.api_key, base_url=config.base_url)
+        else:
+            self.client = client
 
     async def rank(self, query: str, passages: list[str]) -> list[tuple[str, float]]:
         openai_messages_list: Any = [
@@ -62,7 +68,7 @@ class OpenAIRerankerClient(CrossEncoderClient):
                 Message(
                     role='user',
                     content=f"""
-                           Respond with "True" if PASSAGE is relevant to QUERY and "False" otherwise. 
+                           Respond with "True" if PASSAGE is relevant to QUERY and "False" otherwise.
                            <PASSAGE>
                            {passage}
                            </PASSAGE>

--- a/graphiti_core/cross_encoder/openai_reranker_client.py
+++ b/graphiti_core/cross_encoder/openai_reranker_client.py
@@ -18,7 +18,7 @@ import logging
 from typing import Any
 
 import openai
-from openai import AsyncOpenAI
+from openai import AsyncAzureOpenAI, AsyncOpenAI
 from pydantic import BaseModel
 
 from ..helpers import semaphore_gather
@@ -39,15 +39,17 @@ class OpenAIRerankerClient(CrossEncoderClient):
     def __init__(
         self,
         config: LLMConfig | None = None,
-        client: Any = None,
+        client: AsyncOpenAI | AsyncAzureOpenAI | None = None,
     ):
         """
-        Initialize the OpenAIClient with the provided configuration, cache setting, and client.
+        Initialize the OpenAIRerankerClient with the provided configuration and client.
+
+        This reranker uses the OpenAI API to run a simple boolean classifier prompt concurrently
+        for each passage. Log-probabilities are used to rank the passages.
 
         Args:
             config (LLMConfig | None): The configuration for the LLM client, including API key, model, base URL, temperature, and max tokens.
-            cache (bool): Whether to use caching for responses. Defaults to False.
-            client (Any | None): An optional async client instance to use. If not provided, a new AsyncOpenAI client is created.
+            client (AsyncOpenAI | AsyncAzureOpenAI | None): An optional async client instance to use. If not provided, a new AsyncOpenAI client is created.
         """
         if config is None:
             config = LLMConfig()


### PR DESCRIPTION
This pull request addresses following issue: #254 

Previously only llm client exposed an option to pass custom compatible client.

This resulted in `OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable` when creating an embedder and cross encoder.

This PR introduces option to pass your own instance of client into both `OpeanAIEmbedder` as well as `OpenAIRerankerClient` following the convention from `OpenAIClient`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allow custom client instances in `OpenAIEmbedder` and `OpenAIRerankerClient` to fix API key error.
> 
>   - **Behavior**:
>     - Allow custom client instances in `OpenAIEmbedder` and `OpenAIRerankerClient` constructors.
>     - Fixes `OpenAIError` related to missing API key by allowing client injection.
>   - **Files**:
>     - `openai_reranker_client.py`: Modify `OpenAIRerankerClient.__init__()` to accept `client` parameter.
>     - `openai.py`: Modify `OpenAIEmbedder.__init__()` to accept `client` parameter.
>     - `__init__.py`: Add `OpenAIRerankerClient` to `__all__` for module exports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 0374108e1921b4288684b987e926d7470ca92bf1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->