### PR TITLE
Fix: Remove unnecessary max_tokens cap in AnthropicClient

### DIFF
--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -204,12 +204,9 @@ class AnthropicClient(LLMClient):
         user_messages = [{'role': m.role, 'content': m.content} for m in messages[1:]]
         user_messages_cast = typing.cast(list[MessageParam], user_messages)
 
-        # TODO: Replace hacky min finding solution after fixing hardcoded EXTRACT_EDGES_MAX_TOKENS = 16384 in
-        # edge_operations.py. Throws errors with cheaper models that lower max_tokens.
-        max_creation_tokens: int = min(
-            max_tokens if max_tokens is not None else self.config.max_tokens,
-            DEFAULT_MAX_TOKENS,
-        )
+        # Use the provided max_tokens or fall back to the instance max_tokens
+        # This aligns with how other LLM clients handle max_tokens
+        max_creation_tokens: int = max_tokens or self.max_tokens
 
         try:
             # Create the appropriate tool based on whether response_model is provided


### PR DESCRIPTION
Removes the hacky min() workaround that was capping max_tokens to DEFAULT_MAX_TOKENS (8192) in the AnthropicClient. This fix allows the client to respect the max_tokens parameter passed by callers, particularly for edge extraction operations that may require higher token limits (e.g., 16384).

The new implementation aligns with how other LLM clients (OpenAI, Gemini) handle max_tokens by using the provided value or falling back to the instance max_tokens without an arbitrary cap.

Resolves TODO in anthropic_client.py:207-208.

## Summary
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
**For new features and performance improvements:** Clearly describe the objective and rationale for this change.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

## Breaking Changes
- [ ] This PR contains breaking changes

If this is a breaking change, describe:
- What functionality is affected
- Migration path for existing users

## Checklist
- [ ] Code follows project style guidelines (`make lint` passes)
- [ ] Self-review completed
- [ ] Documentation updated where necessary
- [ ] No secrets or sensitive information committed

## Related Issues
Closes #[issue number]