### PR TITLE
Implement Small Model in MCP Server; Default to 4.1-nano

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -75,7 +75,9 @@ The server uses the following environment variables:
 - `NEO4J_PASSWORD`: Neo4j password (default: `demodemo`)
 - `OPENAI_API_KEY`: OpenAI API key (required for LLM operations)
 - `OPENAI_BASE_URL`: Optional base URL for OpenAI API
-- `MODEL_NAME`: Optional model name to use for LLM inference
+- `MODEL_NAME`: OpenAI model name to use for LLM operations.
+- `SMALL_MODEL_NAME`: OpenAI model name to use for smaller LLM operations.
+- `LLM_TEMPERATURE`: Temperature for LLM responses (0.0-2.0).
 - `AZURE_OPENAI_ENDPOINT`: Optional Azure OpenAI endpoint URL
 - `AZURE_OPENAI_DEPLOYMENT_NAME`: Optional Azure OpenAI deployment name
 - `AZURE_OPENAI_API_VERSION`: Optional Azure OpenAI API version
@@ -101,10 +103,12 @@ uv run graphiti_mcp_server.py --model gpt-4.1-mini --transport sse
 
 Available arguments:
 
-- `--model`: Specify the model name to use with the LLM client
+- `--model`: Overrides the `MODEL_NAME` environment variable.
+- `--small-model`: Overrides the `SMALL_MODEL_NAME` environment variable.
+- `--temperature`: Overrides the `LLM_TEMPERATURE` environment variable.
 - `--transport`: Choose the transport method (sse or stdio, default: sse)
 - `--group-id`: Set a namespace for the graph (optional). If not provided, defaults to "default".
-- `--destroy-graph`: Destroy all Graphiti graphs (use with caution)
+- `--destroy-graph`: If set, destroys all Graphiti graphs on startup.
 - `--use-custom-entities`: Enable entity extraction using the predefined ENTITY_TYPES
 
 ### Docker Deployment


### PR DESCRIPTION
- Introduced a new small LLM model configuration option (`SMALL_LLM_MODEL`) in `GraphitiLLMConfig`.
- Updated environment variable documentation to include `SMALL_MODEL_NAME`.
- Added command-line argument support for `--small-model` to override the small model name.
- Enhanced logging for small model configuration to improve user feedback.

These changes enhance flexibility in model selection for LLM operations.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add small model configuration option to `GraphitiLLMConfig`, update CLI and environment variable documentation, and enhance logging in `graphiti_mcp_server.py`.
> 
>   - **Configuration**:
>     - Add `SMALL_LLM_MODEL` defaulting to 'gpt-4.1-nano' in `graphiti_mcp_server.py`.
>     - Add `small_model` attribute to `GraphitiLLMConfig`.
>     - Update `from_env()` and `from_cli_and_env()` in `GraphitiLLMConfig` to handle `small_model`.
>   - **CLI and Environment**:
>     - Add `--small-model` CLI argument in `graphiti_mcp_server.py` to override `SMALL_MODEL_NAME`.
>     - Update `README.md` to document `SMALL_MODEL_NAME` environment variable and `--small-model` argument.
>   - **Logging**:
>     - Enhance logging in `initialize_graphiti()` to include small model configuration details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 1890037840b472d4f333bc94b221986133609526. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->