### PR TITLE
Update SEMAPHORE_LIMIT default value in docker-compose.yml to 10 for improved concurrency management

### DIFF
--- a/mcp_server/docker-compose.yml
+++ b/mcp_server/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - MODEL_NAME=${MODEL_NAME}
       - PATH=/root/.local/bin:${PATH}
-      - SEMAPHORE_LIMIT=${SEMAPHORE_LIMIT}
+      - SEMAPHORE_LIMIT=${SEMAPHORE_LIMIT:-10}
     ports:
       - "8000:8000" # Expose the MCP server via HTTP for SSE transport
     command: ["uv", "run", "graphiti_mcp_server.py", "--transport", "sse"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `SEMAPHORE_LIMIT` default value to 10 in `docker-compose.yml` for `graphiti-mcp` service.
> 
>   - **Environment Variable**:
>     - Update `SEMAPHORE_LIMIT` default value to 10 in `docker-compose.yml` for `graphiti-mcp` service.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 065c0baacffe49b7a3e920a30d45d0bd116301a7. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->