### PR TITLE
remove BGE reranker client from cross_encoder initializatio nto preve…

### DIFF
--- a/graphiti_core/cross_encoder/__init__.py
+++ b/graphiti_core/cross_encoder/__init__.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from .bge_reranker_client import BGERerankerClient
 from .client import CrossEncoderClient
 from .openai_reranker_client import OpenAIRerankerClient
 

--- a/graphiti_core/cross_encoder/__init__.py
+++ b/graphiti_core/cross_encoder/__init__.py
@@ -18,4 +18,4 @@ from .bge_reranker_client import BGERerankerClient
 from .client import CrossEncoderClient
 from .openai_reranker_client import OpenAIRerankerClient
 
-__all__ = ['CrossEncoderClient', 'BGERerankerClient', 'OpenAIRerankerClient']
+__all__ = ['CrossEncoderClient', 'OpenAIRerankerClient']


### PR DESCRIPTION
…nt loading of sentence transformers
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove `BGERerankerClient` from `graphiti_core/cross_encoder/__init__.py` to prevent unnecessary loading of sentence transformers.
> 
>   - **Imports**:
>     - Remove `BGERerankerClient` import from `graphiti_core/cross_encoder/__init__.py`.
>   - **Exports**:
>     - Remove `BGERerankerClient` from `__all__` in `graphiti_core/cross_encoder/__init__.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for ca162250c452f383a58d11cab425eb4482bc4e7f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->