### PR TITLE
Disable fork PR comment job in workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -77,27 +77,30 @@ jobs:
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*)"
             --model claude-sonnet-4-5-20250929
 
-  notify-external-contributor:
-    needs: check-fork
-    if: needs.check-fork.outputs.is_fork == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Add comment for external contributors
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const comment = `👋 Thanks for your contribution!
-
-            This PR is from a fork, so automated Claude Code reviews are not run for security reasons.
-            A maintainer will manually trigger a review after an initial security check.
-
-            You can expect feedback soon!`;
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            });
+  # Disabled: This job fails with "Resource not accessible by integration" error
+  # when triggered by pull_request events from forks due to GitHub security restrictions.
+  # Fork PRs run with read-only GITHUB_TOKEN and cannot post comments.
+  # notify-external-contributor:
+  #   needs: check-fork
+  #   if: needs.check-fork.outputs.is_fork == 'true'
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     pull-requests: write
+  #   steps:
+  #     - name: Add comment for external contributors
+  #       uses: actions/github-script@v7
+  #       with:
+  #         script: |
+  #           const comment = `👋 Thanks for your contribution!
+  #
+  #           This PR is from a fork, so automated Claude Code reviews are not run for security reasons.
+  #           A maintainer will manually trigger a review after an initial security check.
+  #
+  #           You can expect feedback soon!`;
+  #
+  #           github.rest.issues.createComment({
+  #             issue_number: context.issue.number,
+  #             owner: context.repo.owner,
+  #             repo: context.repo.repo,
+  #             body: comment
+  #           });


### PR DESCRIPTION
Fixes the "Resource not accessible by integration" error in the Claude Code review workflow. The notify-external-contributor job cannot post comments on fork PRs due to GitHub's security restrictions limiting fork workflows to read-only tokens.

This disables the failing job by commenting it out. Fork PRs will simply skip the review without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)