### PR TITLE
update rate limits

### DIFF
--- a/graphiti_core/llm_client/config.py
+++ b/graphiti_core/llm_client/config.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-DEFAULT_MAX_TOKENS = 2048
+DEFAULT_MAX_TOKENS = 8192
 DEFAULT_TEMPERATURE = 0
 
 

--- a/graphiti_core/utils/maintenance/graph_data_operations.py
+++ b/graphiti_core/utils/maintenance/graph_data_operations.py
@@ -92,14 +92,17 @@ async def build_indices_and_constraints(driver: AsyncDriver, delete_existing: bo
     )
 
 
-async def clear_data(driver: AsyncDriver, group_ids: list[str] | None):
+async def clear_data(driver: AsyncDriver, group_ids: list[str] | None = None):
     async with driver.session() as session:
+
         async def delete_all(tx):
             await tx.run('MATCH (n) DETACH DELETE n')
 
         async def delete_group_ids(tx):
-            await tx.run('MATCH (n:Entity|Episodic|Community) WHERE n.group_id IN $group_ids DETACH DELETE n',
-                         group_ids=group_ids)
+            await tx.run(
+                'MATCH (n:Entity|Episodic|Community) WHERE n.group_id IN $group_ids DETACH DELETE n',
+                group_ids=group_ids,
+            )
 
         if group_ids is None:
             await session.execute_write(delete_all)
@@ -108,10 +111,10 @@ async def clear_data(driver: AsyncDriver, group_ids: list[str] | None):
 
 
 async def retrieve_episodes(
-        driver: AsyncDriver,
-        reference_time: datetime,
-        last_n: int = EPISODE_WINDOW_LEN,
-        group_ids: list[str] | None = None,
+    driver: AsyncDriver,
+    reference_time: datetime,
+    last_n: int = EPISODE_WINDOW_LEN,
+    group_ids: list[str] | None = None,
 ) -> list[EpisodicNode]:
     """
     Retrieve the last n episodic nodes from the graph.

--- a/graphiti_core/utils/maintenance/graph_data_operations.py
+++ b/graphiti_core/utils/maintenance/graph_data_operations.py
@@ -92,20 +92,26 @@ async def build_indices_and_constraints(driver: AsyncDriver, delete_existing: bo
     )
 
 
-async def clear_data(driver: AsyncDriver):
+async def clear_data(driver: AsyncDriver, group_ids: list[str] | None):
     async with driver.session() as session:
-
         async def delete_all(tx):
             await tx.run('MATCH (n) DETACH DELETE n')
 
-        await session.execute_write(delete_all)
+        async def delete_group_ids(tx):
+            await tx.run('MATCH (n:Entity|Episodic|Community) WHERE n.group_id IN $group_ids DETACH DELETE n',
+                         group_ids=group_ids)
+
+        if group_ids is None:
+            await session.execute_write(delete_all)
+        else:
+            await session.execute_write(delete_group_ids)
 
 
 async def retrieve_episodes(
-    driver: AsyncDriver,
-    reference_time: datetime,
-    last_n: int = EPISODE_WINDOW_LEN,
-    group_ids: list[str] | None = None,
+        driver: AsyncDriver,
+        reference_time: datetime,
+        last_n: int = EPISODE_WINDOW_LEN,
+        group_ids: list[str] | None = None,
 ) -> list[EpisodicNode]:
     """
     Retrieve the last n episodic nodes from the graph.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `DEFAULT_MAX_TOKENS` to 8192 and enhance `clear_data()` to support selective deletion by `group_ids`.
> 
>   - **Configuration**:
>     - Update `DEFAULT_MAX_TOKENS` from 2048 to 8192 in `config.py`.
>   - **Data Operations**:
>     - Modify `clear_data()` in `graph_data_operations.py` to accept `group_ids` parameter for selective node deletion.
>     - Add `delete_group_ids` function to handle deletion of nodes with specific `group_ids`.
>     - Retain existing behavior for deleting all nodes when `group_ids` is `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 3ebc24c06a2239b73a28336bce1bf331fde15454. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->