### PR TITLE
docs: Update Ollama integration to use OpenAIGenericClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,25 +431,27 @@ The Gemini reranker uses the `gemini-2.5-flash-lite-preview-06-17` model by defa
 Graphiti supports Ollama for running local LLMs and embedding models via Ollama's OpenAI-compatible API. This is ideal for privacy-focused applications or when you want to avoid API costs.
 
 Install the models:
+```bash
 ollama pull deepseek-r1:7b # LLM
 ollama pull nomic-embed-text # embeddings
+```
 
 ```python
 from graphiti_core import Graphiti
 from graphiti_core.llm_client.config import LLMConfig
-from graphiti_core.llm_client.openai_client import OpenAIClient
+from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
 from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig
 from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient
 
 # Configure Ollama LLM client
 llm_config = LLMConfig(
-    api_key="abc",  # Ollama doesn't require a real API key
+    api_key="ollama",  # Ollama doesn't require a real API key, but some placeholder is needed
     model="deepseek-r1:7b",
     small_model="deepseek-r1:7b",
-    base_url="http://localhost:11434/v1", # Ollama provides this port
+    base_url="http://localhost:11434/v1",  # Ollama's OpenAI-compatible endpoint
 )
 
-llm_client = OpenAIClient(config=llm_config)
+llm_client = OpenAIGenericClient(config=llm_config)
 
 # Initialize Graphiti with Ollama clients
 graphiti = Graphiti(
@@ -459,7 +461,7 @@ graphiti = Graphiti(
     llm_client=llm_client,
     embedder=OpenAIEmbedder(
         config=OpenAIEmbedderConfig(
-            api_key="abc",
+            api_key="ollama",  # Placeholder API key
             embedding_model="nomic-embed-text",
             embedding_dim=768,
             base_url="http://localhost:11434/v1",


### PR DESCRIPTION
Updates the README.md Ollama section to use OpenAIGenericClient instead of OpenAIClient, providing better compatibility with Ollama's OpenAI-compatible API.

Changes:
- Replace OpenAIClient with OpenAIGenericClient in imports and usage
- Add bash code block formatting for model installation commands
- Update API key placeholder for clarity
- Add explanatory comments

Fixes #809

Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `README.md` to use `OpenAIGenericClient` for Ollama integration, improving compatibility and clarity.
> 
>   - **Behavior**:
>     - Replace `OpenAIClient` with `OpenAIGenericClient` in `README.md` for better compatibility with Ollama's API.
>     - Update API key placeholder to `ollama` for clarity.
>   - **Formatting**:
>     - Add bash code block formatting for model installation commands.
>     - Add explanatory comments in the Ollama section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fgraphiti&utm_source=github&utm_medium=referral)<sup> for 11f107a8b0d3dfa230e1af079155dba5c9f7aef5. You can [customize](https://app.ellipsis.dev/getzep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->