### PR TITLE
Fix edge deletion check to handle empty episodes list

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -797,7 +797,7 @@ class Graphiti:
         # We should only delete edges created by the episode
         edges_to_delete: list[EntityEdge] = []
         for edge in edges:
-            if edge.episodes[0] == episode.uuid:
+            if edge.episodes and edge.episodes[0] == episode.uuid:
                 edges_to_delete.append(edge)
 
         # Find nodes mentioned by the episode


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes edge deletion logic in `remove_episode` in `graphiti.py` to handle empty `episodes` list.
> 
>   - **Behavior**:
>     - Fixes edge deletion logic in `remove_episode` in `graphiti.py` to handle empty `episodes` list.
>     - Ensures edges are only deleted if `episodes` list is not empty and the first element matches `episode.uuid`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for d94525f07383d43b903d649524e6432e3adf5083. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->