### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: depot-ubuntu-22.04


### PR DESCRIPTION
Potential fix for [https://github.com/getzep/graphiti/security/code-scanning/17](https://github.com/getzep/graphiti/security/code-scanning/17)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily interacts with repository contents (e.g., checking out code), the `contents: read` permission is sufficient. This change should be applied at the root level of the workflow to cover all jobs unless specific jobs require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `permissions: contents: read` to `.github/workflows/unit_tests.yml` to address a security alert by specifying least privileges.
> 
>   - **Security**:
>     - Adds `permissions: contents: read` to `.github/workflows/unit_tests.yml` to address code scanning alert no. 17.
>     - Ensures the workflow has the least privileges required for interacting with repository contents.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for c45a9a17762bb736173c8ff8d4f3e1b7ac9ee150. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->