### PR TITLE
feat: add pre-built Docker image for Graphiti MCP server

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -163,6 +163,8 @@ The Docker Compose setup includes a Neo4j container with the following default c
 
 #### Running with Docker Compose
 
+A Graphiti MCP container is available at: `zepai/knowledge-graph-mcp`. The latest build of this container is used by the Compose setup below.
+
 Start the services using Docker Compose:
 
 ```bash

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -21,9 +21,9 @@ The Graphiti MCP server exposes the following key high-level functions of Graphi
 - **Group Management**: Organize and manage groups of related data with group_id filtering
 - **Graph Maintenance**: Clear the graph and rebuild indices
 
-## Quick Start for Claude Desktop, Cursor, and other clients
+## Quick Start
 
-1. Clone the Graphiti GitHub repo
+### Clone the Graphiti GitHub repo
 
 ```bash
 git clone https://github.com/getzep/graphiti.git
@@ -35,7 +35,9 @@ or
 gh repo clone getzep/graphiti
 ```
 
-Note the full path to this directory.
+### For Claude Desktop and other `stdio` only clients
+
+1. Note the full path to this directory.
 
 ```
 cd graphiti && pwd
@@ -44,6 +46,18 @@ cd graphiti && pwd
 2. Install the [Graphiti prerequisites](#prerequisites).
 
 3. Configure Claude, Cursor, or other MCP client to use [Graphiti with a `stdio` transport](#integrating-with-mcp-clients). See the client documentation on where to find their MCP configuration files.
+
+### For Cursor and other `sse`-enabled clients
+
+1. Change directory to the `mcp_server` directory
+
+`cd graphiti/mcp_server`
+
+2. Start the service using Docker Compose
+
+`docker compose up`
+
+3. Point your MCP client to `http://localhost:8000/sse`
 
 ## Installation
 

--- a/mcp_server/docker-compose.yml
+++ b/mcp_server/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       start_period: 30s
 
   graphiti-mcp:
+    image: zepai/knowledge-graph-mcp:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds pre-built Docker image for Graphiti MCP server and updates documentation for Docker Compose usage.
> 
>   - **Docker Image**:
>     - Adds pre-built Docker image `zepai/knowledge-graph-mcp:latest` for Graphiti MCP server in `docker-compose.yml`.
>     - Updates `docker-compose.yml` to use the pre-built image instead of building from source.
>   - **Documentation**:
>     - Updates `README.md` to include instructions for using Docker Compose with the pre-built image.
>     - Adds sections for `stdio` and `sse` client configurations in `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 35f82c88e5334dece4787aaf328edd2a41f13db1. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->