### PR TITLE
remove redundant endpoint

### DIFF
--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -265,31 +265,6 @@ class EpisodicNode(Node):
 
         return episodes
 
-    @classmethod
-    async def get_by_entity_node_uuid(cls, driver: AsyncDriver, entity_node_uuid: str):
-        records, _, _ = await driver.execute_query(
-            """
-        MATCH (e:Episodic)-[r:MENTIONS]->(n:Entity {uuid: $entity_node_uuid})
-            RETURN DISTINCT
-            e.content AS content,
-            e.created_at AS created_at,
-            e.valid_at AS valid_at,
-            e.uuid AS uuid,
-            e.name AS name,
-            e.group_id AS group_id,
-            e.source_description AS source_description,
-            e.source AS source,
-            e.entity_edges AS entity_edges
-        """,
-            entity_node_uuid=entity_node_uuid,
-            database_=DEFAULT_DATABASE,
-            routing_='r',
-        )
-
-        episodes = [get_episodic_node_from_record(record) for record in records]
-
-        return episodes
-
 
 class EntityNode(Node):
     name_embedding: list[float] | None = Field(default=None, description='embedding of the name')
@@ -337,8 +312,8 @@ class EntityNode(Node):
     async def get_by_uuid(cls, driver: AsyncDriver, uuid: str):
         query = (
             """
-                MATCH (n:Entity {uuid: $uuid})
-                """
+                    MATCH (n:Entity {uuid: $uuid})
+                    """
             + ENTITY_NODE_RETURN
         )
         records, _, _ = await driver.execute_query(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove redundant `get_by_entity_node_uuid` method from `EpisodicNode` class in `nodes.py`.
> 
>   - **Removal**:
>     - Removed `get_by_entity_node_uuid` method from `EpisodicNode` class in `nodes.py`. This method fetched episodic nodes by entity node UUID but was redundant.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for c63e816a026fa2ce1d2686358bbe1a5132712943. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->