### PR TITLE
fix: update key name in edge attributes context

### DIFF
--- a/graphiti_core/utils/maintenance/edge_operations.py
+++ b/graphiti_core/utils/maintenance/edge_operations.py
@@ -439,7 +439,7 @@ async def resolve_extracted_edge(
         resolved_edge.name = fact_type
 
         edge_attributes_context = {
-            'message': episode.content,
+            'episode_content': episode.content,
             'reference_time': episode.valid_at,
             'fact': resolved_edge.fact,
         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename key from `message` to `episode_content` in `edge_attributes_context` within `resolve_extracted_edge()` in `edge_operations.py`.
> 
>   - **Behavior**:
>     - Rename key in `edge_attributes_context` from `message` to `episode_content` in `resolve_extracted_edge()` function in `edge_operations.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for afcd94dc085a1b60634fa75076afd9cf3fb46527. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->