### PR TITLE
Fix empty group_ids bug in episode_fulltext_search

### DIFF
--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -455,7 +455,7 @@ async def episode_fulltext_search(
         YIELD node AS episode, score
         MATCH (e:Episodic)
         WHERE e.uuid = episode.uuid
-        AND e.group_id IN $group_ids
+        AND (size(coalesce($group_ids, [])) = 0 OR e.group_id IN $group_ids)
         RETURN
         """
         + EPISODIC_NODE_RETURN


### PR DESCRIPTION
Fixes #801

The episode search was returning empty results when group_ids wasn't specified. Added a simple check to handle None/empty group_ids, similar to how other search functions do it.

Changed:
`AND e.group_id IN $group_ids`
to:
`AND (size(coalesce($group_ids, [])) = 0 OR e.group_id IN $group_ids)`

Tested locally and all checks pass.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `episode_fulltext_search` to handle empty `group_ids` by adjusting query condition in `search_utils.py`.
> 
>   - **Behavior**:
>     - Fixes bug in `episode_fulltext_search` in `search_utils.py` where empty `group_ids` resulted in no search results.
>     - Changes query condition to `AND (size(coalesce($group_ids, [])) = 0 OR e.group_id IN $group_ids)` to handle `None` or empty `group_ids`.
>   - **Testing**:
>     - Tested locally with all checks passing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 9fa5f2baca4f1934aed53059aff9fe68888def11. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->