### PR TITLE
remove example usage

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -226,30 +226,6 @@ add_episode(
 )
 ```
 
-## Example Usage
-
-Once the Graphiti MCP server is running and configured with an MCP-compatible client:
-
-```
-User: Add information about a company to the knowledge graph.
-
-Assistant: I'll help you add information about a company to the knowledge graph.
-
-[Assistant uses the add_episode tool to add the information]
-
-User: Now search for information about this company.
-
-Assistant: I'll search the knowledge graph for information about the company.
-
-[Assistant uses the search_facts tool to find relevant facts]
-
-User: Can you show me a summary of entities related to this company?
-
-Assistant: I'll search for node summaries related to the company.
-
-[Assistant uses the search_nodes tool to find relevant entity summaries]
-```
-
 ## Integrating with the Cursor IDE
 
 To integrate the Graphiti MCP Server with the Cursor IDE, follow these steps:


### PR DESCRIPTION
remove example usage
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes 'Example Usage' section from `README.md` in `mcp_server`, which contained a conversational example of using the Graphiti MCP server.
> 
>   - **Documentation**:
>     - Removes 'Example Usage' section from `README.md` in `mcp_server`.
>     - Section contained a conversational example of using the Graphiti MCP server with an MCP-compatible client.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 65634ff4ae2c7918a1fd5027d04441197fdba9a7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->