### PR TITLE
bump builder to python 3.11

### DIFF
--- a/.github/workflows/release-graphiti-core.yml
+++ b/.github/workflows/release-graphiti-core.yml
@@ -15,10 +15,10 @@ jobs:
       url: https://pypi.org/p/zep-cloud
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Python version to 3.11 in GitHub Actions workflow for PyPI release.
> 
>   - **GitHub Actions**:
>     - Update Python version from 3.10 to 3.11 in `release-graphiti-core.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for ee885ce89d282e54cad1f3516735e1ef14e4b383. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->