### PR TITLE
Force to use dedupe int ID from FACT INVALIDATION CANDIDATES

### DIFF
--- a/graphiti_core/prompts/dedupe_edges.py
+++ b/graphiti_core/prompts/dedupe_edges.py
@@ -73,7 +73,7 @@ def edge(context: dict[str, Any]) -> list[Message]:
         <NEW EDGE>
         {to_prompt_json(context['extracted_edges'], ensure_ascii=context.get('ensure_ascii', False), indent=2)}
         </NEW EDGE>
-        
+
         Task:
         If the New Edges represents the same factual information as any edge in Existing Edges, return the id of the duplicate fact
             as part of the list of duplicate_facts.
@@ -127,27 +127,28 @@ def resolve_edge(context: dict[str, Any]) -> list[Message]:
         <NEW FACT>
         {context['new_edge']}
         </NEW FACT>
-        
+
         <EXISTING FACTS>
         {context['existing_edges']}
         </EXISTING FACTS>
         <FACT INVALIDATION CANDIDATES>
         {context['edge_invalidation_candidates']}
         </FACT INVALIDATION CANDIDATES>
-        
+
         <FACT TYPES>
         {context['edge_types']}
         </FACT TYPES>
-        
+
 
         Task:
         If the NEW FACT represents identical factual information of one or more in EXISTING FACTS, return the idx of the duplicate facts.
         Facts with similar information that contain key differences should not be marked as duplicates.
+        When returning the idx list, ensure to use the integer id from FACT INVALIDATION CANDIDATES items, not the uuid from EXISTING FACTS.
         If the NEW FACT is not a duplicate of any of the EXISTING FACTS, return an empty list.
-        
+
         Given the predefined FACT TYPES, determine if the NEW FACT should be classified as one of these types.
         Return the fact type as fact_type or DEFAULT if NEW FACT is not one of the FACT TYPES.
-        
+
         Based on the provided FACT INVALIDATION CANDIDATES and NEW FACT, determine which existing facts the new fact contradicts.
         Return a list containing all idx's of the facts that are contradicted by the NEW FACT.
         If there are no contradicted facts, return an empty list.


### PR DESCRIPTION
## Summary
I'm parsing documentation and code with graphiti, I wrote a Bedrock (aws)  adapter to use with it, (Maybe that's why I needed to change the message) and in some cases the documentation/code is repeated and the deduplication process fails because Bedrock (Nova) returns the uuid from the entity instead of the item index from the facts candidates. Checking the dedupe code, we need always the index instead of the ID. 
Adding this extra sentence fixed the issue for me.

(The issue is when deduplicating edges)

## Type of Change
- :heavy_check_mark:   Bug fix

The model input message:
```
{'content': '\n'
            '        <NEW FACT>\n'
            '        Brand Kit includes Equal.\n'
            '        </NEW FACT>\n'
            '        \n'
            '        <EXISTING FACTS>\n'
            "        [{'id': "
            "'97a641ab-0342-4dbe-82e2-fc93eb250db9', 'fact': "
            "'Brand Kit has a subsection on Equal.'}]\n"
            '        </EXISTING FACTS>\n'
            '        <FACT INVALIDATION CANDIDATES>\n'
            "        [{'id': 0, 'fact': 'Brand Kit has a "
            "subsection on Equal.'}, {'id': 1, 'fact': "
            "'Equalizer Docs has a section on Brand Kit.'}, "
            "{'id': 2, 'fact': 'Brand Kit has a subsection on "
            "Equity.'}, {'id': 3, 'fact': 'Brand Kit has a "
            "subsection on Scale.'}]\n"
            '        </FACT INVALIDATION CANDIDATES>\n'
.....
```

Model output:
```
....
  '  "required": [\n'
  '    "duplicate_facts",\n'
  '    "contradicted_facts",\n'
  '    "fact_type"\n'
  '  ],\n'
  '  "title": "EdgeDuplicate",\n'
  '  "type": "object",\n'
  '  "duplicate_facts": '
  '[97a641ab-0342-4dbe-82e2-fc93eb250db9],\n' <= this makes raise a json issue for missing quotes (that's how I found the issue)
  '  "contradicted_facts": [],\n'
  '  "fact_type": "DEFAULT"\n'
```

## Testing
- :heavy_check_mark:  All existing tests pass
(Would be great if somebody could test this for other models)

## Breaking Changes
- :x:  This PR contains breaking changes

## Checklist
- :heavy_check_mark:   Code follows project style guidelines (`make lint` passes)
- :heavy_check_mark:  Self-review completed
- :heavy_check_mark:  Documentation updated where necessary
- :heavy_check_mark:  No secrets or sensitive information committed