### PR TITLE
Add GitHub Actions workflow for building and pushing MCP Server Docker image

### DIFF
--- a/.github/workflows/mcp-server-docker.yml
+++ b/.github/workflows/mcp-server-docker.yml
@@ -1,0 +1,70 @@
+name: Build and Push MCP Server Docker Image
+
+on:
+  push:
+    paths:
+      - "mcp_server/pyproject.toml"
+    branches:
+      - main
+  pull_request:
+    paths:
+      - "mcp_server/pyproject.toml"
+    branches:
+      - main
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: zepai/knowledge-graph-mcp
+
+jobs:
+  build-and-push:
+    runs-on: depot-ubuntu-22.04
+    environment: development
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract version from pyproject.toml
+        id: version
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('mcp_server/pyproject.toml', 'rb'))['project']['version'])")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=${{ steps.version.outputs.tag }}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Depot build and push image
+        uses: depot/build-push-action@v1
+        with:
+          project: v9jv1mlpwc
+          context: ./mcp_server
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false


### PR DESCRIPTION
This commit introduces a new workflow that triggers on changes to the pyproject.toml file in the main branch. It builds and pushes the Docker image to Docker Hub, extracting the version from the pyproject.toml and setting up necessary permissions and steps for the process.