### PR TITLE
proposed fix: handle missing target_node_uuid in edge operations

### DIFF
--- a/graphiti_core/utils/maintenance/edge_operations.py
+++ b/graphiti_core/utils/maintenance/edge_operations.py
@@ -277,7 +277,7 @@ async def resolve_extracted_edges(
     edge_types_lst: list[dict[str, BaseModel]] = []
     for extracted_edge in extracted_edges:
         source_node_labels = uuid_entity_map[extracted_edge.source_node_uuid].labels
-        target_node_labels = uuid_entity_map[extracted_edge.target_node_uuid].labels
+        target_node_labels = uuid_entity_map[extracted_edge.target_node_uuid].labels if extracted_edge.target_node_uuid else []
         label_tuples = [
             (source_label, target_label)
             for source_label in source_node_labels


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix handling of missing `target_node_uuid` in `resolve_extracted_edges` in `edge_operations.py` by setting `target_node_labels` to an empty list.
> 
>   - **Behavior**:
>     - In `resolve_extracted_edges` in `edge_operations.py`, handle missing `target_node_uuid` by setting `target_node_labels` to an empty list if `target_node_uuid` is `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 12786feae5391d1880deff67c06122c8413f91d4. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->