### PR TITLE
Fix Azure OpenAI configuration parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ graphiti = Graphiti(
     "neo4j",
     "password",
     llm_client=OpenAIClient(
-        llm_config=azure_llm_config,
+        config=azure_llm_config,
         client=llm_client_azure
     ),
     embedder=OpenAIEmbedder(
@@ -327,7 +327,7 @@ graphiti = Graphiti(
         client=embedding_client_azure
     ),
     cross_encoder=OpenAIRerankerClient(
-        llm_config=LLMConfig(
+        config=LLMConfig(
             model=azure_llm_config.small_model  # Use small model for reranking
         ),
         client=llm_client_azure


### PR DESCRIPTION
## Summary
- Fixed `llm_config` parameter to `config` in Azure OpenAI configuration examples
- Updated both OpenAIClient and OpenAIRerankerClient initialization examples in README
- Resolves TypeError when users follow the Azure OpenAI configuration guide

## Issue
Addresses GitHub issue #797 where users following the Azure OpenAI configuration documentation were encountering:
```
TypeError: OpenAIClient.__init__() got an unexpected keyword argument 'llm_config'
```

## Changes
- `README.md`: Fixed parameter names in Azure OpenAI example
  - Line 320: `llm_config=azure_llm_config` → `config=azure_llm_config` 
  - Line 330: `llm_config=LLMConfig(...)` → `config=LLMConfig(...)`

## Test plan
- [x] Verified parameter names match actual OpenAIClient and OpenAIRerankerClient constructors
- [x] Confirmed examples align with working code patterns in the codebase
- [x] Code review shows these changes will resolve the TypeError

Closes #797

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes parameter name in Azure OpenAI configuration examples in `README.md` to resolve a `TypeError`.
> 
>   - **Behavior**:
>     - Fixes `TypeError` in Azure OpenAI configuration by correcting parameter name from `llm_config` to `config` in `README.md`.
>   - **Documentation**:
>     - Updates `OpenAIClient` and `OpenAIRerankerClient` initialization examples in `README.md`.
>     - Changes on lines 320 and 330: `llm_config=azure_llm_config` to `config=azure_llm_config` and `llm_config=LLMConfig(...)` to `config=LLMConfig(...)`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 4d2d5b76c98273e8b966e409249ec4a52110c8c2. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->