### PR TITLE
remove sanitize

### DIFF
--- a/graphiti_core/search/search_filters.py
+++ b/graphiti_core/search/search_filters.py
@@ -60,7 +60,7 @@ def node_search_filter_query_constructor(
     filter_params: dict[str, Any] = {}
 
     if filters.node_labels is not None:
-        node_labels = '|'.join(list(map(lucene_sanitize, filters.node_labels)))
+        node_labels = '|'.join(filters.node_labels)
         node_label_filter = ' AND n:' + node_labels
         filter_query += node_label_filter
 
@@ -80,7 +80,7 @@ def edge_search_filter_query_constructor(
         filter_params['edge_types'] = edge_types
 
     if filters.node_labels is not None:
-        node_labels = '|'.join(list(map(lucene_sanitize, filters.node_labels)))
+        node_labels = '|'.join(filters.node_labels)
         node_label_filter = '\nAND n:' + node_labels + ' AND m:' + node_labels
         filter_query += node_label_filter
 

--- a/graphiti_core/search/search_filters.py
+++ b/graphiti_core/search/search_filters.py
@@ -21,8 +21,6 @@ from typing import Any
 from pydantic import BaseModel, Field
 from typing_extensions import LiteralString
 
-from graphiti_core.helpers import lucene_sanitize
-
 
 class ComparisonOperator(Enum):
     equals = '='

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "graphiti-core"
 description = "A temporal graph building library"
-version = "0.12.0pre2"
+version = "0.12.0pre3"
 authors = [
     { "name" = "Paul Paliychuk", "email" = "paul@getzep.com" },
     { "name" = "Preston Rasmussen", "email" = "preston@getzep.com" },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `lucene_sanitize` from search filter query constructors and update version to `0.12.0pre3`.
> 
>   - **Code Simplification**:
>     - Remove `lucene_sanitize` from `node_search_filter_query_constructor()` and `edge_search_filter_query_constructor()` in `search_filters.py`.
>     - Directly use `filters.node_labels` without sanitization.
>   - **Version Update**:
>     - Update version in `pyproject.toml` from `0.12.0pre2` to `0.12.0pre3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for ee9075d75a71290997c53c017fda4ce017f9a02c. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->