### PR TITLE
Fix missing parameter exception on neptune node_similarity_search

### DIFF
--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -687,11 +687,11 @@ async def node_similarity_search(
         )
         resp, header, _ = await driver.execute_query(
             query,
-            params=filter_params,
             search_vector=search_vector,
             limit=limit,
             min_score=min_score,
             routing_='r',
+            **filter_params,
         )
 
         if len(resp) > 0:


### PR DESCRIPTION
## Summary
Fixed an issue where using Neptune as the driver caused a MalformedQueryException: MissingParameter error during node_similarity_search.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
**For new features and performance improvements:** Clearly describe the objective and rationale for this change.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass
DISABLE_FALKORDB=1 DISABLE_KUZU=1 DISABLE_NEPTUNE=1 uv run pytest -m "not integration"
================================================================== test session starts ==================================================================
platform darwin -- Python 3.12.12, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/don_tang/Documents/AI/repo/graphiti
configfile: pytest.ini
plugins: anyio-4.9.0, xdist-3.8.0, langsmith-0.4.4, asyncio-1.0.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 207 items / 17 deselected / 190 selected

tests/cross_encoder/test_bge_reranker_client_int.py ... [ 1%]
tests/cross_encoder/test_gemini_reranker_client.py ................. [ 10%]
tests/driver/test_falkordb_driver.py .......................s [ 23%]
tests/embedder/test_gemini.py ............... [ 31%]
tests/embedder/test_openai.py .. [ 32%]
tests/embedder/test_voyage.py .. [ 33%]
tests/helpers_test.py . [ 33%]
tests/llm_client/test_anthropic_client.py ........... [ 39%]
tests/llm_client/test_client.py . [ 40%]
tests/llm_client/test_errors.py ...... [ 43%]
tests/llm_client/test_gemini_client.py ...................... [ 54%]
tests/test_edge_int.py ... [ 56%]
tests/test_graphiti_mock.py ........................ [ 68%]
tests/test_node_int.py ... [ 70%]
tests/test_text_utils.py ........... [ 76%]
tests/utils/maintenance/test_bulk_utils.py .......... [ 81%]
tests/utils/maintenance/test_edge_operations.py ....... [ 85%]
tests/utils/maintenance/test_node_operations.py ....................... [ 97%]
tests/utils/search/search_utils_test.py ..... [100%]

=================================================================== warnings summary ====================================================================
.venv/lib/python3.12/site-packages/pydantic/_internal/_config.py:323
/Users/don_tang/Documents/AI/repo/graphiti/.venv/lib/python3.12/site-packages/pydantic/_internal/_config.py:323: PydanticDeprecatedSince20: Support for class-based config is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================== 189 passed, 1 skipped, 17 deselected, 1 warning in 46.51s ===============================================

## Breaking Changes
- [ ] This PR contains breaking changes

If this is a breaking change, describe:
- What functionality is affected
- Migration path for existing users

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Closes #[issue number]