### PR TITLE
fix: Improve deduplication ID validation and logging

### DIFF
--- a/graphiti_core/prompts/dedupe_nodes.py
+++ b/graphiti_core/prompts/dedupe_nodes.py
@@ -166,7 +166,9 @@ def nodes(context: dict[str, Any]) -> list[Message]:
         - They have similar names or purposes but refer to separate instances or concepts.
 
         Task:
-        Respond with a JSON object that contains an "entity_resolutions" array with one entry for each entity in ENTITIES, ordered by the entity id.
+        ENTITIES contains {len(context['extracted_nodes'])} entities with IDs 0 through {len(context['extracted_nodes']) - 1}.
+        Respond with a JSON object that contains an "entity_resolutions" array with EXACTLY {len(context['extracted_nodes'])} entries - one for each entity in ENTITIES.
+        Your response MUST use only the IDs 0 through {len(context['extracted_nodes']) - 1}. Do not skip any IDs or use IDs outside this range.
 
         For every entity, return an object with the following keys:
         {{

--- a/graphiti_core/prompts/dedupe_nodes.py
+++ b/graphiti_core/prompts/dedupe_nodes.py
@@ -167,8 +167,7 @@ def nodes(context: dict[str, Any]) -> list[Message]:
 
         Task:
         ENTITIES contains {len(context['extracted_nodes'])} entities with IDs 0 through {len(context['extracted_nodes']) - 1}.
-        Respond with a JSON object that contains an "entity_resolutions" array with EXACTLY {len(context['extracted_nodes'])} entries - one for each entity in ENTITIES.
-        Your response MUST use only the IDs 0 through {len(context['extracted_nodes']) - 1}. Do not skip any IDs or use IDs outside this range.
+        Your response MUST include EXACTLY {len(context['extracted_nodes'])} resolutions using these exact IDs (0 through {len(context['extracted_nodes']) - 1}). Do not skip IDs or use IDs outside this range.
 
         For every entity, return an object with the following keys:
         {{

--- a/graphiti_core/prompts/dedupe_nodes.py
+++ b/graphiti_core/prompts/dedupe_nodes.py
@@ -167,7 +167,7 @@ def nodes(context: dict[str, Any]) -> list[Message]:
 
         Task:
         ENTITIES contains {len(context['extracted_nodes'])} entities with IDs 0 through {len(context['extracted_nodes']) - 1}.
-        Your response MUST include EXACTLY {len(context['extracted_nodes'])} resolutions using these exact IDs (0 through {len(context['extracted_nodes']) - 1}). Do not skip IDs or use IDs outside this range.
+        Your response MUST include EXACTLY {len(context['extracted_nodes'])} resolutions with IDs 0 through {len(context['extracted_nodes']) - 1}. Do not skip or add IDs.
 
         For every entity, return an object with the following keys:
         {{

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -274,7 +274,7 @@ async def _resolve_with_llm(
         'Sending %d entities to LLM for deduplication with IDs 0-%d (actual IDs sent: %s)',
         len(llm_extracted_nodes),
         len(llm_extracted_nodes) - 1,
-        sent_ids if len(sent_ids) <= 20 else f'{sent_ids[:10]}...{sent_ids[-10:]}',
+        sent_ids if len(sent_ids) < 20 else f'{sent_ids[:10]}...{sent_ids[-10:]}',
     )
     if llm_extracted_nodes:
         sample_size = min(3, len(extracted_nodes_context))

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -328,9 +328,8 @@ async def _resolve_with_llm(
     extra_ids = received_ids - expected_ids
 
     logger.debug(
-        'Received %d resolutions for %d entities (expected %d)',
+        'Received %d resolutions for %d entities',
         len(node_resolutions),
-        len(state.unresolved_indices),
         len(state.unresolved_indices),
     )
 


### PR DESCRIPTION
## Summary
- Enhanced logging to verify IDs sent to LLM match expected range (0 through N-1)
- Strengthened deduplication prompt with explicit ID bounds
- Added validation warnings when LLM returns missing or extra IDs
- Improved error message clarity for invalid dedupe ID scenarios

## Context
Users were seeing errors like:
```
Skipping invalid LLM dedupe id 19 (unresolved indices: [1, 2, 3, 4, 5, 6, 9, 10, 11, 12, 13, 15, 16, 18, 19, 20, 21, 23, 24])
```

The error message was confusing - it showed the original indices but not the valid relative ID range (0-18).

## Changes

### 1. Pre-LLM Logging (node_operations.py:272-291)
- Logs all IDs being sent to LLM (or first/last 10 if >20 entities)
- Shows sample entities with their assigned IDs
- Helps verify no index leakage or gaps

### 2. Post-LLM Validation (node_operations.py:323-340)
- Calculates missing IDs (expected but not received)
- Calculates extra IDs (received but invalid)
- Warns when LLM skips entities or returns invalid IDs
- Shows complete list of returned IDs for comparison

### 3. Improved Error Messages (node_operations.py:347-352)
**Before:**
```
Skipping invalid LLM dedupe id 19 (unresolved indices: [1, 2, 3, ...])
```

**After:**
```
Skipping invalid LLM dedupe id 19 (valid range: 0-18, received 20 resolutions)
LLM returned invalid IDs outside valid range 0-18: [19] (all returned IDs: [0, 1, 2, ..., 19])
```

### 4. Strengthened Prompt (dedupe_nodes.py:169-171)
Added explicit instructions:
- "ENTITIES contains {N} entities with IDs 0 through {N-1}"
- "Your response MUST use only the IDs 0 through {N-1}"
- "Do not skip any IDs or use IDs outside this range"

## Test plan
- [x] All 23 existing tests pass
- [x] Verified logging shows correct ID ranges
- [x] Error messages are more actionable
- [x] Prompt explicitly bounds ID range

## Expected Impact
- Better diagnostics for debugging LLM deduplication issues
- Reduced LLM confusion about valid ID ranges
- Clearer error messages for end users

🤖 Generated with [Claude Code](https://claude.com/claude-code)