### PR TITLE
Updated docker-compose.test.yml to fix security vulnerability [yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service]

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,6 +2,7 @@ version: '3.8'
 
 services:
   graph:
+    read_only: true
     image: graphiti-service:${GITHUB_SHA}
     ports:
       - "8000:8000"


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** Service 'graph' is running with a writable root filesystem. This may allow malicious applications to download and run additional payloads, or modify container files. If an application inside a container has to save something temporarily consider using a tmpfs. Add 'read_only: true' to this service to prevent this.
- **Rule ID:** yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service
- **Severity:** HIGH
- **File:** docker-compose.test.yml
- **Lines Affected:** 4 - 4

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `docker-compose.test.yml` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `read_only: true` to `graph` service in `docker-compose.test.yml` to fix writable root filesystem vulnerability.
> 
>   - **Security Fix**:
>     - Adds `read_only: true` to the `graph` service in `docker-compose.test.yml` to prevent writable root filesystem vulnerability.
>     - Addresses HIGH severity vulnerability identified by rule `yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 8855d7410ce195f4750dee91060bd9c85c4ba179. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->