### PR TITLE
make bulk save more robust

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -397,7 +397,7 @@ class Graphiti:
                 episode.content = ''
 
             await add_nodes_and_edges_bulk(
-                self.driver, [episode], episodic_edges, hydrated_nodes, entity_edges
+                self.driver, [episode], episodic_edges, hydrated_nodes, entity_edges, self.embedder
             )
 
             # Update any communities
@@ -693,7 +693,7 @@ class Graphiti:
         invalidated_edges = resolve_edge_contradictions(resolved_edge, contradicting_edges)
 
         await add_nodes_and_edges_bulk(
-            self.driver, [], [], resolved_nodes, [resolved_edge] + invalidated_edges
+            self.driver, [], [], resolved_nodes, [resolved_edge] + invalidated_edges, self.embedder
         )
 
     async def remove_episode(self, episode_uuid: str):

--- a/graphiti_core/utils/bulk_utils.py
+++ b/graphiti_core/utils/bulk_utils.py
@@ -96,10 +96,16 @@ async def add_nodes_and_edges_bulk(
     episodic_edges: list[EpisodicEdge],
     entity_nodes: list[EntityNode],
     entity_edges: list[EntityEdge],
+    embedder: EmbedderClient,
 ):
     async with driver.session(database=DEFAULT_DATABASE) as session:
         await session.execute_write(
-            add_nodes_and_edges_bulk_tx, episodic_nodes, episodic_edges, entity_nodes, entity_edges
+            add_nodes_and_edges_bulk_tx,
+            episodic_nodes,
+            episodic_edges,
+            entity_nodes,
+            entity_edges,
+            embedder,
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "graphiti-core"
 description = "A temporal graph building library"
-version = "0.11.6pre2"
+version = "0.11.6pre3"
 authors = [
     { "name" = "Paul Paliychuk", "email" = "paul@getzep.com" },
     { "name" = "Preston Rasmussen", "email" = "preston@getzep.com" },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance bulk save robustness by integrating embedding generation for nodes and edges in `graphiti.py` and `bulk_utils.py`.
> 
>   - **Behavior**:
>     - `add_nodes_and_edges_bulk` in `bulk_utils.py` now requires `EmbedderClient` to generate embeddings for nodes and edges if missing.
>     - Updates `add_episode_endpoint` and `add_triplet` in `graphiti.py` to pass `self.embedder` to `add_nodes_and_edges_bulk`.
>   - **Embedding Generation**:
>     - In `add_nodes_and_edges_bulk_tx`, generates `name_embedding` for nodes and `fact_embedding` for edges if they are `None`.
>   - **Version Update**:
>     - Increment version in `pyproject.toml` from `0.11.6pre2` to `0.11.6pre3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for f13e09c40a58ea5c460f2b451916f64a8586d408. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->