### PR TITLE
feat(mcp): separate LLM and embedder endpoints 

### DIFF
--- a/mcp_server/.env.example
+++ b/mcp_server/.env.example
@@ -11,6 +11,12 @@ NEO4J_PASSWORD=demodemo
 OPENAI_API_KEY=your_openai_api_key_here
 MODEL_NAME=gpt-4.1-mini
 
+# Embedding Service Configuration (Optional)  
+# Use these to configure a separate embedding service (e.g., Ollama, Voyage, or custom OpenAI-compatible service)  
+# EMBEDDER_API_KEY=your_embedder_api_key_here  # Defaults to OPENAI_API_KEY if not set  
+# EMBEDDER_BASE_URL=http://localhost:11434/v1  # For Ollama or other OpenAI-compatible endpoints  
+# EMBEDDER_MODEL_NAME=nomic-embed-text          # Model name for embedding service  
+  
 # Optional: Only needed for non-standard OpenAI endpoints
 # OPENAI_BASE_URL=https://api.openai.com/v1
 

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -92,6 +92,9 @@ The server uses the following environment variables:
 - `MODEL_NAME`: OpenAI model name to use for LLM operations.
 - `SMALL_MODEL_NAME`: OpenAI model name to use for smaller LLM operations.
 - `LLM_TEMPERATURE`: Temperature for LLM responses (0.0-2.0).
+- `EMBEDDER_API_KEY`: Optional API key for embedding service (defaults to OPENAI_API_KEY if not set)  
+- `EMBEDDER_BASE_URL`: Optional base URL for embedding service (e.g., http://localhost:11434/v1 for Ollama)  
+- `EMBEDDER_MODEL_NAME`: Embedding model name (default: text-embedding-3-small) 
 - `AZURE_OPENAI_ENDPOINT`: Optional Azure OpenAI LLM endpoint URL
 - `AZURE_OPENAI_DEPLOYMENT_NAME`: Optional Azure OpenAI LLM deployment name
 - `AZURE_OPENAI_API_VERSION`: Optional Azure OpenAI LLM API version

--- a/mcp_server/docker-compose.yml
+++ b/mcp_server/docker-compose.yml
@@ -35,7 +35,11 @@ services:
       - NEO4J_USER=${NEO4J_USER:-neo4j}
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:-demodemo}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL}
       - MODEL_NAME=${MODEL_NAME}
+      - EMBEDDER_API_KEY=${EMBEDDER_API_KEY}          
+      - EMBEDDER_BASE_URL=${EMBEDDER_BASE_URL}       
+      - EMBEDDER_MODEL_NAME=${EMBEDDER_MODEL_NAME}     
       - PATH=/root/.local/bin:${PATH}
       - SEMAPHORE_LIMIT=${SEMAPHORE_LIMIT:-10}
     ports:

--- a/mcp_server/graphiti_mcp_server.py
+++ b/mcp_server/graphiti_mcp_server.py
@@ -354,6 +354,7 @@ class GraphitiEmbedderConfig(BaseModel):
 
     model: str = DEFAULT_EMBEDDER_MODEL
     api_key: str | None = None
+    base_url: str | None = None
     azure_openai_endpoint: str | None = None
     azure_openai_deployment_name: str | None = None
     azure_openai_api_version: str | None = None
@@ -366,6 +367,11 @@ class GraphitiEmbedderConfig(BaseModel):
         # Get model from environment, or use default if not set or empty
         model_env = os.environ.get('EMBEDDER_MODEL_NAME', '')
         model = model_env if model_env.strip() else DEFAULT_EMBEDDER_MODEL
+
+        # Get base_url from environment
+        base_url = os.environ.get('EMBEDDER_BASE_URL', None)  
+        logger.info(f'EMBEDDER_BASE_URL from env: {base_url}')  
+        logger.info(f'EMBEDDER_MODEL_NAME from env: {model}')  
 
         azure_openai_endpoint = os.environ.get('AZURE_OPENAI_EMBEDDING_ENDPOINT', None)
         azure_openai_api_version = os.environ.get('AZURE_OPENAI_EMBEDDING_API_VERSION', None)
