### PR TITLE
fix: ensure fact_embedding is removed from attributes in format_fact_…

### DIFF
--- a/mcp_server/graphiti_mcp_server.py
+++ b/mcp_server/graphiti_mcp_server.py
@@ -628,12 +628,14 @@ def format_fact_result(edge: EntityEdge) -> dict[str, Any]:
     Returns:
         A dictionary representation of the edge with serialized dates and excluded embeddings
     """
-    return edge.model_dump(
+    result = edge.model_dump(
         mode='json',
         exclude={
             'fact_embedding',
         },
     )
+    result.get('attributes', {}).pop('fact_embedding', None)
+    return result
 
 
 # Dictionary to store queues for each group_id


### PR DESCRIPTION
…result

This ensures that fact_embedding is completely cleaned from the result, both from the main level and from the attributes dictionary.

Fixes issue: https://github.com/getzep/graphiti/issues/610