### PR TITLE
feat: add thinking_config support for Gemini 2.5 models

### DIFF
--- a/graphiti_core/llm_client/gemini_client.py
+++ b/graphiti_core/llm_client/gemini_client.py
@@ -51,10 +51,10 @@ class GeminiClient(LLMClient):
         model (str): The model name to use for generating responses.
         temperature (float): The temperature to use for generating responses.
         max_tokens (int): The maximum number of tokens to generate in a response.
-        thinking_budget (int): The maximum number of tokens to spend on thinking for 2.5 version models. 0 disables thinking.
+        thinking_config (types.ThinkingConfig | None): Optional thinking configuration for models that support it.
     Methods:
-        __init__(config: LLMConfig | None = None, cache: bool = False):
-            Initializes the GeminiClient with the provided configuration and cache setting.
+        __init__(config: LLMConfig | None = None, cache: bool = False, thinking_config: types.ThinkingConfig | None = None):
+            Initializes the GeminiClient with the provided configuration, cache setting, and optional thinking config.
 
         _generate_response(messages: list[Message]) -> dict[str, typing.Any]:
             Generates a response from the language model based on the provided messages.
@@ -65,15 +65,16 @@ class GeminiClient(LLMClient):
         config: LLMConfig | None = None,
         cache: bool = False,
         max_tokens: int = DEFAULT_MAX_TOKENS,
-        thinking_budget: int = DEFAULT_THINKING_BUDGET,
+        thinking_config: types.ThinkingConfig | None = None,
     ):
         """
-        Initialize the GeminiClient with the provided configuration and cache setting.
+        Initialize the GeminiClient with the provided configuration, cache setting, and optional thinking config.
 
         Args:
             config (LLMConfig | None): The configuration for the LLM client, including API key, model, temperature, and max tokens.
             cache (bool): Whether to use caching for responses. Defaults to False.
-            thinking_budget (int): The maximum number of tokens to spend on thinking for 2.5 version models. 0 disables thinking.
+            thinking_config (types.ThinkingConfig | None): Optional thinking configuration for models that support it.
+                Only use with models that support thinking (gemini-2.5+). Defaults to None.
 
         """
         if config is None:
@@ -87,7 +88,7 @@ class GeminiClient(LLMClient):
             api_key=config.api_key,
         )
         self.max_tokens = max_tokens
-        self.thinking_budget = thinking_budget
+        self.thinking_config = thinking_config
 
     async def _generate_response(
         self,
@@ -157,7 +158,7 @@ class GeminiClient(LLMClient):
                 response_mime_type='application/json' if response_model else None,
                 response_schema=response_model if response_model else None,
                 system_instruction=system_prompt,
-                thinking_config=thinking_config_arg,
+                thinking_config=self.thinking_config,
             )
 
             # Generate content using the simple string approach

--- a/graphiti_core/llm_client/gemini_client.py
+++ b/graphiti_core/llm_client/gemini_client.py
@@ -29,15 +29,7 @@ from .errors import RateLimitError
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = 'gemini-2.0-flash'
-DEFAULT_THINKING_BUDGET = 0
-
-# Gemini models that support thinking capabilities
-GEMINI_THINKING_MODELS = [
-    'gemini-2.5-pro',
-    'gemini-2.5-flash',
-    'gemini-2.5-flash-lite',
-]
+DEFAULT_MODEL = 'gemini-2.5-flash'
 
 
 class GeminiClient(LLMClient):
@@ -140,17 +132,6 @@ class GeminiClient(LLMClient):
                     types.Content(role=m.role, parts=[types.Part.from_text(text=m.content)])
                 )
 
-            # Determine the model to be used
-            model_to_use = self.model or DEFAULT_MODEL
-
-            # Conditionally create thinking_config for models that support thinking
-            thinking_config_arg = None
-            if model_to_use in GEMINI_THINKING_MODELS:
-                thinking_config_arg = types.ThinkingConfig(
-                    include_thoughts=False,
-                    thinking_budget=self.thinking_budget,
-                )
-
             # Create generation config
             generation_config = types.GenerateContentConfig(
                 temperature=self.temperature,
@@ -163,7 +144,7 @@ class GeminiClient(LLMClient):
 
             # Generate content using the simple string approach
             response = await self.client.aio.models.generate_content(
-                model=model_to_use,
+                model=self.model or DEFAULT_MODEL,
                 contents=gemini_messages,
                 config=generation_config,
             )


### PR DESCRIPTION

Add user-controllable thinking config support for Gemini models

### Problem
Users need to leverage Gemini 2.5's improved capabilities while maintaining control over thinking behavior. Gemini 2.5+ models support thinking config for enhanced reasoning, but older models (2.0, 1.5) throw 400 errors if they receive ThinkingConfig parameters. Additionally, the implementation needs to be future-proof for upcoming models like Gemini 3.0.

### Solution
Add user-controlled thinking config support to GeminiClient that provides flexibility while maintaining backward compatibility:

**Key Changes:**
- **Constructor**: Added `thinking_config: types.ThinkingConfig | None = None` parameter to `GeminiClient`
- **User control**: Users can provide complete ThinkingConfig objects for models that support thinking
- **Safe defaults**: `thinking_config=None` by default ensures compatibility with all models
- **Future-proof**: No hardcoded model version checking - works with any current or future Gemini models
- **Direct implementation**: Thinking config passed directly to generation config when provided

### Benefits

**Cost/Performance Control**: Users have complete control over thinking behavior:
- Default mode (thinking_config=None): Fast, cost-effective operation (~$0.60/1M tokens for Gemini-2.5-flash)
- Thinking mode: Users can enable with custom parameters for enhanced reasoning (slower, ~$3.50/1M tokens)

**Backward Compatibility**: Existing code continues working unchanged with all current models

**Future-Proof Design**: Automatically supports any future Gemini models without code modifications

**Full Flexibility**: Users control all ThinkingConfig parameters (thinking_budget, include_thoughts, etc.) rather than limited preset options

**Clear Responsibility**: Users decide which models support thinking config with clear documentation guidance

### Usage
```python
# Default - works with any Gemini model
client = GeminiClient()

# Advanced - full thinking config control for compatible models
from google.genai import types
thinking_config = types.ThinkingConfig(
    include_thoughts=False,
    thinking_budget=1000
)
client = GeminiClient(thinking_config=thinking_config)
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `thinking_budget` support to `GeminiClient` for Gemini 2.5 models, enabling 'thinking' mode control.
> 
>   - **Behavior**:
>     - Adds `thinking_budget` parameter to `GeminiClient` constructor, defaulting to 0.
>     - Constructs `types.ThinkingConfig` only for models starting with `gemini-2.5`.
>     - `thinking_budget = 0` keeps non-thinking mode; >0 enables thinking mode.
>     - Avoids sending `thinking_config` to pre-2.5 models to prevent errors.
>   - **Files**:
>     - Updates `gemini_client.py` to handle `thinking_budget` and model detection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for a20fa45defca4d1edaec41f8c08cae6095cf5577. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->