### PR TITLE
fix: neo4j username/password should not be hardcoded

### DIFF
--- a/mcp_server/docker-compose.yml
+++ b/mcp_server/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       - "7474:7474" # HTTP
       - "7687:7687" # Bolt
     environment:
-      - NEO4J_AUTH=neo4j/demodemo
+      - NEO4J_AUTH=${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD:-demodemo}
       - NEO4J_server_memory_heap_initial__size=512m
       - NEO4J_server_memory_heap_max__size=1G
       - NEO4J_server_memory_pagecache_size=512m


### PR DESCRIPTION
## Summary

The `neo4j` username and password are currently hardcoded in `mcp_server/docker-compose.yml`.
If `NEO4J_USER` or `NEO4J_PASSWORD` is overridden (e.g., via environment variables), the `graphiti-mcp` container will fail to start due to a mismatch in credentials between `neo4j` and `graphiti-mcp`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
**For new features and performance improvements:** Clearly describe the objective and rationale for this change.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

## Breaking Changes
- [ ] This PR contains breaking changes

If this is a breaking change, describe:
- What functionality is affected
- Migration path for existing users

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
  - Note: `uv run pyright ./graphiti_core` failed but it has nothing to do with my change
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Closes #[issue number]
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes hardcoded Neo4j credentials in `docker-compose.yml` by using environment variables for authentication.
> 
>   - **Security Fix**:
>     - Replaces hardcoded `NEO4J_AUTH` credentials in `docker-compose.yml` with environment variables `NEO4J_USER` and `NEO4J_PASSWORD`.
>     - Defaults to `neo4j/demodemo` if environment variables are not set.
>   - **Behavior**:
>     - Prevents authentication failure in `graphiti-mcp` container when custom `NEO4J_USER` or `NEO4J_PASSWORD` is set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for add878bdbba6d9ec60ae91172e10ae4b0d05b1d2. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->