### PR TITLE
update to 4.1 models

### DIFF
--- a/examples/langgraph-agent/agent.ipynb
+++ b/examples/langgraph-agent/agent.ipynb
@@ -283,7 +283,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = ChatOpenAI(model='gpt-4o-mini', temperature=0).bind_tools(tools)"
+    "llm = ChatOpenAI(model='gpt-4.1-mini', temperature=0).bind_tools(tools)"
    ]
   },
   {

--- a/graphiti_core/cross_encoder/openai_reranker_client.py
+++ b/graphiti_core/cross_encoder/openai_reranker_client.py
@@ -28,7 +28,7 @@ from .client import CrossEncoderClient
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = 'gpt-4o-mini'
+DEFAULT_MODEL = 'gpt-4.1-nano'
 
 
 class BooleanClassifier(BaseModel):

--- a/graphiti_core/llm_client/config.py
+++ b/graphiti_core/llm_client/config.py
@@ -43,7 +43,7 @@ class LLMConfig:
                                                 This is required for making authorized requests.
 
                 model (str, optional): The specific LLM model to use for generating responses.
-                                                                Defaults to "gpt-4o-mini", which appears to be a custom model name.
+                                                                Defaults to "gpt-4.1-mini", which appears to be a custom model name.
                                                                 Common values might include "gpt-3.5-turbo" or "gpt-4".
 
                 base_url (str, optional): The base URL of the LLM API service.

--- a/graphiti_core/llm_client/openai_client.py
+++ b/graphiti_core/llm_client/openai_client.py
@@ -30,7 +30,7 @@ from .errors import RateLimitError, RefusalError
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = 'gpt-4o-mini'
+DEFAULT_MODEL = 'gpt-4.1-mini'
 
 
 class OpenAIClient(LLMClient):

--- a/graphiti_core/llm_client/openai_generic_client.py
+++ b/graphiti_core/llm_client/openai_generic_client.py
@@ -31,7 +31,7 @@ from .errors import RateLimitError, RefusalError
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = 'gpt-4o-mini'
+DEFAULT_MODEL = 'gpt-4.1-mini'
 
 
 class OpenAIGenericClient(LLMClient):

--- a/mcp_server/.env.example
+++ b/mcp_server/.env.example
@@ -9,7 +9,7 @@ NEO4J_PASSWORD=demodemo
 # OpenAI API Configuration
 # Required for LLM operations
 OPENAI_API_KEY=your_openai_api_key_here
-MODEL_NAME=gpt-4o-mini
+MODEL_NAME=gpt-4.1-mini
 
 # Optional: Only needed for non-standard OpenAI endpoints
 # OPENAI_BASE_URL=https://api.openai.com/v1

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -66,7 +66,7 @@ uv run graphiti_mcp_server.py
 With options:
 
 ```bash
-uv run graphiti_mcp_server.py --model gpt-4o-mini --transport sse
+uv run graphiti_mcp_server.py --model gpt-4.1-mini --transport sse
 ```
 
 Available arguments:
@@ -96,7 +96,7 @@ Before running the Docker Compose setup, you need to configure the environment v
       ```
       # Required for LLM operations
       OPENAI_API_KEY=your_openai_api_key_here
-      MODEL_NAME=gpt-4o-mini
+      MODEL_NAME=gpt-4.1-mini
       # Optional: OPENAI_BASE_URL only needed for non-standard OpenAI endpoints
       # OPENAI_BASE_URL=https://api.openai.com/v1
       ```
@@ -105,7 +105,7 @@ Before running the Docker Compose setup, you need to configure the environment v
 2. **Using environment variables directly**:
     - You can also set the environment variables when running the Docker Compose command:
       ```bash
-      OPENAI_API_KEY=your_key MODEL_NAME=gpt-4o-mini docker compose up
+      OPENAI_API_KEY=your_key MODEL_NAME=gpt-4.1-mini docker compose up
       ```
 
 #### Neo4j Configuration
@@ -162,7 +162,7 @@ To use the Graphiti MCP server with an MCP-compatible client, configure it to co
         "NEO4J_USER": "neo4j",
         "NEO4J_PASSWORD": "demodemo",
         "OPENAI_API_KEY": "${OPENAI_API_KEY}",
-        "MODEL_NAME": "gpt-4o-mini"
+        "MODEL_NAME": "gpt-4.1-mini"
       }
     }
   }
