### PR TITLE
Add FalkorDB support for docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,14 @@ COPY ./server/graph_service ./graph_service
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 
+# Install falkordb if requested
+ARG INSTALL_FALKORDB=false
+RUN --mount=type=cache,target=/root/.cache/uv \
+    if [ "$INSTALL_FALKORDB" = "true" ]; then \
+        WHEEL=$(ls /tmp/*.whl | head -n 1); \
+        uv pip install "$WHEEL[falkordb]"; \
+    fi
+
 # Change ownership to app user
 RUN chown -R app:app /app
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,22 @@ The quickstart demonstrates:
 The example is fully documented with clear explanations of each functionality and includes a comprehensive README with
 setup instructions and next steps.
 
+### Running with Docker Compose
+
+You can use Docker Compose to quickly start the required services:
+
+- **Neo4j Docker:**
+  ```sh
+  docker compose up
+  ```
+  This will start the Neo4j Docker service and related components.
+
+- **FalkorDB Docker:**
+  ```sh
+  docker compose --profile falkordb up
+  ```
+  This will start the FalkorDB Docker service and related components.
+
 ## MCP Server
 
 The `mcp_server` directory contains a Model Context Protocol (MCP) server implementation for Graphiti. This server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   graph:
+    profiles: [""]
     build:
       context: .
     ports:
@@ -24,8 +25,10 @@ services:
       - NEO4J_USER=${NEO4J_USER}
       - NEO4J_PASSWORD=${NEO4J_PASSWORD}
       - PORT=8000
+      - db_backend=neo4j
   neo4j:
     image: neo4j:5.26.2
+    profiles: [""]
     healthcheck:
       test:
         [
@@ -44,5 +47,46 @@ services:
     environment:
       - NEO4J_AUTH=${NEO4J_USER}/${NEO4J_PASSWORD}
 
+  falkordb:
+    image: falkordb/falkordb:latest
+    profiles: ["falkordb"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - falkordb_data:/data
+    environment:
+      - FALKORDB_ARGS=--port 6379 --cluster-enabled no
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6379", "ping"]
+      interval: 1s
+      timeout: 10s
+      retries: 10
+      start_period: 3s
+  graph-falkordb:
+    build:
+      args:
+        INSTALL_FALKORDB: "true"
+      context: .
+    profiles: ["falkordb"]
+    ports:
+      - "8001:8001"
+    depends_on:
+      falkordb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/healthcheck')"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - FALKORDB_HOST=falkordb
+      - FALKORDB_PORT=6379
+      - FALKORDB_DATABASE=default_db
+      - GRAPHITI_BACKEND=falkordb
+      - PORT=8001
+      - db_backend=falkordb
+
 volumes:
   neo4j_data:
+  falkordb_data:


### PR DESCRIPTION
## Summary
adding FalkorDB Docker Compose support to Graphiti. The changes enable users to run Graphiti with FalkorDB as an alternative graph database backend using Docker profiles.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
**For new features and performance improvements:** Clearly describe the objective and rationale for this change.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

## Breaking Changes
- [ ] This PR contains breaking changes

If this is a breaking change, describe:
- What functionality is affected
- Migration path for existing users

## Checklist
- [ ] Code follows project style guidelines (`make lint` passes)
- [ ] Self-review completed
- [ ] Documentation updated where necessary
- [ ] No secrets or sensitive information committed

## Related Issues
Closes #[issue number]