### PR TITLE
Fix for using non default neo4j database

### DIFF
--- a/graphiti_core/utils/bulk_utils.py
+++ b/graphiti_core/utils/bulk_utils.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel
 from typing_extensions import Any
 
 from graphiti_core.edges import Edge, EntityEdge, EpisodicEdge
-from graphiti_core.helpers import semaphore_gather
+from graphiti_core.helpers import DEFAULT_DATABASE, semaphore_gather
 from graphiti_core.llm_client import LLMClient
 from graphiti_core.models.edges.edge_db_queries import (
     ENTITY_EDGE_SAVE_BULK,
@@ -95,7 +95,7 @@ async def add_nodes_and_edges_bulk(
     entity_nodes: list[EntityNode],
     entity_edges: list[EntityEdge],
 ):
-    async with driver.session() as session:
+    async with driver.session(database=DEFAULT_DATABASE) as session:
         await session.execute_write(
             add_nodes_and_edges_bulk_tx, episodic_nodes, episodic_edges, entity_nodes, entity_edges
         )

--- a/graphiti_core/utils/maintenance/graph_data_operations.py
+++ b/graphiti_core/utils/maintenance/graph_data_operations.py
@@ -42,7 +42,7 @@ async def build_indices_and_constraints(driver: AsyncDriver, delete_existing: bo
                 driver.execute_query(
                     """DROP INDEX $name""",
                     name=name,
-                    _database=DEFAULT_DATABASE,
+                    database_=DEFAULT_DATABASE,
                 )
                 for name in index_names
             ]
@@ -85,7 +85,7 @@ async def build_indices_and_constraints(driver: AsyncDriver, delete_existing: bo
         *[
             driver.execute_query(
                 query,
-                _database=DEFAULT_DATABASE,
+                database_=DEFAULT_DATABASE,
             )
             for query in index_queries
         ]
@@ -93,7 +93,7 @@ async def build_indices_and_constraints(driver: AsyncDriver, delete_existing: bo
 
 
 async def clear_data(driver: AsyncDriver, group_ids: list[str] | None = None):
-    async with driver.session() as session:
+    async with driver.session(database=DEFAULT_DATABASE) as session:
 
         async def delete_all(tx):
             await tx.run('MATCH (n) DETACH DELETE n')
@@ -148,7 +148,7 @@ async def retrieve_episodes(
         reference_time=reference_time,
         num_episodes=last_n,
         group_ids=group_ids,
-        _database=DEFAULT_DATABASE,
+        database_=DEFAULT_DATABASE,
     )
     episodes = [
         EpisodicNode(


### PR DESCRIPTION
Correctly pass database_ too driver session  and database to execute_query to allow setting DEFAULT_DATABASE via .env 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes to ensure non-default Neo4j database usage by passing `DEFAULT_DATABASE` to sessions and queries in `bulk_utils.py` and `graph_data_operations.py`.
> 
>   - **Behavior**:
>     - Pass `DEFAULT_DATABASE` to `driver.session()` in `add_nodes_and_edges_bulk()` in `bulk_utils.py` and `clear_data()` in `graph_data_operations.py`.
>     - Pass `DEFAULT_DATABASE` to `driver.execute_query()` in `build_indices_and_constraints()` and `retrieve_episodes()` in `graph_data_operations.py`.
>   - **Imports**:
>     - Import `DEFAULT_DATABASE` from `graphiti_core.helpers` in `bulk_utils.py`.
>   - **Misc**:
>     - Rename `_database` to `database_` in `build_indices_and_constraints()` and `retrieve_episodes()` in `graph_data_operations.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 3bf84735040cf2d0800fbf6d502ea993bb098586. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->