### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,5 +1,8 @@
 name: Pyright Type Check
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/getzep/graphiti/security/code-scanning/18](https://github.com/getzep/graphiti/security/code-scanning/18)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions required for the workflow. Based on the provided workflow, it appears that the workflow only needs read access to the repository contents. Therefore, the `permissions` block should be set to `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
