### PR TITLE
Updated docker-compose.test.yml to fix security vulnerability [yaml.docker-compose.security.no-new-privileges.no-new-privileges]

### DIFF
--- a/docker-compose.test.yml.bak
+++ b/docker-compose.test.yml.bak
@@ -2,10 +2,6 @@ version: '3.8'
 
 services:
   graph:
-    security_opt:
-      - no-new-privileges:true
-    security_opt:
-      - no-new-privileges:true
     image: graphiti-service:${GITHUB_SHA}
     ports:
       - "8000:8000"


### PR DESCRIPTION
**Context and Purpose:**

            This PR automatically remediates a security vulnerability:
            - **Description:** Service 'graph' allows for privilege escalation via setuid or setgid binaries. Add 'no-new-privileges:true' in 'security_opt' to prevent this.
            - **Rule ID:** yaml.docker-compose.security.no-new-privileges.no-new-privileges
            - **Severity:** HIGH
            - **File:** docker-compose.test.yml
            - **Lines Affected:** 4 - 4

            This change is necessary to protect the application from potential security risks associated with this vulnerability.

            **Solution Implemented:**

            The automated remediation process has applied the necessary changes to the affected code in `docker-compose.test.yml` to resolve the identified issue.

            Please review the changes to ensure they are correct and integrate as expected.
            
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `no-new-privileges:true` to `graph` service in `docker-compose.test.yml` to prevent privilege escalation, with a backup file created.
> 
>   - **Security Fix**:
>     - Adds `no-new-privileges:true` to `security_opt` for `graph` service in `docker-compose.test.yml` to prevent privilege escalation.
>     - Duplicate `security_opt` entry added, which might be an error.
>   - **Backup**:
>     - Creates `docker-compose.test.yml.bak` as a backup of the original configuration without the security option.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 8634521b062a57ab6482683bc03fc0c9eebb3758. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->