### PR TITLE
Refactor summary prompts to use character limit and prevent meta-commentary

### DIFF
--- a/graphiti_core/prompts/extract_nodes.py
+++ b/graphiti_core/prompts/extract_nodes.py
@@ -20,47 +20,44 @@ from pydantic import BaseModel, Field
 
 from .models import Message, PromptFunction, PromptVersion
 from .prompt_helpers import to_prompt_json
+from .snippets import summary_instructions
 
 
 class ExtractedEntity(BaseModel):
-    name: str = Field(..., description="Name of the extracted entity")
+    name: str = Field(..., description='Name of the extracted entity')
     entity_type_id: int = Field(
-        description="ID of the classified entity type. "
-        "Must be one of the provided entity_type_id integers.",
+        description='ID of the classified entity type. '
+        'Must be one of the provided entity_type_id integers.',
     )
 
 
 class ExtractedEntities(BaseModel):
-    extracted_entities: list[ExtractedEntity] = Field(
-        ..., description="List of extracted entities"
-    )
+    extracted_entities: list[ExtractedEntity] = Field(..., description='List of extracted entities')
 
 
 class MissedEntities(BaseModel):
-    missed_entities: list[str] = Field(
-        ..., description="Names of entities that weren't extracted"
-    )
+    missed_entities: list[str] = Field(..., description="Names of entities that weren't extracted")
 
 
 class EntityClassificationTriple(BaseModel):
-    uuid: str = Field(description="UUID of the entity")
-    name: str = Field(description="Name of the entity")
+    uuid: str = Field(description='UUID of the entity')
+    name: str = Field(description='Name of the entity')
     entity_type: str | None = Field(
         default=None,
-        description="Type of the entity. Must be one of the provided types or None",
+        description='Type of the entity. Must be one of the provided types or None',
     )
 
 
 class EntityClassification(BaseModel):
     entity_classifications: list[EntityClassificationTriple] = Field(
-        ..., description="List of entities classification triples."
+        ..., description='List of entities classification triples.'
     )
 
 
 class EntitySummary(BaseModel):
     summary: str = Field(
         ...,
-        description="Summary containing the important information about the entity. Under 8 sentences.",
+        description='Summary containing the important information about the entity. Under 250 characters.',
     )
 
 
@@ -128,8 +125,8 @@ reference entities. Only extract distinct entities from the CURRENT MESSAGE. Don
 {context['custom_prompt']}
 """
     return [
-        Message(role="system", content=sys_prompt),
-        Message(role="user", content=user_prompt),
+        Message(role='system', content=sys_prompt),
+        Message(role='user', content=user_prompt),
     ]
 
 
@@ -161,8 +158,8 @@ Guidelines:
 3. Do NOT extract any properties that contain dates
 """
     return [
-        Message(role="system", content=sys_prompt),
-        Message(role="user", content=user_prompt),
+        Message(role='system', content=sys_prompt),
+        Message(role='user', content=user_prompt),
     ]
 
 
@@ -192,8 +189,8 @@ Guidelines:
 4. Be as explicit as possible in your node names, using full names and avoiding abbreviations.
 """
     return [
-        Message(role="system", content=sys_prompt),
-        Message(role="user", content=user_prompt),
+        Message(role='system', content=sys_prompt),
+        Message(role='user', content=user_prompt),
     ]
 
 
@@ -216,8 +213,8 @@ Given the above previous messages, current message, and list of extracted entiti
 extracted.
 """
     return [
-        Message(role="system", content=sys_prompt),
-        Message(role="user", content=user_prompt),
+        Message(role='system', content=sys_prompt),
+        Message(role='user', content=user_prompt),
     ]
 
 
@@ -248,19 +245,19 @@ def classify_nodes(context: dict[str, Any]) -> list[Message]:
     3. If none of the provided entity types accurately classify an extracted node, the type should be set to None
 """
     return [
-        Message(role="system", content=sys_prompt),
-        Message(role="user", content=user_prompt),
+        Message(role='system', content=sys_prompt),
+        Message(role='user', content=user_prompt),
     ]
 
 
 def extract_attributes(context: dict[str, Any]) -> list[Message]:
     return [
         Message(
-            role="system",
-            content="You are a helpful assistant that extracts entity properties from the provided text.",
+            role='system',
+            content='You are a helpful assistant that extracts entity properties from the provided text.',
         ),
         Message(
-            role="user",
+            role='user',
             content=f"""
 
         <MESSAGES>