@@ -405,9 +411,12 @@ class GraphitiEmbedderConfig(BaseModel):
                 azure_openai_deployment_name=azure_openai_deployment_name,
             )
         else:
+            api_key = os.environ.get('EMBEDDER_API_KEY') or os.environ.get('OPENAI_API_KEY')
+
             return cls(
                 model=model,
-                api_key=os.environ.get('OPENAI_API_KEY'),
+                api_key=api_key,
+                base_url=base_url,
             )
 
     def create_client(self) -> EmbedderClient | None:
@@ -444,7 +453,7 @@ class GraphitiEmbedderConfig(BaseModel):
             if not self.api_key:
                 return None
 
-            embedder_config = OpenAIEmbedderConfig(api_key=self.api_key, embedding_model=self.model)
+            embedder_config = OpenAIEmbedderConfig(api_key=self.api_key, embedding_model=self.model, base_url=self.base_url)
 
             return OpenAIEmbedder(config=embedder_config)
 


### PR DESCRIPTION
## Summary
This PR adds support for separate LLM and embedding service endpoints in the Graphiti MCP server, enabling users to mix and match different providers (e.g., Groq for LLM inference + Ollama for local embeddings, or OpenRouter + Voyage AI).

- Add base_url parameter to GraphitiEmbedderConfig
- Support EMBEDDER_BASE_URL, EMBEDDER_API_KEY, EMBEDDER_MODEL_NAME env vars
- Update docker-compose.yml to pass embedder environment variables
- Add documentation in README.md and .env.example
- Enables use of Ollama, Voyage, and other OpenAI-compatible embedding services

Partially resolves #912, #517


## Type of Change
- [ ] Bug fix
- [O ] New feature
- [ ] Performance improvement
- [O] Documentation/Tests

## Objective
**Problem: Users reported difficulties configuring Graphiti to use different services for LLM inference and embeddings (Issues #517, #912, #868). The MCP server previously forced both to use the same OPENAI_BASE_URL, preventing flexible provider combinations.

**Solution: This PR extends GraphitiEmbedderConfig to support independent configuration via three new environment variables:

EMBEDDER_BASE_URL - Custom endpoint for embedding service
EMBEDDER_API_KEY - Separate API key for embedder (falls back to OPENAI_API_KEY)
EMBEDDER_MODEL_NAME - Embedding model name
Use Cases Enabled:

Cost optimization: Use cheaper/local embeddings (Ollama) with cloud LLM (Groq, OpenRouter)
Privacy: Keep embeddings local while using cloud LLM for complex reasoning
Specialized services: Combine general-purpose LLM with specialized embedding providers (Voyage AI)

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

 Manual testing completed: Successfully tested with:
Groq (LLM) + Ollama (embeddings) - nomic-embed-text:latest
Groq (LLM) + Voyage AI (embeddings) - voyage-3 model
 Docker deployment verified: Environment variables correctly passed to container

# LLM via Groq  
OPENAI_API_KEY=gsk_xxx  
OPENAI_BASE_URL=https://api.groq.com/openai/v1  
MODEL_NAME=moonshotai/kimi-k2-instruct-0905  
SMALL_MODEL_NAME=moonshotai/kimi-k2-instruct-0905  
  
# Embeddings via Ollama (local)  
EMBEDDER_API_KEY=ollama  
EMBEDDER_BASE_URL=http://host.docker.internal:11434/v1  
EMBEDDER_MODEL_NAME=nomic-embed-text:latest  
EMBEDDING_DIM=768

## Breaking Changes
- [ ] This PR contains breaking changes

If this is a breaking change, describe:
- What functionality is affected
- Migration path for existing users

## Checklist
- [ ] Code follows project style guidelines (`make lint` passes)
- [ O ] Self-review completed
- [ O ] Documentation updated where necessary
- [ O ] No secrets or sensitive information committed

## Related Issues
Closes #[issue number]