### PR TITLE
add get_by_entity_node_uuid

### DIFF
--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -267,7 +267,7 @@ class EpisodicNode(Node):
             e.source AS source,
             e.entity_edges AS entity_edges
         """,
-            uuids=entity_node_uuid,
+            entity_node_uuid=entity_node_uuid,
             database_=DEFAULT_DATABASE,
             routing_='r',
         )

--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -251,6 +251,31 @@ class EpisodicNode(Node):
 
         return episodes
 
+    @classmethod
+    async def get_by_entity_node_uuid(cls, driver: AsyncDriver, entity_node_uuid: str):
+        records, _, _ = await driver.execute_query(
+            """
+        MATCH (e:Episodic)-[r:MENTIONS]->(n:Entity {uuid: $entity_node_uuid})
+            RETURN DISTINCT
+            e.content AS content,
+            e.created_at AS created_at,
+            e.valid_at AS valid_at,
+            e.uuid AS uuid,
+            e.name AS name,
+            e.group_id AS group_id,
+            e.source_description AS source_description,
+            e.source AS source,
+            e.entity_edges AS entity_edges
+        """,
+            uuids=entity_node_uuid,
+            database_=DEFAULT_DATABASE,
+            routing_='r',
+        )
+
+        episodes = [get_episodic_node_from_record(record) for record in records]
+
+        return episodes
+
 
 class EntityNode(Node):
     name_embedding: list[float] | None = Field(default=None, description='embedding of the name')


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `get_by_entity_node_uuid()` to `EpisodicNode` for retrieving episodes by entity node UUID in `nodes.py`.
> 
>   - **Behavior**:
>     - Adds `get_by_entity_node_uuid()` to `EpisodicNode` in `nodes.py` to retrieve episodes mentioning a specific entity node by UUID.
>     - Executes a Neo4j query matching `Episodic` nodes with `Entity` nodes via `MENTIONS` relationship.
>   - **Misc**:
>     - No changes to existing methods or classes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 3e7dca33c5b5becd8856fccc6a09438f96a08364. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->