### PR TITLE
node classification failsafe - remove node labels not part of the custom ontology

### DIFF
--- a/examples/podcast/podcast_runner.py
+++ b/examples/podcast/podcast_runner.py
@@ -65,7 +65,7 @@ class Person(BaseModel):
 async def main():
     setup_logging()
     client = Graphiti(neo4j_uri, neo4j_user, neo4j_password)
-    # await clear_data(client.driver)
+    await clear_data(client.driver)
     await client.build_indices_and_constraints()
     messages = parse_podcast_messages()
 

--- a/examples/podcast/podcast_runner.py
+++ b/examples/podcast/podcast_runner.py
@@ -65,7 +65,7 @@ class Person(BaseModel):
 async def main():
     setup_logging()
     client = Graphiti(neo4j_uri, neo4j_user, neo4j_password)
-    await clear_data(client.driver)
+    # await clear_data(client.driver)
     await client.build_indices_and_constraints()
     messages = parse_podcast_messages()
 

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -189,6 +189,9 @@ async def extract_nodes(
     new_nodes = []
     for name in extracted_node_names:
         entity_type = node_classifications.get(name)
+        if entity_type not in entity_types.keys():
+            entity_type = None
+
         labels = (
             ['Entity']
             if entity_type is None or entity_type == 'None' or entity_type == 'null'

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -189,7 +189,7 @@ async def extract_nodes(
     new_nodes = []
     for name in extracted_node_names:
         entity_type = node_classifications.get(name)
-        if entity_types is not None and entity_type not in entity_types.keys():
+        if entity_types is not None and entity_type not in entity_types:
             entity_type = None
 
         labels = (

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -189,7 +189,7 @@ async def extract_nodes(
     new_nodes = []
     for name in extracted_node_names:
         entity_type = node_classifications.get(name)
-        if entity_type not in entity_types.keys():
+        if entity_types is not None and entity_type not in entity_types.keys():
             entity_type = None
 
         labels = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "graphiti-core"
-version = "0.8.0"
+version = "0.8.1"
 description = "A temporal graph building library"
 authors = [
     "Paul Paliychuk <paul@getzep.com>",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add failsafe in `extract_nodes` to remove node labels not in custom ontology and update version to `0.8.1`.
> 
>   - **Behavior**:
>     - In `extract_nodes` in `node_operations.py`, added a failsafe to remove node labels not in the custom ontology.
>   - **Versioning**:
>     - Updated version in `pyproject.toml` from `0.8.0` to `0.8.1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 6294e407f2c7ad0b6d1aa93093967a75dcb3a501. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->