### PR TITLE
fix: rename add_episode to add_memory

### DIFF
--- a/mcp_server/cursor_rules.md
+++ b/mcp_server/cursor_rules.md
@@ -9,7 +9,7 @@
 
 ### Always Save New or Updated Information
 
-- **Capture requirements and preferences immediately:** When a user expresses a requirement or preference, use `add_episode` to store it right away.
+- **Capture requirements and preferences immediately:** When a user expresses a requirement or preference, use `add_memory` to store it right away.
   - _Best practice:_ Split very long requirements into shorter, logical chunks.
 - **Be explicit if something is an update to existing knowledge.** Only add what's changed or new to the graph.
 - **Document procedures clearly:** When you discover how a user wants things done, record it as a procedure.

--- a/mcp_server/graphiti_mcp_server.py
+++ b/mcp_server/graphiti_mcp_server.py
@@ -539,7 +539,7 @@ Facts contain temporal metadata, allowing you to track the time of creation and 
 (superseded by new information).
 
 Key capabilities:
-1. Add episodes (text, messages, or JSON) to the knowledge graph with the add_episode tool
+1. Add episodes (text, messages, or JSON) to the knowledge graph with the add_memory tool
 2. Search for nodes (entities) in the graph using natural language queries with search_nodes
 3. Find relevant facts (relationships between entities) with search_facts
 4. Retrieve specific entity edges or episodes by UUID
@@ -707,7 +707,7 @@ async def add_memory(
 
     Examples:
         # Adding plain text content
-        add_episode(
+        add_memory(
             name="Company News",
             episode_body="Acme Corp announced a new product line today.",
             source="text",
@@ -717,7 +717,7 @@ async def add_memory(
 
         # Adding structured JSON data
         # NOTE: episode_body must be a properly escaped JSON string. Note the triple backslashes
-        add_episode(
+        add_memory(
             name="Customer Profile",
             episode_body="{\\\"company\\\": {\\\"name\\\": \\\"Acme Technologies\\\"}, \\\"products\\\": [{\\\"id\\\": \\\"P001\\\", \\\"name\\\": \\\"CloudSync\\\"}, {\\\"id\\\": \\\"P002\\\", \\\"name\\\": \\\"DataMiner\\\"}]}",
             source="json",
@@ -725,7 +725,7 @@ async def add_memory(
         )
 
         # Adding message-style content
-        add_episode(
+        add_memory(
             name="Customer Conversation",
             episode_body="user: What's your return policy?\nassistant: You can return items within 30 days.",
             source="message",


### PR DESCRIPTION
address #586 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename `add_episode` to `add_memory` in `mcp_server/cursor_rules.md` and `mcp_server/graphiti_mcp_server.py`.
> 
>   - **Function Renaming**:
>     - Rename `add_episode` to `add_memory` in `mcp_server/cursor_rules.md` and `mcp_server/graphiti_mcp_server.py`.
>     - Update all instances of `add_episode` to `add_memory` in examples and documentation within `graphiti_mcp_server.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 5c43b2ba3777826f27b6b4ddc01d99b966b15852. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->