### PR TITLE
Fix index out of range errors in LLM deduplication responses

### DIFF
--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -241,7 +241,11 @@ async def _resolve_with_llm(
     previous_episodes: list[EpisodicNode] | None,
     entity_types: dict[str, type[BaseModel]] | None,
 ) -> None:
-    """Escalate unresolved nodes to the dedupe prompt so the LLM can select or reject duplicates."""
+    """Escalate unresolved nodes to the dedupe prompt so the LLM can select or reject duplicates.
+
+    The guardrails below defensively ignore malformed or duplicate LLM responses so the
+    ingestion workflow remains deterministic even when the model misbehaves.
+    """
     if not state.unresolved_indices:
         return
 

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -291,18 +291,41 @@ async def _resolve_with_llm(
 
     node_resolutions: list[NodeDuplicate] = NodeResolutions(**llm_response).entity_resolutions
 
+    valid_relative_range = range(len(state.unresolved_indices))
+    processed_relative_ids: set[int] = set()
+
     for resolution in node_resolutions:
         relative_id: int = resolution.id
         duplicate_idx: int = resolution.duplicate_idx
 
+        if relative_id not in valid_relative_range:
+            logger.warning(
+                'Skipping invalid LLM dedupe id %s (unresolved indices: %s)',
+                relative_id,
+                state.unresolved_indices,
+            )
+            continue
+
+        if relative_id in processed_relative_ids:
+            logger.warning('Duplicate LLM dedupe id %s received; ignoring.', relative_id)
+            continue
+        processed_relative_ids.add(relative_id)
+
         original_index = state.unresolved_indices[relative_id]
         extracted_node = extracted_nodes[original_index]
 
-        resolved_node = (
-            indexes.existing_nodes[duplicate_idx]
-            if 0 <= duplicate_idx < len(indexes.existing_nodes)
-            else extracted_node
-        )
+        resolved_node: EntityNode
+        if duplicate_idx == -1:
+            resolved_node = extracted_node
+        elif 0 <= duplicate_idx < len(indexes.existing_nodes):
+            resolved_node = indexes.existing_nodes[duplicate_idx]
+        else:
+            logger.warning(
+                'Invalid duplicate_idx %s for extracted node %s; treating as no duplicate.',
+                duplicate_idx,
+                extracted_node.uuid,
+            )
+            resolved_node = extracted_node
 
         state.resolved_nodes[original_index] = resolved_node
         state.uuid_map[extracted_node.uuid] = resolved_node.uuid


### PR DESCRIPTION
**Fixes crashes caused by malformed LLM responses during node deduplication.**

### Problem
The LLM deduplication process could crash with "index out of range" errors when the model returned:
- Invalid relative IDs outside the unresolved indices range
- Duplicate relative IDs in the same response  
- Invalid duplicate indices referencing non-existent nodes

### Solution
Added defensive validation that:
- Skips invalid relative IDs with warning logs
- Ignores duplicate relative IDs (processes only the first occurrence)
- Defaults to extracted node when duplicate_idx is out of range
- Maintains deterministic behavior even with malformed responses

### Testing
Added comprehensive tests covering all error scenarios to ensure robust handling of LLM response edge cases.