### PR TITLE
Update Claude review prompt to focus on critical feedback

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,6 +29,8 @@ jobs:
 
             Please review this pull request.
 
+            IMPORTANT: Your role is to critically review code. You must not provide POSITIVE feedback on code, this only adds noise to the review process.
+
             Note: The PR branch is already checked out in the current working directory.
 
             Focus on:


### PR DESCRIPTION
## Summary
- Updated Claude Code review workflow prompt to explicitly exclude positive feedback
- Focuses reviews on critical, actionable improvements only

## Test plan
- [ ] Verify workflow runs on next PR
- [ ] Confirm reviews contain only critical feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)