### PR TITLE
BUG FIX: Fix trailing AND in edge_search_filter_query_constructor Cypher query

### DIFF
--- a/graphiti_core/search/search_filters.py
+++ b/graphiti_core/search/search_filters.py
@@ -95,12 +95,12 @@ def edge_search_filter_query_constructor(
             and_filter_query = ''
             for j, and_filter in enumerate(and_filters):
                 and_filter_query += and_filter
-                if j != len(and_filter_query) - 1:
+                if j != len(and_filters) - 1:
                     and_filter_query += ' AND '
 
             valid_at_filter += and_filter_query
 
-            if i == len(or_list) - 1:
+            if i == len(filters.valid_at) - 1:
                 valid_at_filter += ')'
             else:
                 valid_at_filter += ' OR '
@@ -120,12 +120,12 @@ def edge_search_filter_query_constructor(
             and_filter_query = ''
             for j, and_filter in enumerate(and_filters):
                 and_filter_query += and_filter
-                if j != len(and_filter_query) - 1:
+                if j != len(and_filters) - 1:
                     and_filter_query += ' AND '
 
             invalid_at_filter += and_filter_query
 
-            if i == len(or_list) - 1:
+            if i == len(filters.invalid_at) - 1:
                 invalid_at_filter += ')'
             else:
                 invalid_at_filter += ' OR '
@@ -145,12 +145,12 @@ def edge_search_filter_query_constructor(
             and_filter_query = ''
             for j, and_filter in enumerate(and_filters):
                 and_filter_query += and_filter
-                if j != len(and_filter_query) - 1:
+                if j != len(and_filters) - 1:
                     and_filter_query += ' AND '
 
             created_at_filter += and_filter_query
 
-            if i == len(or_list) - 1:
+            if i == len(filters.created_at) - 1:
                 created_at_filter += ')'
             else:
                 created_at_filter += ' OR '
@@ -170,12 +170,12 @@ def edge_search_filter_query_constructor(
             and_filter_query = ''
             for j, and_filter in enumerate(and_filters):
                 and_filter_query += and_filter
-                if j != len(and_filter_query) - 1:
+                if j != len(and_filters) - 1:
                     and_filter_query += ' AND '
 
             expired_at_filter += and_filter_query
 
-            if i == len(or_list) - 1:
+            if i == len(filters.expired_at) - 1:
                 expired_at_filter += ')'
             else:
                 expired_at_filter += ' OR '


### PR DESCRIPTION
When using the filters, I found a bug that would create a neo4j error. The Neo.ClientError.Statement.SyntaxError occurs because the Cypher query generated by the edge_search_filter_query_constructor function in graphiti_core.search.search_filters is syntactically invalid.

Specifically:
```
- ERROR - Error using Graphiti client in searchCrypto: {code: Neo.ClientError.Statement.SyntaxError} {message: Invalid input ')': expected an expression (line 6, column 38 (offset: 292))
"AND ((r.valid_at >= $valid_at_0) AND ) AND ((r.invalid_at > $invalid_at_0) AND )AND ((r.expired_at > $expired_at_0) AND )"
                                      ^}
```

From this:
```
from graphiti_core.search.search_filters import ComparisonOperator, DateFilter, SearchFilters, edge_search_filter_query_constructor
from datetime import datetime, timedelta, timezone

current_date = datetime.now(timezone.utc)
one_month_ago = current_date - timedelta(days=30)

filters = SearchFilters(
	valid_at=[
		[DateFilter(date=one_month_ago, comparison_operator=ComparisonOperator.greater_than_equal)]
	],
	invalid_at=[
		[DateFilter(date=current_date, comparison_operator=ComparisonOperator.greater_than)]
	],
	expired_at=[
		[DateFilter(date=current_date, comparison_operator=ComparisonOperator.greater_than)]
	]
)

# Perform the search with the user-provided query
user_facts = await graphiti_client.search(
	query=query,
	num_results=int(amount),
	group_ids=[f"{config.group_namespace}"],
	search_filter=filters
)
```

Fix:
Corrected the edge_search_filter_query_constructor function to prevent trailing AND operators in generated Cypher queries, which caused Neo.ClientError.Statement.SyntaxError. Changed condition from `j != len(and_filter_query) - 1` to `j != len(and_filters) - 1` for valid_at, invalid_at, created_at, and expired_at filter blocks. Also fixed outer loop condition to use `len(filters.<field>)` instead of `len(or_list)`. Ensures valid Cypher syntax for single DateFilter cases..


Testing:
I have tested it with the code above, and seems to be in working order. I am yet to test multiple datefilters at the moment but will once I find the time.

This is my first proper PR in forever and I'm new to Python coming from Java :^) so I'm sorry if I messed up anything!