### PR TITLE
Add set max_tokens attribute in OpenAIClient initialization

### DIFF
--- a/graphiti_core/llm_client/openai_client.py
+++ b/graphiti_core/llm_client/openai_client.py
@@ -87,6 +87,8 @@ class OpenAIClient(LLMClient):
         else:
             self.client = client
 
+        self.max_tokens = max_tokens
+
     async def _generate_response(
         self,
         messages: list[Message],


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `max_tokens` attribute to `OpenAIClient` initialization and use it in `_generate_response()` to limit response tokens.
> 
>   - **Initialization**:
>     - Add `max_tokens` attribute to `OpenAIClient` in `openai_client.py` during initialization.
>   - **Response Generation**:
>     - Use `max_tokens` attribute in `_generate_response()` method to limit token count in responses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for cb0828afba8c39012279c7f1a28959c3bceb02e6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->