### PR TITLE
Add triplet

### DIFF
--- a/graphiti_core/edges.py
+++ b/graphiti_core/edges.py
@@ -286,6 +286,8 @@ class EntityEdge(Edge):
         edge_data: dict[str, Any] = {
             'source_uuid': self.source_node_uuid,
             'target_uuid': self.target_node_uuid,
+            'source_node_uuid': self.source_node_uuid,
+            'target_node_uuid': self.target_node_uuid,
             'uuid': self.uuid,
             'name': self.name,
             'group_id': self.group_id,

--- a/graphiti_core/models/edges/edge_db_queries.py
+++ b/graphiti_core/models/edges/edge_db_queries.py
@@ -129,7 +129,7 @@ def get_entity_edge_save_bulk_query(provider: GraphProvider, has_aoss: bool = Fa
                 MATCH (source:Entity {uuid: edge.source_node_uuid})
                 MATCH (target:Entity {uuid: edge.target_node_uuid})
                 MERGE (source)-[r:RELATES_TO {uuid: edge.uuid}]->(target)
-                SET r = {uuid: edge.uuid, name: edge.name, group_id: edge.group_id, fact: edge.fact, episodes: edge.episodes,
+                SET r = {uuid: edge.uuid, source_node_uuid: edge.source_node_uuid, target_node_uuid: edge.target_node_uuid, name: edge.name, group_id: edge.group_id, fact: edge.fact, episodes: edge.episodes,
                 created_at: edge.created_at, expired_at: edge.expired_at, valid_at: edge.valid_at, invalid_at: edge.invalid_at, fact_embedding: vecf32(edge.fact_embedding)}
                 WITH r, edge
                 RETURN edge.uuid AS uuid


### PR DESCRIPTION
## Summary
When using add_triplet() with FalkorDB, edges were created successfully but the source_node_uuid and target_node_uuid properties on relationships were stored as None instead of the actual node UUIDs. This caused critical issues with edge deduplication, filtering, and data integrity validation.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
**For new features and performance improvements:** Clearly describe the objective and rationale for this change.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All existing tests pass

## Breaking Changes
- [ ] This PR contains breaking changes

If this is a breaking change, describe:
- What functionality is affected
- Migration path for existing users

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Closes #1001