@@ -200,7 +200,7 @@ Or start the server with uv and connect to it:
         "NEO4J_USER": "neo4j",
         "NEO4J_PASSWORD": "demodemo",
         "OPENAI_API_KEY": "${OPENAI_API_KEY}",
-        "MODEL_NAME": "gpt-4o-mini"
+        "MODEL_NAME": "gpt-4.1-mini"
       }
     }
   }

--- a/mcp_server/graphiti_mcp_server.py
+++ b/mcp_server/graphiti_mcp_server.py
@@ -31,7 +31,7 @@ from graphiti_core.utils.maintenance.graph_data_operations import clear_data
 
 load_dotenv()
 
-DEFAULT_LLM_MODEL = 'gpt-4o-mini'
+DEFAULT_LLM_MODEL = 'gpt-4.1-mini'
 
 
 class Requirement(BaseModel):
@@ -344,13 +344,11 @@ For optimal performance, ensure the database is properly configured and accessib
 API keys are provided for any language model operations.
 """
 
-
 # MCP server instance
 mcp = FastMCP(
     'graphiti',
     instructions=GRAPHITI_MCP_INSTRUCTIONS,
 )
-
 
 # Initialize Graphiti client
 graphiti_client: Graphiti | None = None

--- a/mcp_server/mcp_config_stdio_example.json
+++ b/mcp_server/mcp_config_stdio_example.json
@@ -1,21 +1,21 @@
 {
-    "mcpServers": {
-        "graphiti": {
-            "transport": "stdio",
-            "command": "uv",
-            "args": [
-                "run",
-                "/ABSOLUTE/PATH/TO/graphiti_mcp_server.py",
-                "--transport",
-                "stdio"
-            ],
-            "env": {
-                "NEO4J_URI": "bolt://localhost:7687",
-                "NEO4J_USER": "neo4j",
-                "NEO4J_PASSWORD": "demodemo",
-                "OPENAI_API_KEY": "${OPENAI_API_KEY}",
-                "MODEL_NAME": "gpt-4o-mini"
-            }
-        }
+  "mcpServers": {
+    "graphiti": {
+      "transport": "stdio",
+      "command": "uv",
+      "args": [
+        "run",
+        "/ABSOLUTE/PATH/TO/graphiti_mcp_server.py",
+        "--transport",
+        "stdio"
+      ],
+      "env": {
+        "NEO4J_URI": "bolt://localhost:7687",
+        "NEO4J_USER": "neo4j",
+        "NEO4J_PASSWORD": "demodemo",
+        "OPENAI_API_KEY": "${OPENAI_API_KEY}",
+        "MODEL_NAME": "gpt-4.1-mini"
+      }
     }
+  }
 }

--- a/tests/evals/eval_e2e_graph_building.py
+++ b/tests/evals/eval_e2e_graph_building.py
@@ -99,7 +99,7 @@ async def build_baseline_graph(multi_session: list[int], session_length: int):
 
 async def eval_graph(multi_session: list[int], session_length: int, llm_client=None) -> float:
     if llm_client is None:
-        llm_client = OpenAIClient()
+        llm_client = OpenAIClient(config=LLMConfig(model='gpt-4.1-mini'))
     graphiti = Graphiti(NEO4J_URI, NEO4j_USER, NEO4j_PASSWORD, llm_client=llm_client)
     with open('baseline_graph_results.json') as file:
         baseline_results_raw = json.load(file)
@@ -127,7 +127,6 @@ async def eval_graph(multi_session: list[int], session_length: int, llm_client=N
     for user_id in add_episode_results:
         user_count += 1
         user_raw_score = 0
-        print('add_episode_context: ', add_episode_context)
         for baseline_result, add_episode_result, episodes in zip(
             baseline_results[user_id],
             add_episode_results[user_id],


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update default LLM models to 'gpt-4.1-mini' and 'gpt-4.1-nano' across the codebase and documentation.
> 
>   - **Model Updates**:
>     - Change default model from `gpt-4o-mini` to `gpt-4.1-mini` in `openai_client.py`, `openai_generic_client.py`, and `config.py`.
>     - Change default model from `gpt-4o-mini` to `gpt-4.1-nano` in `openai_reranker_client.py`.
>   - **Configuration and Documentation**:
>     - Update `MODEL_NAME` to `gpt-4.1-mini` in `.env.example`, `README.md`, and `mcp_config_stdio_example.json`.
>   - **Tests**:
>     - Update `eval_e2e_graph_building.py` to use `gpt-4.1-mini` for LLM client initialization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 86ed26c69c9905ee27a46847e91f55e555f65a09. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->