### PR TITLE
set requires-python to fix poetry install

### DIFF
--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -3,7 +3,7 @@ name = "mcp-server"
 version = "0.1.0"
 description = "Graphiti MCP Server"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<4"
 dependencies = [
     "mcp>=1.5.0",
     "openai>=1.68.2",


### PR DESCRIPTION
Set requires-python = ">=3.10,<4"

Fixes install issue:

```
$ poetry install --no-root
Updating dependencies
Resolving dependencies... (2.8s)

The current project's supported Python range (>=3.10) is not compatible with some of the required packages Python requirement:
  - graphiti-core requires Python <4,>=3.10, so it will not be installable for Python >=4
  - graphiti-core requires Python <4,>=3.10, so it will not be installable for Python >=4
  - graphiti-core requires Python <4,>=3.10, so it will not be installable for Python >=4
  - graphiti-core requires Python <4,>=3.10, so it will not be installable for Python >=4
  - graphiti-core requires Python <4,>=3.10, so it will not be installable for Python >=4
  - graphiti-core requires Python <4,>=3.10, so it will not be installable for Python >=4

Because no versions of graphiti-core match >0.11.6,<0.12.0 || >0.12.0,<0.12.1 || >0.12.1,<0.12.2 || >0.12.2,<0.12.3 || >0.12.3,<0.12.4 || >0.12.4
 and graphiti-core (0.11.6) requires Python <4,>=3.10, graphiti-core is forbidden.
And because graphiti-core (0.12.0) requires Python <4,>=3.10
 and graphiti-core (0.12.1) requires Python <4,>=3.10, graphiti-core is forbidden.
And because graphiti-core (0.12.2) requires Python <4,>=3.10
 and graphiti-core (0.12.3) requires Python <4,>=3.10, graphiti-core is forbidden.
So, because graphiti-core (0.12.4) requires Python <4,>=3.10
 and mcp-server depends on graphiti-core (>=0.11.6), version solving failed.

  * Check your dependencies Python requirement: The Python requirement can be specified via the `python` or `markers` properties

    For graphiti-core, a possible solution would be to set the `python` property to ">=3.10,<4"
For graphiti-core, a possible solution would be to set the `python` property to ">=3.10,<4"
For graphiti-core, a possible solution would be to set the `python` property to ">=3.10,<4"
For graphiti-core, a possible solution would be to set the `python` property to ">=3.10,<4"
For graphiti-core, a possible solution would be to set the `python` property to ">=3.10,<4"
For graphiti-core, a possible solution would be to set the `python` property to ">=3.10,<4"

    https://python-poetry.org/docs/dependency-specification/#python-restricted-dependencies,
    https://python-poetry.org/docs/dependency-specification/#using-environment-markers
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes poetry install issue by updating `requires-python` to `">=3.10,<4"` in `pyproject.toml`.
> 
>   - **Behavior**:
>     - Updates `requires-python` in `pyproject.toml` to `">=3.10,<4"` to fix poetry install issue with `graphiti-core`.
>     - Ensures compatibility with Python versions 3.10 up to, but not including, 4.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 1fc228f48f667cfe3d3841ad1be861eb05c2a38c. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->