### PR TITLE
Bind FastMCP to All Network Interfaces for Docker Compatibility

### DIFF
--- a/mcp_server/graphiti_mcp_server.py
+++ b/mcp_server/graphiti_mcp_server.py
@@ -566,6 +566,7 @@ API keys are provided for any language model operations.
 mcp = FastMCP(
     'Graphiti Agent Memory',
     instructions=GRAPHITI_MCP_INSTRUCTIONS,
+    host='0.0.0.0',  # Bind to all interfaces
 )
 
 # Initialize Graphiti client


### PR DESCRIPTION
## Summary
This change updates the FastMCP initialization to explicitly bind the service to 0.0.0.0, allowing the application to accept incoming connections from outside the container.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
This is necessary to ensure proper network access when running the service in Docker or other containerized environments.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

## Breaking Changes
- [ ] This PR contains breaking changes

If this is a breaking change, describe:
- What functionality is affected
- Migration path for existing users

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bind `FastMCP` to `0.0.0.0` in `graphiti_mcp_server.py` for Docker compatibility.
> 
>   - **Behavior**:
>     - Update `FastMCP` initialization in `graphiti_mcp_server.py` to bind to `0.0.0.0`, allowing external connections.
>   - **Objective**:
>     - Ensures network access for Docker and container environments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 721ee18b8a7c03db3c0edfb4d12c69b743ccf336. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->