### PR TITLE
fix: correct spacing in group IDs filter concatenation in fulltext_query function

### DIFF
--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -67,7 +67,7 @@ def fulltext_query(query: str, group_ids: list[str] | None = None):
     )
     group_ids_filter = ''
     for f in group_ids_filter_list:
-        group_ids_filter += f if not group_ids_filter else f'OR {f}'
+        group_ids_filter += f if not group_ids_filter else f' OR {f}'
 
     group_ids_filter += ' AND ' if group_ids_filter else ''
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes spacing issue in `fulltext_query()` in `search_utils.py` for group IDs filter concatenation.
> 
>   - **Behavior**:
>     - Fixes spacing issue in `fulltext_query()` in `search_utils.py` by adding a space before 'OR' in group IDs filter concatenation.
>     - Ensures correct query string format when multiple group IDs are present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for d4c6ff251604257a549e6177593b549595cd1e21. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->