### PR TITLE
feat: add smithery.yaml configuration for MCP server

### DIFF
--- a/mcp_server/smithery.yaml
+++ b/mcp_server/smithery.yaml
@@ -1,0 +1,27 @@
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required:
+      - openaiApiKey
+      - groupId
+    properties:
+      openaiApiKey:
+        type: string
+        description: Your OpenAI API key.
+      groupId:
+        type: string
+        description: The group ID to namespace the graph. An arbitrary string.
+  commandFunction: |
+    (config) => ({ 
+      command: 'uv', 
+      args: [
+        'run', 
+        'graphiti_mcp_server.py',
+        '--group-id',
+        config.groupId
+      ],
+      env: {
+        OPENAI_API_KEY: config.openaiApiKey
+      }
+    }) 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `smithery.yaml` configuration to `mcp_server` for starting the server with specific parameters and environment variables.
> 
>   - **Configuration**:
>     - Adds `smithery.yaml` to `mcp_server`.
>     - Defines `startCommand` with `type: stdio`.
>     - Specifies `configSchema` requiring `openaiApiKey` and `groupId`.
>     - `commandFunction` runs `graphiti_mcp_server.py` with `--group-id` argument and sets `OPENAI_API_KEY` environment variable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 26a19eeeb3ac0bc2322ddbce02b73410c669d2b3. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->