### PR TITLE
Feat/driver factory

### DIFF
--- a/graphiti_core/driver/factory.py
+++ b/graphiti_core/driver/factory.py
@@ -1,0 +1,27 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+class GraphDriverFactory:
+    @staticmethod
+    def get_driver(uri: str, user: str, password: str):
+        if uri.startswith("falkor://"):
+            from .falkordb_driver import FalkorDriver
+            return FalkorDriver(uri, user, password)
+        elif uri.startswith("neo4j://"):
+            from .neo4j_driver import Neo4jDriver
+            return Neo4jDriver(uri, user, password)
+        else:
+            raise ValueError(f"Unknown database URI scheme in {uri}")

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -25,7 +25,7 @@ from typing_extensions import LiteralString
 from graphiti_core.cross_encoder.client import CrossEncoderClient
 from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient
 from graphiti_core.driver.driver import GraphDriver
-from graphiti_core.driver.neo4j_driver import Neo4jDriver
+from graphiti_core.driver.factory import GraphDriverFactory
 from graphiti_core.edges import EntityEdge, EpisodicEdge
 from graphiti_core.embedder import EmbedderClient, OpenAIEmbedder
 from graphiti_core.graphiti_types import GraphitiClients
@@ -140,7 +140,7 @@ class Graphiti:
         Graphiti if you're using the default OpenAIClient.
         """
 
-        self.driver = graph_driver if graph_driver else Neo4jDriver(uri, user, password)
+        self.driver = graph_driver if graph_driver else GraphDriverFactory.get_driver(uri, user, password)
 
         self.database = DEFAULT_DATABASE
         self.store_raw_episode_content = store_raw_episode_content


### PR DESCRIPTION
Context and Purpose:

This PR introduces a driver factory to the codebase, enabling automatic selection of the appropriate graph database driver (e.g., Neo4j or FalkorDB) based on the URI scheme provided to the Graphiti class.

Description:
Previously, the backend driver was hardcoded to Neo4j unless a driver instance was manually provided. However, due to import limitations, it was not possible to instantiate and inject a custom driver from outside the project, making it difficult to use alternative backends like FalkorDB. The new factory approach streamlines backend selection and improves extensibility.

Solution Implemented:
* Added a GraphDriverFactory with a static get_driver method that selects and instantiates the correct driver based on the URI scheme.
* Refactored the Graphiti class to use the factory for driver instantiation, removing direct imports of specific drivers.

Impact:
* Users can now specify a neo4j:// or falkor:// URI, and the correct driver will be used automatically.
* Manual driver injection from outside the project is still not possible due to import restrictions, but this change lays the groundwork for future improvements in that area.