### PR TITLE
REFACTOR: use env variables in docker-compose for mcp

### DIFF
--- a/mcp_server/docker-compose.yml
+++ b/mcp_server/docker-compose.yml
@@ -31,9 +31,9 @@ services:
       neo4j:
         condition: service_healthy
     environment:
-      - NEO4J_URI=bolt://neo4j:7687
-      - NEO4J_USER=neo4j
-      - NEO4J_PASSWORD=demodemo
+      - NEO4J_URI=${NEO4J_URI}
+      - NEO4J_USER=${NEO4J_USER}
+      - NEO4J_PASSWORD=${NEO4J_PASSWORD}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - MODEL_NAME=${MODEL_NAME}
       - PATH=/root/.local/bin:${PATH}

--- a/mcp_server/docker-compose.yml
+++ b/mcp_server/docker-compose.yml
@@ -31,9 +31,9 @@ services:
       neo4j:
         condition: service_healthy
     environment:
-      - NEO4J_URI=${NEO4J_URI}
-      - NEO4J_USER=${NEO4J_USER}
-      - NEO4J_PASSWORD=${NEO4J_PASSWORD}
+      - NEO4J_URI=${NEO4J_URI:-bolt://neo4j:7687}
+      - NEO4J_USER=${NEO4J_USER:-neo4j}
+      - NEO4J_PASSWORD=${NEO4J_PASSWORD:-demodemo}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - MODEL_NAME=${MODEL_NAME}
       - PATH=/root/.local/bin:${PATH}


### PR DESCRIPTION
- instead of using hardcoded values for neo4j, use it from env variable file
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces hardcoded Neo4j configuration in `docker-compose.yml` with environment variables for flexibility.
> 
>   - **Environment Variables**:
>     - Replaces hardcoded Neo4j configuration values with environment variables in `docker-compose.yml`.
>     - Uses `${NEO4J_URI}`, `${NEO4J_USER}`, and `${NEO4J_PASSWORD}` for Neo4j connection settings.
>   - **Configuration**:
>     - Ensures Neo4j settings can be configured via an external `.env` file, enhancing flexibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 188d9a9fab1aa6a5160b34241d21ecbf3141d56d. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->