@@ -286,11 +283,11 @@ def extract_attributes(context: dict[str, Any]) -> list[Message]:
 def extract_summary(context: dict[str, Any]) -> list[Message]:
     return [
         Message(
-            role="system",
-            content="You are a helpful assistant that extracts entity summaries from the provided text.",
+            role='system',
+            content='You are a helpful assistant that extracts entity summaries from the provided text.',
         ),
         Message(
-            role="user",
+            role='user',
             content=f"""
 
         <MESSAGES>
@@ -301,11 +298,7 @@ def extract_summary(context: dict[str, Any]) -> list[Message]:
         Given the above MESSAGES and the following ENTITY, update the summary that combines relevant information about the entity
         from the messages and relevant information from the existing summary.
         
-        Guidelines:
-        1. Do not hallucinate entity summary information if they cannot be found in the current context.
-        2. Only use the provided MESSAGES and ENTITY to set attribute values.
-        3. The summary attribute represents a summary of the ENTITY, and should be updated with new information about the Entity from the MESSAGES. 
-        4. Keep the summary concise and to the point. SUMMARIES MUST BE LESS THAN 8 SENTENCES.
+        {summary_instructions}
 
         <ENTITY>
         {context['node']}
@@ -316,11 +309,11 @@ def extract_summary(context: dict[str, Any]) -> list[Message]:
 
 
 versions: Versions = {
-    "extract_message": extract_message,
-    "extract_json": extract_json,
-    "extract_text": extract_text,
-    "reflexion": reflexion,
-    "extract_summary": extract_summary,
-    "classify_nodes": classify_nodes,
-    "extract_attributes": extract_attributes,
+    'extract_message': extract_message,
+    'extract_json': extract_json,
+    'extract_text': extract_text,
+    'reflexion': reflexion,
+    'extract_summary': extract_summary,
+    'classify_nodes': classify_nodes,
+    'extract_attributes': extract_attributes,
 }

--- a/graphiti_core/prompts/prompt_helpers.py
+++ b/graphiti_core/prompts/prompt_helpers.py
@@ -1,3 +1,19 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import json
 from typing import Any
 

--- a/graphiti_core/prompts/snippets.py
+++ b/graphiti_core/prompts/snippets.py
@@ -1,5 +1,20 @@
-summary_instructions = """
-        Guidelines:
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+summary_instructions = """Guidelines:
         1. Output only factual content. Never explain what you're doing, why, or mention limitations/constraints. 
         2. Only use the provided messages, entity, and entity context to set attribute values.
         3. Keep the summary concise and to the point. STATE FACTS DIRECTLY IN UNDER 250 CHARACTERS.

--- a/graphiti_core/prompts/snippets.py
+++ b/graphiti_core/prompts/snippets.py
@@ -1,0 +1,14 @@
+summary_instructions = """
+        Guidelines:
+        1. Output only factual content. Never explain what you're doing, why, or mention limitations/constraints. 
+        2. Only use the provided messages, entity, and entity context to set attribute values.
+        3. Keep the summary concise and to the point. STATE FACTS DIRECTLY IN UNDER 250 CHARACTERS.
+
+        Example summaries:
+        BAD: "This is the only activity in the context. The user listened to this song. No other details were provided to include in this summary."
+        GOOD: "User played 'Blue Monday' by New Order (electronic genre) on 2024-12-03 at 14:22 UTC."
+        BAD: "Based on the messages provided, the user attended a meeting. This summary focuses on that event as it was the main topic discussed."
+        GOOD: "User attended Q3 planning meeting with sales team on March 15."
+        BAD: "The context shows John ordered pizza. Due to length constraints, other details are omitted from this summary."
+        GOOD: "John ordered pepperoni pizza from Mario's at 7:30 PM, delivered to office."
+        """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "graphiti-core"
 description = "A temporal graph building library"
-version = "0.22.0pre1"
+version = "0.22.0pre2"
 authors = [
     { name = "Paul Paliychuk", email = "paul@getzep.com" },
     { name = "Preston Rasmussen", email = "preston@getzep.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -783,7 +783,7 @@ wheels = [
 
 [[package]]
 name = "graphiti-core"
-version = "0.22.0rc0"
+version = "0.22.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
## Summary
- Changed summary length constraint from "8 sentences" to "250 characters" for more predictable output length
- Created reusable `summary_instructions` snippet in `snippets.py` with clear BAD/GOOD examples to prevent meta-commentary
- Added explicit instruction to output only factual content without explaining limitations or constraints
- Applied consistent formatting across `extract_nodes.py` and `summarize_nodes.py`
- Bumped version to `0.22.0pre2`

## Test plan
- [ ] Run test suite to verify LLM outputs still conform to expected schemas
- [ ] Test with sample data to ensure summaries stay under 250 characters
- [ ] Verify summaries no longer contain meta-commentary like "Based on the messages provided..." or "Due to length constraints..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)