### PR TITLE
Enable FalkorDB fulltext search tests

### DIFF
--- a/tests/test_graphiti_mock.py
+++ b/tests/test_graphiti_mock.py
@@ -918,8 +918,8 @@ async def test_get_communities_by_nodes(graph_driver, mock_embedder):
 async def test_edge_fulltext_search(
     graph_driver, mock_embedder, mock_llm_client, mock_cross_encoder_client
 ):
-    if graph_driver.provider in [GraphProvider.FALKORDB, GraphProvider.KUZU]:
-        pytest.skip('Skipping as fulltext indexing not supported for FalkorDB and Kuzu')
+    if graph_driver.provider == GraphProvider.KUZU:
+        pytest.skip('Skipping as fulltext indexing not supported for Kuzu')
 
     graphiti = Graphiti(
         graph_driver=graph_driver,
@@ -1307,8 +1307,8 @@ async def test_edge_bfs_search(graph_driver, mock_embedder):
 async def test_node_fulltext_search(
     graph_driver, mock_embedder, mock_llm_client, mock_cross_encoder_client
 ):
-    if graph_driver.provider in [GraphProvider.FALKORDB, GraphProvider.KUZU]:
-        pytest.skip('Skipping as fulltext indexing not supported for FalkorDB and Kuzu')
+    if graph_driver.provider == GraphProvider.KUZU:
+        pytest.skip('Skipping as fulltext indexing not supported for Kuzu')
 
     graphiti = Graphiti(
         graph_driver=graph_driver,
@@ -1516,8 +1516,8 @@ async def test_node_bfs_search(graph_driver, mock_embedder):
 async def test_episode_fulltext_search(
     graph_driver, mock_embedder, mock_llm_client, mock_cross_encoder_client
 ):
-    if graph_driver.provider in [GraphProvider.FALKORDB, GraphProvider.KUZU]:
-        pytest.skip('Skipping as fulltext indexing not supported for FalkorDB and Kuzu')
+    if graph_driver.provider == GraphProvider.KUZU:
+        pytest.skip('Skipping as fulltext indexing not supported for Kuzu')
 
     graphiti = Graphiti(
         graph_driver=graph_driver,
@@ -1567,8 +1567,8 @@ async def test_episode_fulltext_search(
 async def test_community_fulltext_search(
     graph_driver, mock_embedder, mock_llm_client, mock_cross_encoder_client
 ):
-    if graph_driver.provider in [GraphProvider.FALKORDB, GraphProvider.KUZU]:
-        pytest.skip('Skipping as fulltext indexing not supported for FalkorDB and Kuzu')
+    if graph_driver.provider == GraphProvider.KUZU:
+        pytest.skip('Skipping as fulltext indexing not supported for Kuzu')
 
     graphiti = Graphiti(
         graph_driver=graph_driver,


### PR DESCRIPTION
## Summary
- Remove FalkorDB from fulltext search test skip conditions
- All 4 FalkorDB fulltext search tests pass successfully
- Keep Kuzu skipped (legitimately doesn't support dynamic fulltext indexing)

## Testing
Tested locally with FalkorDB 1.2.3 - all tests pass:
- `test_edge_fulltext_search[GraphProvider.FALKORDB]` ✅
- `test_node_fulltext_search[GraphProvider.FALKORDB]` ✅  
- `test_episode_fulltext_search[GraphProvider.FALKORDB]` ✅
- `test_community_fulltext_search[GraphProvider.FALKORDB]` ✅

## Background
The skip for FalkorDB was added in PR #872 without explanation. Testing confirms it's unnecessary - FalkorDB's fulltext search implementation works correctly.