### PR TITLE
fix: update provider type mapping for VoyageAI to use 'voyageai' instead of 'voyage'

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -240,7 +240,7 @@ class Graphiti:
             return 'falkordb'
         # Embedder providers
         elif 'voyage' in class_name:
-            return 'voyage'
+            return 'voyageai'
         else:
             return 'unknown'
 


### PR DESCRIPTION
This ensures consistency between telemetry provider name and the actual extra name used in pyproject.toml, preventing confusion about which extra to install.

Resolves #728

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `_get_provider_type` in `graphiti.py` to map 'voyage' to 'voyageai', ensuring consistency with `pyproject.toml`.
> 
>   - **Behavior**:
>     - Update `_get_provider_type` in `graphiti.py` to return 'voyageai' instead of 'voyage' for class names containing 'voyage'.
>     - Ensures consistency between telemetry provider name and `pyproject.toml` extra name.
>   - **Misc**:
>     - Resolves issue #728.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 566dbb5273a47c2347634f73f2d38151ee725714. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->