### PR TITLE
Fix custom edge types not persisting to Neo4j (Issue #707)

### DIFF
--- a/graphiti_core/graph_queries.py
+++ b/graphiti_core/graph_queries.py
@@ -140,8 +140,8 @@ def get_entity_edge_save_bulk_query(db_type: str = 'neo4j') -> str:
         UNWIND $entity_edges AS edge
         MATCH (source:Entity {uuid: edge.source_node_uuid}) 
         MATCH (target:Entity {uuid: edge.target_node_uuid}) 
-        MERGE (source)-[r:RELATES_TO {uuid: edge.uuid}]->(target)
-        SET r = {uuid: edge.uuid, name: edge.name, group_id: edge.group_id, fact: edge.fact, episodes: edge.episodes, 
+        MERGE (source)-[r:RELATIONSHIP {uuid: edge.uuid}]->(target)
+        SET r = {uuid: edge.uuid, name: edge.name, relationship_type: edge.name, group_id: edge.group_id, fact: edge.fact, episodes: edge.episodes, 
         created_at: edge.created_at, expired_at: edge.expired_at, valid_at: edge.valid_at, invalid_at: edge.invalid_at, fact_embedding: vecf32(edge.fact_embedding)}
         WITH r, edge
         RETURN edge.uuid AS uuid"""

--- a/graphiti_core/models/edges/edge_db_queries.py
+++ b/graphiti_core/models/edges/edge_db_queries.py
@@ -33,7 +33,7 @@ EPISODIC_EDGE_SAVE_BULK = """
 ENTITY_EDGE_SAVE = """
         MATCH (source:Entity {uuid: $source_uuid}) 
         MATCH (target:Entity {uuid: $target_uuid}) 
-        MERGE (source)-[r:RELATES_TO {uuid: $uuid}]->(target)
+        CALL apoc.create.relationship(source, $edge_data.name, {uuid: $uuid}, target) YIELD rel as r
         SET r = $edge_data
         WITH r CALL db.create.setRelationshipVectorProperty(r, "fact_embedding", $edge_data.fact_embedding)
         RETURN r.uuid AS uuid"""
@@ -42,7 +42,7 @@ ENTITY_EDGE_SAVE_BULK = """
     UNWIND $entity_edges AS edge
     MATCH (source:Entity {uuid: edge.source_node_uuid}) 
     MATCH (target:Entity {uuid: edge.target_node_uuid}) 
-    MERGE (source)-[r:RELATES_TO {uuid: edge.uuid}]->(target)
+    CALL apoc.create.relationship(source, edge.name, {uuid: edge.uuid}, target) YIELD rel as r
     SET r = edge
     WITH r, edge CALL db.create.setRelationshipVectorProperty(r, "fact_embedding", edge.fact_embedding)
     RETURN edge.uuid AS uuid


### PR DESCRIPTION
This issue was blocking me - this is how Claude fixed it. Making a draft PR in case it helps someone else.

------ 

- Replace hardcoded :RELATES_TO with dynamic relationship types using APOC procedures in Neo4j
- Update ENTITY_EDGE_SAVE and ENTITY_EDGE_SAVE_BULK queries to use edge.name for relationship types
- Add FalkorDB support using :RELATIONSHIP type with relationship_type property
- This enables custom edge types like HOLDS_OPINION, REPORTS_OPINION, etc. to be properly stored
- Fixes the disconnect between LLM extraction (which correctly identifies custom types) and database persistence

Resolves: https://github.com/getzep/graphiti/issues/707

## Summary
Brief description of the changes in this PR.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
**For new features and performance improvements:** Clearly describe the objective and rationale for this change.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

## Breaking Changes
- [ ] This PR contains breaking changes

If this is a breaking change, describe:
- What functionality is affected
- Migration path for existing users

## Checklist
- [ ] Code follows project style guidelines (`make lint` passes)
- [ ] Self-review completed
- [ ] Documentation updated where necessary
- [ ] No secrets or sensitive information committed

## Related Issues
Closes #[issue number]