### PR TITLE
fix: missing group filter on node ft search

### DIFF
--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -353,7 +353,7 @@ async def node_fulltext_search(
         YIELD node AS n, score
             WITH n, score
             LIMIT $limit
-            WHERE n:Entity
+            WHERE n:Entity AND n.group_id IN $group_ids
         """
         + filter_query
         + ENTITY_NODE_RETURN

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "graphiti-core"
 description = "A temporal graph building library"
-version = "0.17.7"
+version = "0.17.8"
 authors = [
     { "name" = "Paul Paliychuk", "email" = "paul@getzep.com" },
     { "name" = "Preston Rasmussen", "email" = "preston@getzep.com" },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add group filter to `node_fulltext_search()` in `search_utils.py` and update version to `0.17.8`.
> 
>   - **Behavior**:
>     - Add group filter to `node_fulltext_search()` in `search_utils.py` to filter results by `group_id`.
>   - **Versioning**:
>     - Update version in `pyproject.toml` from `0.17.7` to `0.17.8`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 1b0efe380ef7108850b29da76ce0a3da1c1b207d. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->