### PR TITLE
Revert episodes

### DIFF
--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -54,18 +54,6 @@ DEFAULT_MMR_LAMBDA = 0.5
 MAX_SEARCH_DEPTH = 3
 MAX_QUERY_LENGTH = 32
 
-SEARCH_ENTITY_NODE_RETURN: LiteralString = """
-        RETURN
-            n.uuid As uuid, 
-            n.name AS name,
-            n.name_embedding AS name_embedding,
-            n.group_id AS group_id,
-            n.created_at AS created_at, 
-            n.summary AS summary,
-            labels(n) AS labels,
-            properties(n) AS attributes
-            """
-
 
 def fulltext_query(query: str, group_ids: list[str] | None = None):
     group_ids_filter_list = (
@@ -243,8 +231,8 @@ async def edge_similarity_search(
 
     query: LiteralString = (
         """
-                                                                                                                                                MATCH (n:Entity)-[r:RELATES_TO]->(m:Entity)
-                                                                                                                                                """
+                                                                                                                                                    MATCH (n:Entity)-[r:RELATES_TO]->(m:Entity)
+                                                                                                                                                    """
         + group_filter_query
         + filter_query
         + """\nWITH DISTINCT r, vector.similarity.cosine(r.fact_embedding, $search_vector) AS score
@@ -356,12 +344,12 @@ async def node_fulltext_search(
 
     query = (
         """
-                    CALL db.index.fulltext.queryNodes("node_name_and_summary", $query, {limit: $limit}) 
-                    YIELD node AS n, score
-                    WHERE n:Entity
-                    """
+                        CALL db.index.fulltext.queryNodes("node_name_and_summary", $query, {limit: $limit}) 
+                        YIELD node AS n, score
+                        WHERE n:Entity
+                        """
         + filter_query
-        + SEARCH_ENTITY_NODE_RETURN
+        + ENTITY_NODE_RETURN
         + """
         ORDER BY score DESC
         """
@@ -414,7 +402,7 @@ async def node_similarity_search(
         + """
             WITH n, vector.similarity.cosine(n.name_embedding, $search_vector) AS score
             WHERE score > $min_score"""
-        + SEARCH_ENTITY_NODE_RETURN
+        + ENTITY_NODE_RETURN
         + """
         ORDER BY score DESC
         LIMIT $limit

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -55,8 +55,6 @@ MAX_SEARCH_DEPTH = 3
 MAX_QUERY_LENGTH = 32
 
 SEARCH_ENTITY_NODE_RETURN: LiteralString = """
-        OPTIONAL MATCH (e:Episodic)-[r:MENTIONS]->(n)
-        WITH n, score, collect(e.uuid) AS episodes
         RETURN
             n.uuid As uuid, 
             n.name AS name,
@@ -65,8 +63,8 @@ SEARCH_ENTITY_NODE_RETURN: LiteralString = """
             n.created_at AS created_at, 
             n.summary AS summary,
             labels(n) AS labels,
-            properties(n) AS attributes,
-            episodes"""
+            properties(n) AS attributes
+            """
 
 
 def fulltext_query(query: str, group_ids: list[str] | None = None):
@@ -245,8 +243,8 @@ async def edge_similarity_search(
 
     query: LiteralString = (
         """
-                                                                                                                                            MATCH (n:Entity)-[r:RELATES_TO]->(m:Entity)
-                                                                                                                                            """
+                                                                                                                                                MATCH (n:Entity)-[r:RELATES_TO]->(m:Entity)
+                                                                                                                                                """
         + group_filter_query
         + filter_query
         + """\nWITH DISTINCT r, vector.similarity.cosine(r.fact_embedding, $search_vector) AS score
@@ -358,10 +356,10 @@ async def node_fulltext_search(
 
     query = (
         """
-                CALL db.index.fulltext.queryNodes("node_name_and_summary", $query, {limit: $limit}) 
-                YIELD node AS n, score
-                WHERE n:Entity
-                """
+                    CALL db.index.fulltext.queryNodes("node_name_and_summary", $query, {limit: $limit}) 
+                    YIELD node AS n, score
+                    WHERE n:Entity
+                    """
         + filter_query
         + SEARCH_ENTITY_NODE_RETURN
         + """

--- a/graphiti_core/utils/maintenance/graph_data_operations.py
+++ b/graphiti_core/utils/maintenance/graph_data_operations.py
@@ -132,10 +132,14 @@ async def retrieve_episodes(
     Returns:
         list[EpisodicNode]: A list of EpisodicNode objects representing the retrieved episodes.
     """
-    result = await driver.execute_query(
+    group_id_filter: LiteralString = 'AND e.group_id IN $group_ids' if len(group_ids) > 0 else ''
+
+    query: LiteralString = (
         """
-        MATCH (e:Episodic) WHERE e.valid_at <= $reference_time 
-        AND ($group_ids IS NULL) OR e.group_id in $group_ids
+        MATCH (e:Episodic) WHERE e.valid_at <= $reference_time
+        """
+        + group_id_filter
+        + """
         RETURN e.content AS content,
             e.created_at AS created_at,
             e.valid_at AS valid_at,
@@ -144,9 +148,13 @@ async def retrieve_episodes(
             e.name AS name,
             e.source_description AS source_description,
             e.source AS source
-        ORDER BY e.created_at DESC
+        ORDER BY e.valid_at DESC
         LIMIT $num_episodes
-        """,
+        """
+    )
+
+    result = await driver.execute_query(
+        query,
         reference_time=reference_time,
         num_episodes=last_n,
         group_ids=group_ids,

--- a/graphiti_core/utils/maintenance/graph_data_operations.py
+++ b/graphiti_core/utils/maintenance/graph_data_operations.py
@@ -132,7 +132,7 @@ async def retrieve_episodes(
     Returns:
         list[EpisodicNode]: A list of EpisodicNode objects representing the retrieved episodes.
     """
-    group_id_filter: LiteralString = 'AND e.group_id IN $group_ids' if len(group_ids) > 0 else ''
+    group_id_filter: LiteralString = 'AND e.group_id IN $group_ids' if group_ids and len(group_ids) > 0 else ''
 
     query: LiteralString = (
         """


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Revert episode-related logic in `nodes.py`, `search_utils.py`, and `graph_data_operations.py`, and add method to retrieve episodes by entity node UUID.
> 
>   - **Behavior**:
>     - Remove episode-related logic from `ENTITY_NODE_RETURN` in `nodes.py` and `SEARCH_ENTITY_NODE_RETURN` in `search_utils.py`.
>     - Add `get_by_entity_node_uuid()` method to `EpisodicNode` in `nodes.py` to retrieve episodes by entity node UUID.
>   - **Models**:
>     - Remove `episodes` field from `EntityNode` in `nodes.py`.
>   - **Queries**:
>     - Adjust queries in `retrieve_episodes()` in `graph_data_operations.py` to remove group ID filter logic.
>     - Update `node_fulltext_search()` and `node_similarity_search()` in `search_utils.py` to use `ENTITY_NODE_RETURN`.
>   - **Misc**:
>     - Reorder query components for readability in `nodes.py` and `search_utils.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for c9cdfca8b945b9103baf033c5a4875ea10c976f6. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->