### PR TITLE
Refactor batch deduplication logic to enhance node resolution and track duplicate pairs (#929)

### DIFF
--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -306,6 +306,8 @@ async def _resolve_with_llm(
 
         state.resolved_nodes[original_index] = resolved_node
         state.uuid_map[extracted_node.uuid] = resolved_node.uuid
+        if resolved_node.uuid != extracted_node.uuid:
+            state.duplicate_pairs.append((extracted_node, resolved_node))
 
 
 async def resolve_extracted_nodes(
@@ -332,7 +334,6 @@ async def resolve_extracted_nodes(
         uuid_map={},
         unresolved_indices=[],
     )
-    node_duplicates: list[tuple[EntityNode, EntityNode]] = []
 
     _resolve_with_similarity(extracted_nodes, indexes, state)
 
@@ -359,7 +360,7 @@ async def resolve_extracted_nodes(
 
     new_node_duplicates: list[
         tuple[EntityNode, EntityNode]
-    ] = await filter_existing_duplicate_of_edges(driver, node_duplicates)
+    ] = await filter_existing_duplicate_of_edges(driver, state.duplicate_pairs)
 
     return (
         [node for node in state.resolved_nodes if node is not None],

--- a/tests/utils/maintenance/test_bulk_utils.py
+++ b/tests/utils/maintenance/test_bulk_utils.py
@@ -1,0 +1,87 @@
+from collections import deque
+from unittest.mock import MagicMock
+
+import pytest
+
+from graphiti_core.graphiti_types import GraphitiClients
+from graphiti_core.nodes import EntityNode, EpisodeType, EpisodicNode
+from graphiti_core.utils import bulk_utils
+from graphiti_core.utils.datetime_utils import utc_now
+
+
+def _make_episode(uuid_suffix: str, group_id: str = 'group') -> EpisodicNode:
+    return EpisodicNode(
+        name=f'episode-{uuid_suffix}',
+        group_id=group_id,
+        labels=[],
+        source=EpisodeType.message,
+        content='content',
+        source_description='test',
+        created_at=utc_now(),
+        valid_at=utc_now(),
+    )
+
+
+def _make_clients() -> GraphitiClients:
+    driver = MagicMock()
+    embedder = MagicMock()
+    cross_encoder = MagicMock()
+    llm_client = MagicMock()
+
+    return GraphitiClients.model_construct(  # bypass validation to allow test doubles
+        driver=driver,
+        embedder=embedder,
+        cross_encoder=cross_encoder,
+        llm_client=llm_client,
+        ensure_ascii=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dedupe_nodes_bulk_reuses_canonical_nodes(monkeypatch):
+    clients = _make_clients()
+
+    episode_one = _make_episode('1')
+    episode_two = _make_episode('2')
+
+    extracted_one = EntityNode(name='Alice Smith', group_id='group', labels=['Entity'])
+    extracted_two = EntityNode(name='Alice Smith', group_id='group', labels=['Entity'])
+
+    canonical = extracted_one
+
+    call_queue = deque()
+
+    async def fake_resolve(
+        clients_arg,
+        nodes_arg,
+        episode_arg,
+        previous_episodes_arg,
+        entity_types_arg,
+        existing_nodes_override=None,
+    ):
+        call_queue.append(existing_nodes_override)
+
+        if nodes_arg == [extracted_one]:
+            return [canonical], {canonical.uuid: canonical.uuid}, []
+
+        assert nodes_arg == [extracted_two]
+        assert existing_nodes_override is not None
+        assert existing_nodes_override[0] is canonical
+
+        return [canonical], {extracted_two.uuid: canonical.uuid}, [(extracted_two, canonical)]
+
+    monkeypatch.setattr(bulk_utils, 'resolve_extracted_nodes', fake_resolve)
+
+    nodes_by_episode, compressed_map = await bulk_utils.dedupe_nodes_bulk(
+        clients,
+        [[extracted_one], [extracted_two]],
+        [(episode_one, []), (episode_two, [])],
+    )
+
+    assert len(call_queue) == 2
+    assert call_queue[0] is None
+    assert list(call_queue[1]) == [canonical]
+
+    assert nodes_by_episode[episode_one.uuid] == [canonical]
+    assert nodes_by_episode[episode_two.uuid] == [canonical]
+    assert compressed_map.get(extracted_two.uuid) == canonical.uuid

--- a/tests/utils/maintenance/test_node_operations.py
+++ b/tests/utils/maintenance/test_node_operations.py
@@ -257,6 +257,7 @@ def test_resolve_with_similarity_exact_match_updates_state():
     assert state.resolved_nodes[0].uuid == candidate.uuid
     assert state.uuid_map[extracted.uuid] == candidate.uuid
     assert state.unresolved_indices == []
+    assert state.duplicate_pairs == [(extracted, candidate)]
 
 
 def test_resolve_with_similarity_low_entropy_defers_resolution():
@@ -274,6 +275,7 @@ def test_resolve_with_similarity_low_entropy_defers_resolution():
 
     assert state.resolved_nodes[0] is None
     assert state.unresolved_indices == [0]
+    assert state.duplicate_pairs == []
 
 
 def test_resolve_with_similarity_multiple_exact_matches_defers_to_llm():
@@ -288,6 +290,7 @@ def test_resolve_with_similarity_multiple_exact_matches_defers_to_llm():
 
     assert state.resolved_nodes[0] is None
     assert state.unresolved_indices == [0]
+    assert state.duplicate_pairs == []
 
 
 @pytest.mark.asyncio
@@ -339,3 +342,4 @@ async def test_resolve_with_llm_updates_unresolved(monkeypatch):
     assert state.uuid_map[extracted.uuid] == candidate.uuid
     assert captured_context['existing_nodes'][0]['idx'] == 0
     assert isinstance(captured_context['existing_nodes'], list)
+    assert state.duplicate_pairs == [(extracted, candidate)]


### PR DESCRIPTION
* Simplify deduplication process in bulk_utils by reusing canonical nodes.
* Update dedup_helpers to store duplicate pairs during resolution.
* Modify node_operations to append duplicate pairs when resolving nodes.
* Add tests to verify deduplication behavior and ensure correct state updates.

## Summary
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
**For new features and performance improvements:** Clearly describe the objective and rationale for this change.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

## Breaking Changes
- [ ] This PR contains breaking changes

If this is a breaking change, describe:
- What functionality is affected
- Migration path for existing users

## Checklist
- [ ] Code follows project style guidelines (`make lint` passes)
- [ ] Self-review completed
- [ ] Documentation updated where necessary
- [ ] No secrets or sensitive information committed

## Related Issues
Closes #[issue number]