### PR TITLE
Refactor ORDER BY clauses in edges and nodes to use created_at instead of uuid for better chronological sorting

### DIFF
--- a/graphiti_core/edges.py
+++ b/graphiti_core/edges.py
@@ -161,7 +161,7 @@ class EpisodicEdge(Edge):
             n.uuid AS source_node_uuid, 
             m.uuid AS target_node_uuid, 
             e.created_at AS created_at
-        ORDER BY e.uuid DESC 
+        ORDER BY e.created_at DESC 
         """
             + limit_query,
             group_ids=group_ids,
@@ -322,7 +322,7 @@ class EntityEdge(Edge):
             e.expired_at AS expired_at,
             e.valid_at AS valid_at,
             e.invalid_at AS invalid_at
-        ORDER BY e.uuid DESC 
+        ORDER BY e.created_at DESC 
         """
             + limit_query,
             group_ids=group_ids,
@@ -448,7 +448,7 @@ class CommunityEdge(Edge):
             n.uuid AS source_node_uuid, 
             m.uuid AS target_node_uuid, 
             e.created_at AS created_at
-        ORDER BY e.uuid DESC
+        ORDER BY e.created_at DESC
         """
             + limit_query,
             group_ids=group_ids,

--- a/graphiti_core/edges.py
+++ b/graphiti_core/edges.py
@@ -161,7 +161,7 @@ class EpisodicEdge(Edge):
             n.uuid AS source_node_uuid, 
             m.uuid AS target_node_uuid, 
             e.created_at AS created_at
-        ORDER BY e.created_at DESC 
+        ORDER BY e.created_at, e.uuid DESC 
         """
             + limit_query,
             group_ids=group_ids,
@@ -322,7 +322,7 @@ class EntityEdge(Edge):
             e.expired_at AS expired_at,
             e.valid_at AS valid_at,
             e.invalid_at AS invalid_at
-        ORDER BY e.created_at DESC 
+        ORDER BY e.created_at, e.uuid DESC 
         """
             + limit_query,
             group_ids=group_ids,
@@ -448,7 +448,7 @@ class CommunityEdge(Edge):
             n.uuid AS source_node_uuid, 
             m.uuid AS target_node_uuid, 
             e.created_at AS created_at
-        ORDER BY e.created_at DESC
+        ORDER BY e.created_at, e.uuid DESC
         """
             + limit_query,
             group_ids=group_ids,

--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -237,7 +237,7 @@ class EpisodicNode(Node):
             e.source_description AS source_description,
             e.source AS source,
             e.entity_edges AS entity_edges
-        ORDER BY e.uuid DESC
+        ORDER BY e.created_at DESC
         """
             + limit_query,
             group_ids=group_ids,
@@ -368,7 +368,7 @@ class EntityNode(Node):
             n.summary AS summary,
             labels(n) AS labels,
             properties(n) AS attributes
-        ORDER BY n.uuid DESC
+        ORDER BY n.created_at DESC
         """
             + limit_query,
             group_ids=group_ids,
@@ -483,7 +483,7 @@ class CommunityNode(Node):
             n.group_id AS group_id,
             n.created_at AS created_at, 
             n.summary AS summary
-        ORDER BY n.uuid DESC
+        ORDER BY n.created_at DESC
         """
             + limit_query,
             group_ids=group_ids,

--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -237,7 +237,7 @@ class EpisodicNode(Node):
             e.source_description AS source_description,
             e.source AS source,
             e.entity_edges AS entity_edges
-        ORDER BY e.created_at DESC
+        ORDER BY e.created_at, e.uuid DESC
         """
             + limit_query,
             group_ids=group_ids,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor ORDER BY clauses in `edges.py` and `nodes.py` to use `created_at` for chronological sorting in `get_by_group_ids()` functions.
> 
>   - **Behavior**:
>     - Refactor ORDER BY clauses in `get_by_group_ids()` in `edges.py` and `nodes.py` to use `created_at` instead of `uuid` for sorting.
>     - Affects `EpisodicEdge`, `EntityEdge`, `CommunityEdge` in `edges.py` and `EpisodicNode`, `EntityNode`, `CommunityNode` in `nodes.py`.
>   - **Queries**:
>     - `ORDER BY e.created_at, e.uuid DESC` in `edges.py` for `EpisodicEdge`, `EntityEdge`, `CommunityEdge`.
>     - `ORDER BY n.created_at DESC` in `nodes.py` for `EpisodicNode`, `EntityNode`, `CommunityNode`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 3856325d474b0fc628eef4f0386eb27bba0bedb8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->