### PR TITLE
docs: add note on LLM service compatibility in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ Requirements:
 - Neo4j 5.26 or higher (serves as the embeddings storage backend)
 - OpenAI API key (for LLM inference and embedding)
 
+> [!IMPORTANT]
+> Graphiti works best with LLM services that support Structured Output (such as OpenAI and Gemini).
+> Using other services may result in incorrect output schemas and ingestion failures. This is particularly
+> problematic when using smaller models.
+
 Optional:
 
 - Google Gemini, Anthropic, or Groq API key (for alternative LLM providers)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a note in `README.md` about Graphiti's compatibility with LLM services supporting Structured Output.
> 
>   - **Documentation**:
>     - Adds an important note in `README.md` about Graphiti's compatibility with LLM services that support Structured Output, such as OpenAI and Gemini.
>     - Warns about potential issues with incorrect output schemas and ingestion failures when using smaller models or unsupported services.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 89f4ba3779b7e19c9c0e7a05186e9a6faa95a7aa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->