### PR TITLE
Add Zep vs Graphiti comparison table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,23 @@ We're excited to open-source Graphiti, believing its potential reaches far beyon
     <a href="https://arxiv.org/abs/2501.13956"><img src="images/arxiv-screenshot.png" alt="Zep: A Temporal Knowledge Graph Architecture for Agent Memory" width="700px"></a>
 </p>
 
+## Zep vs Graphiti
+
+| Aspect | Zep | Graphiti |
+|--------|-----|----------|
+| **What they are** | Complete managed platform for AI memory | Open-source graph framework |
+| **User & conversation management** | Built-in users, threads, and message storage | Build your own |
+| **Retrieval & performance** | Pre-configured, production-ready retrieval with sub-200ms performance at scale | Custom implementation required; performance depends on your setup |
+| **Developer tools** | Dashboard with graph visualization, debug logs, API logs; SDKs for Python, TypeScript, and Go | Build your own tools |
+| **Enterprise features** | SLAs, support, security guarantees | Self-managed |
+| **Deployment** | Fully managed or in your cloud | Self-hosted only |
+
+### When to choose which
+
+**Choose Zep** if you want a turnkey, enterprise-grade platform with security, performance, and support baked in.
+
+**Choose Graphiti** if you want a flexible OSS core and you're comfortable building/operating the surrounding system.
+
 ## Why Graphiti?
 
 Traditional RAG approaches often rely on batch processing and static data summarization, making them inefficient for


### PR DESCRIPTION
## Summary
Adds a new section to the README titled "Zep vs Graphiti" which includes a markdown table comparing the two technologies. The table highlights key differences in aspects like their nature, management of users/conversations, retrieval performance, developer tools, enterprise features, and deployment models. A subsection "When to choose which" is also included to guide users on selecting the appropriate tool.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
To provide users with a clear and concise comparison between Zep and Graphiti, helping them understand the distinct offerings and choose the most suitable solution for their needs.

## Testing
- [ ] Local preview of README.md confirmed correct rendering.
- [ ] Verification of markdown table structure and content.
- [ ] [ ] All existing tests pass

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Closes # (No specific issue number provided, assume this is a new addition)
