### PR TITLE
Add rate limit to avoid OpenAI rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ to enable Neo4j's parallel runtime feature for several of our search queries.
 Note that this feature is not supported for Neo4j Community edition or for smaller AuraDB instances,
 as such this feature is off by default.
 
+`LLM_RATE_LIMIT` is an optional integer variable that can be set to limit the number of LLM requests per minute. This can help avoid rate limiting issues with the inference provider. The default value is 60.
+
 ## Using Graphiti with Azure OpenAI
 
 Graphiti supports Azure OpenAI for both LLM inference and embeddings. To use Azure OpenAI, you'll need to configure both the LLM client and embedder with your Azure OpenAI credentials.


### PR DESCRIPTION
Related to #290

Introduce rate limiting for LLM requests to avoid rate limiting issues with the inference provider.

* **Environment Variable**:
  - Add `LLM_RATE_LIMIT` environment variable in `graphiti_core/helpers.py` to set the maximum number of LLM requests per minute.
* **Rate Limiting Logic**:
  - Update `semaphore_gather` function in `graphiti_core/helpers.py` to include rate limiting logic using the `LLM_RATE_LIMIT` environment variable.
  - Update `AsyncWorker` class in `server/graph_service/routers/ingest.py` to include rate limiting logic using the `LLM_RATE_LIMIT` environment variable.
* **Documentation**:
  - Update `README.md` to include instructions on configuring the `LLM_RATE_LIMIT` environment variable.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduce rate limiting for LLM requests using a new `LLM_RATE_LIMIT` environment variable to prevent inference provider rate limiting issues.
> 
>   - **Environment Variable**:
>     - Add `LLM_RATE_LIMIT` environment variable in `graphiti_core/helpers.py` to set the maximum number of LLM requests per minute.
>   - **Rate Limiting Logic**:
>     - Update `semaphore_gather` function in `graphiti_core/helpers.py` to include rate limiting logic using the `LLM_RATE_LIMIT` environment variable.
>     - Update `AsyncWorker` class in `ingest.py` to include rate limiting logic using the `LLM_RATE_LIMIT` environment variable.
>   - **Documentation**:
>     - Update `README.md` to include instructions on configuring the `LLM_RATE_LIMIT` environment variable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for f72822788df503d0a7c4e835a2c5c99cbcc64be9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->