### PR TITLE
fix: graphiti search only connect with default db 'neo4j'  and  custom database config invalid

### DIFF
--- a/graphiti_core/driver/neo4j_driver.py
+++ b/graphiti_core/driver/neo4j_driver.py
@@ -38,17 +38,20 @@ class Neo4jDriver(GraphDriver):
         self._database = database
 
     async def execute_query(self, cypher_query_: LiteralString, **kwargs: Any) -> EagerResult:
-        # Check if database_ is provided in kwargs.
-        # If not populated, set the value to retain backwards compatibility
+        # Extract database from kwargs or use default
+        database = kwargs.pop('database_', self._database)
         params = kwargs.pop('params', None)
         if params is None:
             params = {}
-        params.setdefault('database_', self._database)
 
         try:
-            result = await self.client.execute_query(cypher_query_, parameters_=params, **kwargs)
+            result = await self.client.execute_query(
+                cypher_query_, parameters_=params, database_=database, **kwargs
+            )
         except Exception as e:
-            logger.error(f'Error executing Neo4j query: {e}\n{cypher_query_}\n{params}')
+            logger.error(
+                f'Error executing Neo4j query: {e}\n{cypher_query_}\nDatabase: {database}\nParams: {params}'
+            )
             raise
 
         return result


### PR DESCRIPTION
  ## Summary
  Fixes Neo4j driver to properly handle custom database configurations. The driver now correctly passes the database parameter
  instead of hardcoding the default 'neo4j' database name.

  ## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Performance improvement
  - [ ] Documentation/Tests

  ## Objective
  **For new features and performance improvements:** N/A - This is a bug fix.

  ## Testing
  - [x] Unit tests added/updated
  - [x] Integration tests added/updated
  - [x] All existing tests pass

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
  - [x] Code follows project style guidelines (`make lint` passes)
  - [x] Self-review completed
  - [x] Documentation updated where necessary
  - [x] No secrets or sensitive information committed


## Related Issues
#851