### PR TITLE
fix missing attribute for self._database

### DIFF
--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -95,7 +95,7 @@ class FalkorDriver(GraphDriver):
             self.client = falkor_db
         else:
             self.client = FalkorDB(host=host, port=port, username=username, password=password)
-            self._database = database
+        self._database = database
 
     def _get_graph(self, graph_name: str | None) -> FalkorGraph:
         # FalkorDB requires a non-None database name for multi-tenant graphs; the default is "default_db"


### PR DESCRIPTION
## Summary
Brief description of the changes in this PR.

## Type of Change
- [x] Bug fix

## Objective
A Trivial change. The `self._database` is only set when db is not given (within a conditional branch), but it's used later in other member methods, e.g.

https://github.com/getzep/graphiti/blob/099dc4002532e3cc531064f0131fd228519afc6f/graphiti_core/driver/falkordb_driver.py#L106-L108

...resulting in attribute error
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes missing `_database` attribute initialization in `FalkorDriver` to prevent attribute errors.
> 
>   - **Bug Fix**:
>     - Ensure `self._database` is always set in `FalkorDriver.__init__()` in `falkordb_driver.py`, preventing attribute errors in methods like `_get_graph()` and `execute_query()`.
>     - Previously, `self._database` was only set when `falkor_db` was not provided, causing issues when accessed later.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 099dc4002532e3cc531064f0131fd228519afc6f. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->