### PR TITLE
make node record loading more robust

### DIFF
--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -550,12 +550,12 @@ def get_entity_node_from_record(record: Any) -> EntityNode:
         attributes=record['attributes'],
     )
 
-    del entity_node.attributes['uuid']
-    del entity_node.attributes['name']
-    del entity_node.attributes['group_id']
-    del entity_node.attributes['name_embedding']
-    del entity_node.attributes['summary']
-    del entity_node.attributes['created_at']
+    entity_node.attributes.pop('uuid', None)
+    entity_node.attributes.pop('name', None)
+    entity_node.attributes.pop('group_id', None)
+    entity_node.attributes.pop('name_embedding', None)
+    entity_node.attributes.pop('summary', None)
+    entity_node.attributes.pop('created_at', None)
 
     return entity_node
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "graphiti-core"
 description = "A temporal graph building library"
-version = "0.10.0"
+version = "0.10.1"
 authors = [
     { "name" = "Paul Paliychuk", "email" = "paul@getzep.com" },
     { "name" = "Preston Rasmussen", "email" = "preston@getzep.com" },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Use `pop` instead of `del` to remove attributes in `get_entity_node_from_record` in `nodes.py` to prevent KeyErrors, and update version to `0.10.1`.
> 
>   - **Behavior**:
>     - In `get_entity_node_from_record` in `nodes.py`, replace `del` with `pop` for removing attributes (`uuid`, `name`, `group_id`, `name_embedding`, `summary`, `created_at`) to prevent KeyErrors.
>   - **Versioning**:
>     - Update version in `pyproject.toml` from `0.10.0` to `0.10.1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for a5c2a672ee9b5b87b9bafdf68a2572c60ca0660f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->