### PR TITLE
Add Ollama documentation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,55 @@ graphiti = Graphiti(
 # Now you can use Graphiti with Google Gemini
 ```
 
+## Using Graphiti with Ollama (Local LLM)
+
+Graphiti supports Ollama for running local LLMs and embedding models via Ollama's OpenAI-compatible API. This is ideal for privacy-focused applications or when you want to avoid API costs.
+
+
+Install the models:
+ollama pull deepseek-r1:7b         # LLM
+ollama pull nomic-embed-text       # embeddings
+
+```python
+from graphiti_core import Graphiti
+from graphiti_core.llm_client.config import LLMConfig
+from graphiti_core.llm_client.openai_client import OpenAIClient
+from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig
+from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient
+
+# Configure Ollama LLM client
+llm_config = LLMConfig(
+    api_key="abc",  # Ollama doesn't require a real API key
+    model="deepseek-r1:7b",
+    small_model="deepseek-r1:7b",
+    base_url="http://localhost:11434/v1", # Ollama provides this port
+)
+
+llm_client = OpenAIClient(config=llm_config)
+
+# Initialize Graphiti with Ollama clients
+graphiti = Graphiti(
+    "bolt://localhost:7687",
+    "neo4j",
+    "password",
+    llm_client=llm_client,
+    embedder=OpenAIEmbedder(
+        config=OpenAIEmbedderConfig(
+            api_key="abc",
+            embedding_model="nomic-embed-text",
+            embedding_dim=768,
+            base_url="http://localhost:11434/v1",
+        )
+    ),
+    cross_encoder=OpenAIRerankerClient(client=llm_client, config=llm_config),
+)
+
+# Now you can use Graphiti with local Ollama models
+```
+
+Ensure Ollama is running (`ollama serve`) and that you have pulled the models you want to use.
+
+
 ## Documentation
 
 - [Guides and API documentation](https://help.getzep.com/graphiti).


### PR DESCRIPTION
Added missing documentation for Ollama in the readme. 

Using deepseek-r1:7b worked well as it is big enough to provide reliable structured output (close to gpt 4.1-mini used in the documentation).

https://github.com/getzep/graphiti/issues/485
Request for PR:
https://github.com/getzep/graphiti/issues/484
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds documentation for using Graphiti with Ollama, a local LLM, to the README.md.
> 
>   - **Documentation**:
>     - Adds section "Using Graphiti with Ollama (Local LLM)" to `README.md`.
>     - Describes installation and configuration of Ollama models `deepseek-r1:7b` and `nomic-embed-text`.
>     - Provides example code for setting up `Graphiti` with Ollama's OpenAI-compatible API.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 0d3382352ee2bee01e39f7d999b63c123fab4c8e. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->