### PR TITLE
Fix: Robust handling for dynamic labels during bulk ingestion

### DIFF
--- a/graphiti_core/models/nodes/node_db_queries.py
+++ b/graphiti_core/models/nodes/node_db_queries.py
@@ -31,7 +31,10 @@ EPISODIC_NODE_SAVE_BULK = """
 
 ENTITY_NODE_SAVE = """
         MERGE (n:Entity {uuid: $entity_data.uuid})
-        SET n:$($labels)
+        WITH n, $labels
+        WITH n, $labels AS labels_list
+        // Workaround: Si APOC/addLabels no está disponible, usar Cypher puro para etiquetas dinámicas
+        FOREACH (label IN CASE WHEN labels_list IS NOT NULL AND size(labels_list) > 0 THEN labels_list ELSE [] END | SET n:label)
         SET n = $entity_data
         WITH n CALL db.create.setNodeVectorProperty(n, "name_embedding", $entity_data.name_embedding)
         RETURN n.uuid AS uuid"""
@@ -39,7 +42,10 @@ ENTITY_NODE_SAVE = """
 ENTITY_NODE_SAVE_BULK = """
     UNWIND $nodes AS node
     MERGE (n:Entity {uuid: node.uuid})
-    SET n:$(node.labels)
+    WITH n, node
+    WITH n, node, node.labels AS labels_list
+    // Workaround: Si APOC/addLabels no está disponible, usar Cypher puro para etiquetas dinámicas
+    FOREACH (label IN CASE WHEN labels_list IS NOT NULL AND size(labels_list) > 0 THEN labels_list ELSE [] END | SET n:label)
     SET n = node
     WITH n, node CALL db.create.setNodeVectorProperty(n, "name_embedding", node.name_embedding)
     RETURN n.uuid AS uuid

--- a/tests/test_node_labels_bug_int.py
+++ b/tests/test_node_labels_bug_int.py
@@ -1,0 +1,99 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+from uuid import uuid4
+
+import pytest
+from unittest.mock import AsyncMock
+
+from graphiti_core.driver.driver import AsyncGraphDatabase
+from graphiti_core.embedder import EmbedderClient
+from graphiti_core.nodes import EntityNode
+from graphiti_core.utils.bulk_utils import add_nodes_and_edges_bulk
+
+NEO4J_URI = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
+NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "test")
+
+
+@pytest.fixture
+def sample_entity_node_empty_labels():
+    return EntityNode(
+        uuid=str(uuid4()),
+        name="Test Entity Empty Labels",
+        group_id="test_group_bug_empty",
+        labels=[],
+        name_embedding=[0.5] * 1024,
+        summary="Entity Summary",
+    )
+
+
+@pytest.fixture
+def sample_entity_node_none_labels():
+    return EntityNode(
+        uuid=str(uuid4()),
+        name="Test Entity None Labels",
+        group_id="test_group_bug_none",
+        labels=None,
+        name_embedding=[0.5] * 1024,
+        summary="Entity Summary",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_bulk_save_with_problematic_labels(
+    sample_entity_node_empty_labels,
+    sample_entity_node_none_labels,
+):
+    """Tests that bulk saving nodes with empty or None labels completes successfully."""
+    neo4j_driver = AsyncGraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASSWORD))
+
+    nodes_to_save = [sample_entity_node_empty_labels, sample_entity_node_none_labels]
+
+    # Mock the embedder client
+    mock_embedder = AsyncMock(spec=EmbedderClient)
+    mock_embedder.create_batch.return_value = [[0.1] * 10 for _ in nodes_to_save]
+
+    # Use the high-level bulk save function
+    await add_nodes_and_edges_bulk(
+        driver=neo4j_driver,
+        episodic_nodes=[],
+        episodic_edges=[],
+        entity_nodes=nodes_to_save,
+        entity_edges=[],
+        embedder=mock_embedder,
+    )
+
+    # Verify first node
+    retrieved_empty = await EntityNode.get_by_uuid(
+        neo4j_driver, sample_entity_node_empty_labels.uuid
+    )
+    assert retrieved_empty is not None
+    assert retrieved_empty.uuid == sample_entity_node_empty_labels.uuid
+
+    # Verify second node
+    retrieved_none = await EntityNode.get_by_uuid(
+        neo4j_driver, sample_entity_node_none_labels.uuid
+    )
+    assert retrieved_none is not None
+    assert retrieved_none.uuid == sample_entity_node_none_labels.uuid
+
+    # Cleanup
+    await sample_entity_node_empty_labels.delete(neo4j_driver)
+    await sample_entity_node_none_labels.delete(neo4j_driver)
+    await neo4j_driver.close()


### PR DESCRIPTION
This PR addresses issue #659 by making the bulk ingestion of `EntityNode` more robust.

**Problem:**
The previous implementation could fail if a node's `labels` property was `None` or an empty list, causing a `CypherError` during the query.

**Solution:**
This change uses a conditional `FOREACH` clause in the Cypher query. This ensures that labels are only applied if the `labels` list is not null and not empty, preventing errors during bulk ingestion.

**Validation:**
An integration test (`test_bulk_save_with_problematic_labels`) has been added to verify that nodes with `None` or empty `labels` can be saved successfully using the bulk ingestion mechanism.

Closes #659
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes handling of `None` or empty `labels` in `EntityNode` bulk ingestion with a conditional Cypher query and adds an integration test.
> 
>   - **Behavior**:
>     - Updates `ENTITY_NODE_SAVE` and `ENTITY_NODE_SAVE_BULK` in `node_db_queries.py` to use a conditional `FOREACH` clause for applying labels only if `labels` is not `None` or empty.
>   - **Testing**:
>     - Adds `test_bulk_save_with_problematic_labels` in `test_node_labels_bug_int.py` to verify successful saving of nodes with `None` or empty `labels`.
>     - Uses `pytest` and `AsyncMock` to simulate database interactions and validate the solution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for c6f2ca94d9f2a24e4005e9b0fa5fd32e1aca45d1. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->