### PR TITLE
feat(mcp): Add configurable similarity thresholds

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -101,6 +101,8 @@ The server uses the following environment variables:
 - `AZURE_OPENAI_EMBEDDING_API_VERSION`: Optional Azure OpenAI API version
 - `AZURE_OPENAI_USE_MANAGED_IDENTITY`: Optional use Azure Managed Identities for authentication
 - `SEMAPHORE_LIMIT`: Episode processing concurrency. See [Concurrency and LLM Provider 429 Rate Limit Errors](#concurrency-and-llm-provider-429-rate-limit-errors)
+- `GRAPHITI_MIN_SIMILARITY_SCORE`: Minimum similarity score for semantic search (default: `0.6`, range: 0.0-1.0). Higher values filter more aggressively.
+- `GRAPHITI_RERANKER_MIN_SCORE`: Minimum score after RRF fusion (default: `0.0`). Typically left at 0.0 as RRF is rank-based.
 
 You can set these variables in a `.env` file in the project directory.
 

--- a/mcp_server/graphiti_mcp_server.py
+++ b/mcp_server/graphiti_mcp_server.py
@@ -864,6 +864,17 @@ async def search_memory_nodes(
             search_config = NODE_HYBRID_SEARCH_RRF.model_copy(deep=True)
         search_config.limit = max_nodes
 
+        # Apply configurable similarity thresholds from environment
+        # sim_min_score filters during initial semantic search (recommended to tune for your domain)
+        sim_min_score = float(os.getenv('GRAPHITI_MIN_SIMILARITY_SCORE', '0.6'))
+        # reranker_min_score filters after RRF fusion (recommended to keep at 0.0 per industry consensus,
+        # as RRF is rank-based and doesn't require score thresholds)
+        reranker_min_score = float(os.getenv('GRAPHITI_RERANKER_MIN_SCORE', '0.0'))
+
+        if search_config.node_config:
+            search_config.node_config.sim_min_score = sim_min_score
+        search_config.reranker_min_score = reranker_min_score
+
         filters = SearchFilters()
         if entity != '':
             filters.node_labels = [entity]


### PR DESCRIPTION
## Description
Adds environment variable configuration for search similarity thresholds in the MCP server, allowing users to tune search quality for their specific domain.

## Motivation
Different domains benefit from different similarity thresholds. During testing with scientific documentation, I found that the default 0.6 threshold returned too many tangentially related results. Increasing to 0.8 provided much better precision while maintaining good recall.

## Changes
- Added `GRAPHITI_MIN_SIMILARITY_SCORE` env var (default: 0.6) to control semantic search filtering
- Added `GRAPHITI_RERANKER_MIN_SCORE` env var (default: 0.0) to control post-RRF filtering  
- Updated README with configuration documentation
- Added inline comments explaining best practices (keep reranker at 0.0 per industry consensus on RRF)

## Testing
Tested locally with various thresholds (0.5, 0.6, 0.7, 0.8) on a scientific dataset. Found 0.8 optimal for filtering noise while preserving relevant matches.

## Backward Compatibility
Fully backward compatible - defaults preserve existing behavior.