### PR TITLE
Fix malformed query exception on neptune edge_fulltext_search

### DIFF
--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -214,17 +214,16 @@ async def edge_fulltext_search(
             for r in res['hits']['hits']:
                 input_ids.append({'id': r['_source']['uuid'], 'score': r['_score']})
 
+            filter_query = filter_query + ' AND id(e)=id ' if filter_query else ' WHERE id(e)=id '
+
             # Match the edge ids and return the values
             query = (
                 """
-                                UNWIND $ids as id
-                                MATCH (n:Entity)-[e:RELATES_TO]->(m:Entity)
-                                WHERE e.group_id IN $group_ids 
-                                AND id(e)=id 
-                                """
-                + filter_query
-                + """
-                AND id(e)=id
+                UNWIND $ids as id
+                MATCH (n:Entity)-[e:RELATES_TO]->(m:Entity)
+                """
+                + filter_query +
+                """
                 WITH e, id.score as score, startNode(e) AS n, endNode(e) AS m
                 RETURN
                     e.uuid AS uuid,
@@ -240,7 +239,7 @@ async def edge_fulltext_search(
                     e.invalid_at AS invalid_at,
                     properties(e) AS attributes
                 ORDER BY score DESC LIMIT $limit
-                            """
+                """
             )
 
             records, _, _ = await driver.execute_query(


### PR DESCRIPTION
## Summary
In the logic for performing full-text search on edges, if a document is found in OpenSearch’s edge_name_and_fact index, the UUID of that document is used as a parameter to further query Neptune for the related triplet. The MalformedQueryException occurs at this stage due to a syntax error in the Neptune query. In the [query ](https://github.com/getzep/graphiti/blob/56694a6deaf5286fdb97d701659985633469848c/graphiti_core/search/search_utils.py#L222)source code shown below, the cause of the MalformedQueryException is that the filter_query contains its own WHERE clause, resulting in the overall query having two WHERE clauses, which is invalid syntax.

error log: `graphiti_core.driver.neptune_driver: Error executing query: {'message': 'An error occurred while executing the query.', 'details': "An error occurred (MalformedQueryException) when calling the ExecuteOpenCypherQuery operation: Invalid input 'H': expected 'i/I' (line 6, column 27 (offset: 231))"}`


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
**For new features and performance improvements:** Clearly describe the objective and rationale for this change.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

## Breaking Changes
- [ ] This PR contains breaking changes

If this is a breaking change, describe:
- What functionality is affected
- Migration path for existing users

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Closes #[issue number]