### PR TITLE
Use self.max_tokens when max_token isnt specified

### DIFF
--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -262,7 +262,7 @@ class AnthropicClient(LLMClient):
         self,
         messages: list[Message],
         response_model: type[BaseModel] | None = None,
-        max_tokens: int = DEFAULT_MAX_TOKENS,
+        max_tokens: int | None = None,
     ) -> dict[str, typing.Any]:
         """
         Generate a response from the LLM.
@@ -280,6 +280,9 @@ class AnthropicClient(LLMClient):
             RefusalError: If the LLM refuses to respond.
             Exception: If an error occurs during the generation process.
         """
+        if max_tokens is None:
+            max_tokens = self.max_tokens
+
         retry_count = 0
         max_retries = 2
         last_error: Exception | None = None

--- a/graphiti_core/llm_client/client.py
+++ b/graphiti_core/llm_client/client.py
@@ -127,8 +127,11 @@ class LLMClient(ABC):
         self,
         messages: list[Message],
         response_model: type[BaseModel] | None = None,
-        max_tokens: int = DEFAULT_MAX_TOKENS,
+        max_tokens: int | None = None,
     ) -> dict[str, typing.Any]:
+        if max_tokens is None:
+            max_tokens = self.max_tokens
+
         if response_model is not None:
             serialized_model = json.dumps(response_model.model_json_schema())
             messages[

--- a/graphiti_core/llm_client/gemini_client.py
+++ b/graphiti_core/llm_client/gemini_client.py
@@ -166,7 +166,7 @@ class GeminiClient(LLMClient):
         self,
         messages: list[Message],
         response_model: type[BaseModel] | None = None,
-        max_tokens: int = DEFAULT_MAX_TOKENS,
+        max_tokens: int | None = None,
     ) -> dict[str, typing.Any]:
         """
         Generate a response from the Gemini language model.
@@ -180,6 +180,9 @@ class GeminiClient(LLMClient):
         Returns:
             dict[str, typing.Any]: The response from the language model.
         """
+        if max_tokens is None:
+            max_tokens = self.max_tokens
+
         # Call the internal _generate_response method
         return await self._generate_response(
             messages=messages, response_model=response_model, max_tokens=max_tokens

--- a/graphiti_core/llm_client/openai_client.py
+++ b/graphiti_core/llm_client/openai_client.py
@@ -131,8 +131,11 @@ class OpenAIClient(LLMClient):
         self,
         messages: list[Message],
         response_model: type[BaseModel] | None = None,
-        max_tokens: int = DEFAULT_MAX_TOKENS,
+        max_tokens: int | None = None,
     ) -> dict[str, typing.Any]:
+        if max_tokens is None:
+            max_tokens = self.max_tokens
+
         retry_count = 0
         last_error = None
 

--- a/graphiti_core/llm_client/openai_generic_client.py
+++ b/graphiti_core/llm_client/openai_generic_client.py
@@ -117,8 +117,11 @@ class OpenAIGenericClient(LLMClient):
         self,
         messages: list[Message],
         response_model: type[BaseModel] | None = None,
-        max_tokens: int = DEFAULT_MAX_TOKENS,
+        max_tokens: int | None = None,
     ) -> dict[str, typing.Any]:
+        if max_tokens is None:
+            max_tokens = self.max_tokens
+
         retry_count = 0
         last_error = None
 


### PR DESCRIPTION
## Why

Even max_tokens is specified in llm_client, it isn't referred due to generate_response method is ignoring it.

So, user will face the following error even max_tokens is specified in llmclient.

```
INFO:httpx:HTTP Request: POST https://openrouter.ai/api/v1/chat/completions "HTTP/1.1 200 OK"
INFO:httpx:HTTP Request: POST https://openrouter.ai/api/v1/chat/completions "HTTP/1.1 200 OK"
.....
.....
WARNING:graphiti_core.llm_client.openai_client:Retrying after application error (attempt 2/2): Output length exceeded max tokens 8192: Could not parse response content as the length limit was reached - CompletionUsage(completion_tokens=8192, prompt_tokens=15138, total_tokens=23330, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=None, audio_tokens=None, reasoning_tokens=0, rejected_prediction_tokens=None), prompt_tokens_details=PromptTokensDetails(audio_tokens=None, cached_tokens=14976))
```

## What

* remove default value in method of `generate_response` since default value is already set in client's field.
* add reference to max_tokens in generate_response


## Note

I think this will improve capability of graphiti to extract complex facts.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `generate_response` methods use `self.max_tokens` if `max_tokens` is not specified across multiple client implementations.
> 
>   - **Behavior**:
>     - `generate_response` methods in `anthropic_client.py`, `client.py`, `gemini_client.py`, `openai_client.py`, and `openai_generic_client.py` now use `self.max_tokens` if `max_tokens` is not specified.
>   - **Code Changes**:
>     - Removed default `max_tokens` value in `generate_response` method signatures in the mentioned files.
>     - Added logic to set `max_tokens` to `self.max_tokens` if it is `None` in the `generate_response` methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 3a7e630ed6bbe8e5a2c74984c3497c54caf3d0ce. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->