### PR TITLE
Refactor: Replace dictionary responses with structured response classes in graphiti_mcp_server.py

### DIFF
--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 description = "Graphiti MCP Server"
 readme = "README.md"
 requires-python = ">=3.10,<4"


### PR DESCRIPTION
Updated the error and success responses in various functions to utilize structured response classes (ErrorResponse, SuccessResponse, FactSearchResponse, EpisodeSearchResponse, StatusResponse) for improved consistency and clarity. Incremented version in pyproject.toml to 0.2.1.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactors `graphiti_mcp_server.py` to use structured response classes for consistency and updates version to 0.2.1.
> 
>   - **Behavior**:
>     - Replaces dictionary responses with structured response classes (`ErrorResponse`, `SuccessResponse`, `FactSearchResponse`, `EpisodeSearchResponse`, `StatusResponse`) in `graphiti_mcp_server.py`.
>     - Handles cases where `graphiti_client` is not initialized, and invalid `max_facts` values in `search_memory_facts()`.
>   - **Versioning**:
>     - Updates version in `pyproject.toml` from `0.2.0` to `0.2.1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 557ad518540919ffac73b69d379f83e1dcb84d5e. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->