### PR TITLE
fix bug with updating node type attributes

### DIFF
--- a/graphiti_core/prompts/summarize_nodes.py
+++ b/graphiti_core/prompts/summarize_nodes.py
@@ -85,8 +85,10 @@ def summarize_context(context: dict[str, Any]) -> list[Message]:
         provided ENTITY. Summaries must be under 500 words.
         
         In addition, extract any values for the provided entity properties based on their descriptions.
-        If the value of the entity property cannot be found in the current context, set the value of the property to None.
-        Do not hallucinate entity property values if they cannot be found in the current context.
+        If the value of the entity property cannot be found in the current context, set the value of the property to the Python value None.
+        
+        Guidelines:
+        1. Do not hallucinate entity property values if they cannot be found in the current context.
         
         <ENTITY>
         {context['node_name']}

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -364,7 +364,11 @@ async def resolve_extracted_node(
     )
 
     extracted_node.summary = node_attributes_response.get('summary', '')
-    extracted_node.attributes.update(node_attributes_response)
+    node_attributes = {
+        key: value if value != 'None' else None for key, value in node_attributes_response.items()
+    }
+
+    extracted_node.attributes.update(node_attributes)
 
     is_duplicate: bool = llm_response.get('is_duplicate', False)
     uuid: str | None = llm_response.get('uuid', None)
@@ -386,11 +390,12 @@ async def resolve_extracted_node(
             node.name = name
             node.summary = summary_response.get('summary', '')
 
-            new_attributes = existing_node.attributes
+            new_attributes = extracted_node.attributes
             existing_attributes = existing_node.attributes
             for attribute_name, attribute_value in existing_attributes.items():
                 if new_attributes.get(attribute_name) is None:
                     new_attributes[attribute_name] = attribute_value
+            node.attributes = new_attributes
 
             uuid_map[extracted_node.uuid] = existing_node.uuid
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "graphiti-core"
-version = "0.8.2"
+version = "0.8.3"
 description = "A temporal graph building library"
 authors = [
     "Paul Paliychuk <paul@getzep.com>",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bug in `resolve_extracted_node()` to correctly handle 'None' values and preserve existing attributes, with version update to `0.8.3`.
> 
>   - **Behavior**:
>     - Fixes bug in `resolve_extracted_node()` in `node_operations.py` where 'None' string values were not converted to Python `None` when updating `extracted_node.attributes`.
>     - Ensures existing attributes are preserved if new attributes are `None` in `resolve_extracted_node()`.
>   - **Misc**:
>     - Increment version in `pyproject.toml` from `0.8.2` to `0.8.3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for f01fa45c7c989cf3ca2384f5cbd574636e95e66b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->