### PR TITLE
Fix bug of label_propagation

### DIFF
--- a/graphiti_core/utils/maintenance/community_operations.py
+++ b/graphiti_core/utils/maintenance/community_operations.py
@@ -105,9 +105,13 @@ def label_propagation(projection: dict[str, list[Neighbor]]) -> list[list[str]]:
             ]
 
             community_lst.sort(reverse=True)
-            community_candidate = community_lst[0][1] if len(community_lst) > 0 else -1
-
-            new_community = max(community_candidate, curr_community)
+            candidate_rank, community_candidate = (
+                community_lst[0] if community_lst else (0, -1)
+            )
+            if community_candidate != -1 and candidate_rank > 1:
+                new_community = community_candidate
+            else:
+                new_community = max(community_candidate, curr_community)
 
             new_community_map[uuid] = new_community
 


### PR DESCRIPTION
Fix bug of issue #297
I have read the CLA Document and I hereby sign the CLA
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `label_propagation()` in `community_operations.py` by updating community assignment logic to consider candidate rank.
> 
>   - **Bug Fix**:
>     - Fixes bug in `label_propagation()` in `community_operations.py` related to community assignment logic.
>     - Ensures `new_community` is updated only if `community_candidate` is valid and `candidate_rank` > 1.
>   - **Behavior**:
>     - Handles cases where `community_lst` is empty by setting default values `(0, -1)`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 5dba9500fa709719a6179c4fcac93fcce254fb7f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->