### PR TITLE
get edges by uuids return empty list instead of errors

### DIFF
--- a/graphiti_core/edges.py
+++ b/graphiti_core/edges.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel, Field
 from typing_extensions import LiteralString
 
 from graphiti_core.embedder import EmbedderClient
-from graphiti_core.errors import EdgeNotFoundError, EdgesNotFoundError, GroupsEdgesNotFoundError
+from graphiti_core.errors import EdgeNotFoundError, GroupsEdgesNotFoundError
 from graphiti_core.helpers import DEFAULT_DATABASE, parse_db_date
 from graphiti_core.models.edges.edge_db_queries import (
     COMMUNITY_EDGE_SAVE,
@@ -139,11 +139,11 @@ class EpisodicEdge(Edge):
 
     @classmethod
     async def get_by_group_ids(
-            cls,
-            driver: AsyncDriver,
-            group_ids: list[str],
-            limit: int | None = None,
-            created_at: datetime | None = None,
+        cls,
+        driver: AsyncDriver,
+        group_ids: list[str],
+        limit: int | None = None,
+        created_at: datetime | None = None,
     ):
         cursor_query: LiteralString = 'AND e.created_at < $created_at' if created_at else ''
         limit_query: LiteralString = 'LIMIT $limit' if limit is not None else ''
@@ -293,11 +293,11 @@ class EntityEdge(Edge):
 
     @classmethod
     async def get_by_group_ids(
-            cls,
-            driver: AsyncDriver,
-            group_ids: list[str],
-            limit: int | None = None,
-            created_at: datetime | None = None,
+        cls,
+        driver: AsyncDriver,
+        group_ids: list[str],
+        limit: int | None = None,
+        created_at: datetime | None = None,
     ):
         cursor_query: LiteralString = 'AND e.created_at < $created_at' if created_at else ''
         limit_query: LiteralString = 'LIMIT $limit' if limit is not None else ''
@@ -426,11 +426,11 @@ class CommunityEdge(Edge):
 
     @classmethod
     async def get_by_group_ids(
-            cls,
-            driver: AsyncDriver,
-            group_ids: list[str],
-            limit: int | None = None,
-            created_at: datetime | None = None,
+        cls,
+        driver: AsyncDriver,
+        group_ids: list[str],
+        limit: int | None = None,
+        created_at: datetime | None = None,
     ):
         cursor_query: LiteralString = 'AND e.created_at < $created_at' if created_at else ''
         limit_query: LiteralString = 'LIMIT $limit' if limit is not None else ''

--- a/graphiti_core/edges.py
+++ b/graphiti_core/edges.py
@@ -139,11 +139,11 @@ class EpisodicEdge(Edge):
 
     @classmethod
     async def get_by_group_ids(
-        cls,
-        driver: AsyncDriver,
-        group_ids: list[str],
-        limit: int | None = None,
-        created_at: datetime | None = None,
+            cls,
+            driver: AsyncDriver,
+            group_ids: list[str],
+            limit: int | None = None,
+            created_at: datetime | None = None,
     ):
         cursor_query: LiteralString = 'AND e.created_at < $created_at' if created_at else ''
         limit_query: LiteralString = 'LIMIT $limit' if limit is not None else ''
@@ -289,17 +289,15 @@ class EntityEdge(Edge):
 
         edges = [get_entity_edge_from_record(record) for record in records]
 
-        if len(edges) == 0:
-            raise EdgesNotFoundError(uuids)
         return edges
 
     @classmethod
     async def get_by_group_ids(
-        cls,
-        driver: AsyncDriver,
-        group_ids: list[str],
-        limit: int | None = None,
-        created_at: datetime | None = None,
+            cls,
+            driver: AsyncDriver,
+            group_ids: list[str],
+            limit: int | None = None,
+            created_at: datetime | None = None,
     ):
         cursor_query: LiteralString = 'AND e.created_at < $created_at' if created_at else ''
         limit_query: LiteralString = 'LIMIT $limit' if limit is not None else ''
@@ -428,11 +426,11 @@ class CommunityEdge(Edge):
 
     @classmethod
     async def get_by_group_ids(
-        cls,
-        driver: AsyncDriver,
-        group_ids: list[str],
-        limit: int | None = None,
-        created_at: datetime | None = None,
+            cls,
+            driver: AsyncDriver,
+            group_ids: list[str],
+            limit: int | None = None,
+            created_at: datetime | None = None,
     ):
         cursor_query: LiteralString = 'AND e.created_at < $created_at' if created_at else ''
         limit_query: LiteralString = 'LIMIT $limit' if limit is not None else ''

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -365,7 +365,8 @@ async def resolve_extracted_node(
 
     extracted_node.summary = node_attributes_response.get('summary', '')
     node_attributes = {
-        key: value if value != 'None' else None for key, value in node_attributes_response.items()
+        key: value if (value != 'None' or key == 'summary') else None
+        for key, value in node_attributes_response.items()
     }
 
     extracted_node.attributes.update(node_attributes)

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -369,6 +369,11 @@ async def resolve_extracted_node(
         for key, value in node_attributes_response.items()
     }
 
+    try:
+        del node_attributes['summary']
+    except KeyError:
+        pass
+
     extracted_node.attributes.update(node_attributes)
 
     is_duplicate: bool = llm_response.get('is_duplicate', False)

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import logging
+from contextlib import suppress
 from time import time
 
 import pydantic
@@ -369,10 +370,8 @@ async def resolve_extracted_node(
         for key, value in node_attributes_response.items()
     }
 
-    try:
+    with suppress(KeyError):
         del node_attributes['summary']
-    except KeyError:
-        pass
 
     extracted_node.attributes.update(node_attributes)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `get_by_uuids` in `edges.py` now returns an empty list instead of raising an error when no edges are found, and `node_operations.py` handles potential `KeyError` when deleting 'summary'.
> 
>   - **Behavior**:
>     - `get_by_uuids` in `graphiti_core/edges.py` now returns an empty list instead of raising `EdgesNotFoundError` when no edges are found.
>   - **Error Handling**:
>     - Removed import of `EdgesNotFoundError` from `graphiti_core/errors.py`.
>     - In `resolve_extracted_node` in `node_operations.py`, added `suppress(KeyError)` to safely delete 'summary' key from `node_attributes`.
>   - **Misc**:
>     - Minor refactoring in `node_operations.py` to improve code clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for e38ecc850e3d93108393befb7d84c715125f79a2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->