### PR TITLE
Fix OpenAI Reranker logic

### DIFF
--- a/graphiti_core/cross_encoder/openai_reranker_client.py
+++ b/graphiti_core/cross_encoder/openai_reranker_client.py
@@ -106,7 +106,7 @@ class OpenAIRerankerClient(CrossEncoderClient):
                 if len(top_logprobs) == 0:
                     continue
                 norm_logprobs = np.exp(top_logprobs[0].logprob)
-                if bool(top_logprobs[0].token):
+                if top_logprobs[0].token.strip().split(" ")[0].lower() == "true":
                     scores.append(norm_logprobs)
                 else:
                     scores.append(1 - norm_logprobs)


### PR DESCRIPTION
# Issue
- In class [OpenAIRerankerClient](https://github.com/getzep/graphiti/blob/main/graphiti_core/cross_encoder/openai_reranker_client.py#L34), the logic below is not working properly:
```python
if bool(top_logprobs[0].token):
    scores.append(norm_logprobs)
else:
    scores.append(1 - norm_logprobs)
```

# Test case
- Print the `top_logprobs[0].token` type and it value:
![image](https://github.com/user-attachments/assets/95aa2124-80c3-43fd-926d-bac2891accad)
- Output:
![image](https://github.com/user-attachments/assets/5f1db9f4-1aa7-4169-bf48-a132348cdcc4)

- Workaround:
![image](https://github.com/user-attachments/assets/6c39f3a8-05e6-4393-b931-70e5fda020a6)

# Changes
- Changed the previous condition to this:
```python
if top_logprobs[0].token.strip().split(" ")[0].lower() == "true":
    scores.append(norm_logprobs)
else:
    scores.append(1 - norm_logprobs)
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes logic in `OpenAIRerankerClient` to correctly evaluate token as 'true' in `rank()` method.
> 
>   - **Logic Fix**:
>     - In `OpenAIRerankerClient` class, `rank()` method: Fix condition to check if `top_logprobs[0].token` is 'true' by using `top_logprobs[0].token.strip().split(" ")[0].lower() == "true"`.
>   - **Behavior**:
>     - Correctly appends `norm_logprobs` or `1 - norm_logprobs` to `scores` based on the token value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 8a440312514d8b59e49aa4ad047c158b1eef936e. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->