### PR TITLE
Update dedupe prompt

### DIFF
--- a/graphiti_core/prompts/dedupe_nodes.py
+++ b/graphiti_core/prompts/dedupe_nodes.py
@@ -44,7 +44,7 @@ def node(context: dict[str, Any]) -> list[Message]:
     return [
         Message(
             role='system',
-            content='You are a helpful assistant that de-duplicates entities from entity lists.',
+            content='You are a helpful assistant that determines whether or not a NEW ENTITY is a duplicate of any EXISTING ENTITIES.',
         ),
         Message(
             role='user',
@@ -69,14 +69,21 @@ def node(context: dict[str, Any]) -> list[Message]:
         Given the above EXISTING ENTITIES and their attributes, MESSAGE, and PREVIOUS MESSAGES; Determine if the NEW ENTITY extracted from the conversation
         is a duplicate entity of one of the EXISTING ENTITIES.
         
-        The ENTITY TYPE DESCRIPTION gives more insight into what the entity type means for the NEW ENTITY.
+        Entities should only be considered duplicates if they refer to the *same real-world object or concept*.
+
+        Do NOT mark entities as duplicates if:
+        - They are related but distinct.
+        - They have similar names or purposes but refer to separate instances or concepts.
 
         Task:
         If the NEW ENTITY represents a duplicate entity of any entity in EXISTING ENTITIES, set duplicate_entity_id to the
-        id of the EXISTING ENTITY that is the duplicate. If the NEW ENTITY is not a duplicate of any of the EXISTING ENTITIES,
+        id of the EXISTING ENTITY that is the duplicate. 
+        
+        If the NEW ENTITY is not a duplicate of any of the EXISTING ENTITIES,
         duplicate_entity_id should be set to -1.
         
-        Also return the most complete name for the entity.
+        Also return the name that best describes the NEW ENTITY (whether it is the name of the NEW ENTITY, a node it
+        is a duplicate of, or a combination of the two).
         """,
         ),
     ]

--- a/graphiti_core/prompts/extract_nodes.py
+++ b/graphiti_core/prompts/extract_nodes.py
@@ -26,7 +26,7 @@ class ExtractedEntity(BaseModel):
     name: str = Field(..., description='Name of the extracted entity')
     entity_type_id: int = Field(
         description='ID of the classified entity type. '
-        'Must be one of the provided entity_type_id integers.',
+                    'Must be one of the provided entity_type_id integers.',
     )
 
 
@@ -256,7 +256,7 @@ def extract_attributes(context: dict[str, Any]) -> list[Message]:
         1. Do not hallucinate entity property values if they cannot be found in the current context.
         2. Only use the provided MESSAGES and ENTITY to set attribute values.
         3. The summary attribute represents a summary of the ENTITY, and should be updated with new information about the Entity from the MESSAGES. 
-            Summaries must be no longer than 500 words.
+            Summaries must be no longer than 250 words.
         
         <ENTITY>
         {context['node']}

--- a/graphiti_core/prompts/extract_nodes.py
+++ b/graphiti_core/prompts/extract_nodes.py
@@ -26,7 +26,7 @@ class ExtractedEntity(BaseModel):
     name: str = Field(..., description='Name of the extracted entity')
     entity_type_id: int = Field(
         description='ID of the classified entity type. '
-                    'Must be one of the provided entity_type_id integers.',
+        'Must be one of the provided entity_type_id integers.',
     )
 
 

--- a/graphiti_core/prompts/summarize_nodes.py
+++ b/graphiti_core/prompts/summarize_nodes.py
@@ -25,7 +25,7 @@ from .models import Message, PromptFunction, PromptVersion
 class Summary(BaseModel):
     summary: str = Field(
         ...,
-        description='Summary containing the important information about the entity. Under 500 words',
+        description='Summary containing the important information about the entity. Under 250 words',
     )
 
 
@@ -56,7 +56,7 @@ def summarize_pair(context: dict[str, Any]) -> list[Message]:
             content=f"""
         Synthesize the information from the following two summaries into a single succinct summary.
         
-        Summaries must be under 500 words.
+        Summaries must be under 250 words.
 
         Summaries:
         {json.dumps(context['node_summaries'], indent=2)}
@@ -82,7 +82,7 @@ def summarize_context(context: dict[str, Any]) -> list[Message]:
         
         Given the above MESSAGES and the following ENTITY name, create a summary for the ENTITY. Your summary must only use
         information from the provided MESSAGES. Your summary should also only contain information relevant to the
-        provided ENTITY. Summaries must be under 500 words.
+        provided ENTITY. Summaries must be under 250 words.
         
         In addition, extract any values for the provided entity properties based on their descriptions.
         If the value of the entity property cannot be found in the current context, set the value of the property to the Python value None.
@@ -117,7 +117,7 @@ def summary_description(context: dict[str, Any]) -> list[Message]:
             role='user',
             content=f"""
         Create a short one sentence description of the summary that explains what kind of information is summarized.
-        Summaries must be under 500 words.
+        Summaries must be under 250 words.
 
         Summary:
         {json.dumps(context['summary'], indent=2)}

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -290,7 +290,6 @@ async def resolve_extracted_node(
                 'id': i,
                 'name': node.name,
                 'entity_types': node.labels,
-                'summary': node.summary,
             },
             **node.attributes,
         }
@@ -436,10 +435,7 @@ async def dedupe_node_list(
         node_map[node.uuid] = node
 
     # Prepare context for LLM
-    nodes_context = [
-        {'uuid': node.uuid, 'name': node.name, 'summary': node.summary, **node.attributes}
-        for node in nodes
-    ]
+    nodes_context = [{'uuid': node.uuid, 'name': node.name, **node.attributes} for node in nodes]
 
     context = {
         'nodes': nodes_context,

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -44,10 +44,10 @@ logger = logging.getLogger(__name__)
 
 
 async def extract_nodes_reflexion(
-    llm_client: LLMClient,
-    episode: EpisodicNode,
-    previous_episodes: list[EpisodicNode],
-    node_names: list[str],
+        llm_client: LLMClient,
+        episode: EpisodicNode,
+        previous_episodes: list[EpisodicNode],
+        node_names: list[str],
 ) -> list[str]:
     # Prepare context for LLM
     context = {
@@ -65,10 +65,10 @@ async def extract_nodes_reflexion(
 
 
 async def extract_nodes(
-    clients: GraphitiClients,
-    episode: EpisodicNode,
-    previous_episodes: list[EpisodicNode],
-    entity_types: dict[str, BaseModel] | None = None,
+        clients: GraphitiClients,
+        episode: EpisodicNode,
+        previous_episodes: list[EpisodicNode],
+        entity_types: dict[str, BaseModel] | None = None,
 ) -> list[EntityNode]:
     start = time()
     llm_client = clients.llm_client
@@ -169,9 +169,9 @@ async def extract_nodes(
 
 
 async def dedupe_extracted_nodes(
-    llm_client: LLMClient,
-    extracted_nodes: list[EntityNode],
-    existing_nodes: list[EntityNode],
+        llm_client: LLMClient,
+        extracted_nodes: list[EntityNode],
+        existing_nodes: list[EntityNode],
 ) -> tuple[list[EntityNode], dict[str, str]]:
     start = time()
 
@@ -219,11 +219,11 @@ async def dedupe_extracted_nodes(
 
 
 async def resolve_extracted_nodes(
-    clients: GraphitiClients,
-    extracted_nodes: list[EntityNode],
-    episode: EpisodicNode | None = None,
-    previous_episodes: list[EpisodicNode] | None = None,
-    entity_types: dict[str, BaseModel] | None = None,
+        clients: GraphitiClients,
+        extracted_nodes: list[EntityNode],
+        episode: EpisodicNode | None = None,
+        previous_episodes: list[EpisodicNode] | None = None,
+        entity_types: dict[str, BaseModel] | None = None,
 ) -> tuple[list[EntityNode], dict[str, str]]:
     llm_client = clients.llm_client
 
@@ -272,12 +272,12 @@ async def resolve_extracted_nodes(
 
 
 async def resolve_extracted_node(
-    llm_client: LLMClient,
-    extracted_node: EntityNode,
-    existing_nodes: list[EntityNode],
-    episode: EpisodicNode | None = None,
-    previous_episodes: list[EpisodicNode] | None = None,
-    entity_type: BaseModel | None = None,
+        llm_client: LLMClient,
+        extracted_node: EntityNode,
+        existing_nodes: list[EntityNode],
+        episode: EpisodicNode | None = None,
+        previous_episodes: list[EpisodicNode] | None = None,
+        entity_type: BaseModel | None = None,
 ) -> EntityNode:
     start = time()
     if len(existing_nodes) == 0:
@@ -336,11 +336,11 @@ async def resolve_extracted_node(
 
 
 async def extract_attributes_from_nodes(
-    clients: GraphitiClients,
-    nodes: list[EntityNode],
-    episode: EpisodicNode | None = None,
-    previous_episodes: list[EpisodicNode] | None = None,
-    entity_types: dict[str, BaseModel] | None = None,
+        clients: GraphitiClients,
+        nodes: list[EntityNode],
+        episode: EpisodicNode | None = None,
+        previous_episodes: list[EpisodicNode] | None = None,
+        entity_types: dict[str, BaseModel] | None = None,
 ) -> list[EntityNode]:
     llm_client = clients.llm_client
     embedder = clients.embedder
@@ -366,11 +366,11 @@ async def extract_attributes_from_nodes(
 
 
 async def extract_attributes_from_node(
-    llm_client: LLMClient,
-    node: EntityNode,
-    episode: EpisodicNode | None = None,
-    previous_episodes: list[EpisodicNode] | None = None,
-    entity_type: BaseModel | None = None,
+        llm_client: LLMClient,
+        node: EntityNode,
+        episode: EpisodicNode | None = None,
+        previous_episodes: list[EpisodicNode] | None = None,
+        entity_type: BaseModel | None = None,
 ) -> EntityNode:
     node_context: dict[str, Any] = {
         'name': node.name,
@@ -383,7 +383,7 @@ async def extract_attributes_from_node(
         'summary': (
             str,
             Field(
-                description='Summary containing the important information about the entity. Under 500 words',
+                description='Summary containing the important information about the entity. Under 250 words',
             ),
         )
     }
@@ -424,8 +424,8 @@ async def extract_attributes_from_node(
 
 
 async def dedupe_node_list(
-    llm_client: LLMClient,
-    nodes: list[EntityNode],
+        llm_client: LLMClient,
+        nodes: list[EntityNode],
 ) -> tuple[list[EntityNode], dict[str, str]]:
     start = time()
 

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -44,10 +44,10 @@ logger = logging.getLogger(__name__)
 
 
 async def extract_nodes_reflexion(
-        llm_client: LLMClient,
-        episode: EpisodicNode,
-        previous_episodes: list[EpisodicNode],
-        node_names: list[str],
+    llm_client: LLMClient,
+    episode: EpisodicNode,
+    previous_episodes: list[EpisodicNode],
+    node_names: list[str],
 ) -> list[str]:
     # Prepare context for LLM
     context = {
@@ -65,10 +65,10 @@ async def extract_nodes_reflexion(
 
 
 async def extract_nodes(
-        clients: GraphitiClients,
-        episode: EpisodicNode,
-        previous_episodes: list[EpisodicNode],
-        entity_types: dict[str, BaseModel] | None = None,
+    clients: GraphitiClients,
+    episode: EpisodicNode,
+    previous_episodes: list[EpisodicNode],
+    entity_types: dict[str, BaseModel] | None = None,
 ) -> list[EntityNode]:
     start = time()
     llm_client = clients.llm_client
@@ -169,9 +169,9 @@ async def extract_nodes(
 
 
 async def dedupe_extracted_nodes(
-        llm_client: LLMClient,
-        extracted_nodes: list[EntityNode],
-        existing_nodes: list[EntityNode],
+    llm_client: LLMClient,
+    extracted_nodes: list[EntityNode],
+    existing_nodes: list[EntityNode],
 ) -> tuple[list[EntityNode], dict[str, str]]:
     start = time()
 
@@ -219,11 +219,11 @@ async def dedupe_extracted_nodes(
 
 
 async def resolve_extracted_nodes(
-        clients: GraphitiClients,
-        extracted_nodes: list[EntityNode],
-        episode: EpisodicNode | None = None,
-        previous_episodes: list[EpisodicNode] | None = None,
-        entity_types: dict[str, BaseModel] | None = None,
+    clients: GraphitiClients,
+    extracted_nodes: list[EntityNode],
+    episode: EpisodicNode | None = None,
+    previous_episodes: list[EpisodicNode] | None = None,
+    entity_types: dict[str, BaseModel] | None = None,
 ) -> tuple[list[EntityNode], dict[str, str]]:
     llm_client = clients.llm_client
 
@@ -272,12 +272,12 @@ async def resolve_extracted_nodes(
 
 
 async def resolve_extracted_node(
-        llm_client: LLMClient,
-        extracted_node: EntityNode,
-        existing_nodes: list[EntityNode],
-        episode: EpisodicNode | None = None,
-        previous_episodes: list[EpisodicNode] | None = None,
-        entity_type: BaseModel | None = None,
+    llm_client: LLMClient,
+    extracted_node: EntityNode,
+    existing_nodes: list[EntityNode],
+    episode: EpisodicNode | None = None,
+    previous_episodes: list[EpisodicNode] | None = None,
+    entity_type: BaseModel | None = None,
 ) -> EntityNode:
     start = time()
     if len(existing_nodes) == 0:
@@ -336,11 +336,11 @@ async def resolve_extracted_node(
 
 
 async def extract_attributes_from_nodes(
-        clients: GraphitiClients,
-        nodes: list[EntityNode],
-        episode: EpisodicNode | None = None,
-        previous_episodes: list[EpisodicNode] | None = None,
-        entity_types: dict[str, BaseModel] | None = None,
+    clients: GraphitiClients,
+    nodes: list[EntityNode],
+    episode: EpisodicNode | None = None,
+    previous_episodes: list[EpisodicNode] | None = None,
+    entity_types: dict[str, BaseModel] | None = None,
 ) -> list[EntityNode]:
     llm_client = clients.llm_client
     embedder = clients.embedder
@@ -366,11 +366,11 @@ async def extract_attributes_from_nodes(
 
 
 async def extract_attributes_from_node(
-        llm_client: LLMClient,
-        node: EntityNode,
-        episode: EpisodicNode | None = None,
-        previous_episodes: list[EpisodicNode] | None = None,
-        entity_type: BaseModel | None = None,
+    llm_client: LLMClient,
+    node: EntityNode,
+    episode: EpisodicNode | None = None,
+    previous_episodes: list[EpisodicNode] | None = None,
+    entity_type: BaseModel | None = None,
 ) -> EntityNode:
     node_context: dict[str, Any] = {
         'name': node.name,
@@ -424,8 +424,8 @@ async def extract_attributes_from_node(
 
 
 async def dedupe_node_list(
-        llm_client: LLMClient,
-        nodes: list[EntityNode],
+    llm_client: LLMClient,
+    nodes: list[EntityNode],
 ) -> tuple[list[EntityNode], dict[str, str]]:
     start = time()
 

--- a/tests/utils/maintenance/test_edge_operations.py
+++ b/tests/utils/maintenance/test_edge_operations.py
@@ -119,6 +119,7 @@ async def test_resolve_extracted_edge_no_changes(
         mock_extracted_edge,
         mock_related_edges,
         mock_existing_edges,
+        mock_current_episode,
     )
 
     assert resolved_edge.uuid == mock_extracted_edge.uuid
@@ -170,6 +171,7 @@ async def test_resolve_extracted_edge_with_invalidation(
         mock_extracted_edge,
         mock_related_edges,
         mock_existing_edges,
+        mock_current_episode,
     )
 
     assert resolved_edge.uuid == mock_extracted_edge.uuid


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update deduplication prompt for clarity, reduce summary word limit, and adjust node operations and tests accordingly.
> 
>   - **Prompts**:
>     - Update deduplication prompt in `dedupe_nodes.py` to clarify criteria for identifying duplicate entities.
>     - Reduce summary word limit from 500 to 250 in `extract_nodes.py` and `summarize_nodes.py`.
>   - **Node Operations**:
>     - Remove `summary` field from `resolve_extracted_node()` and `dedupe_node_list()` in `node_operations.py`.
>   - **Tests**:
>     - Add `mock_current_episode` parameter to `test_edge_operations.py` test cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 8d1d4103239abe1b80bf337a16e3bcb288beda4e. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->