### PR TITLE
fix: replace deprecated gemini-2.5-flash-lite-preview with `gemini-2.5-flash-lite`

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ graphiti = Graphiti(
     cross_encoder=GeminiRerankerClient(
         config=LLMConfig(
             api_key=api_key,
-            model="gemini-2.5-flash-lite-preview-06-17"
+            model="gemini-2.5-flash-lite"
         )
     )
 )
@@ -487,7 +487,7 @@ graphiti = Graphiti(
 # Now you can use Graphiti with Google Gemini for all components
 ```
 
-The Gemini reranker uses the `gemini-2.5-flash-lite-preview-06-17` model by default, which is optimized for
+The Gemini reranker uses the `gemini-2.5-flash-lite` model by default, which is optimized for
 cost-effective and low-latency classification tasks. It uses the same boolean classification approach as the OpenAI
 reranker, leveraging Gemini's log probabilities feature to rank passage relevance.
 

--- a/graphiti_core/cross_encoder/gemini_reranker_client.py
+++ b/graphiti_core/cross_encoder/gemini_reranker_client.py
@@ -37,7 +37,7 @@ else:
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = 'gemini-2.5-flash-lite-preview-06-17'
+DEFAULT_MODEL = 'gemini-2.5-flash-lite'
 
 
 class GeminiRerankerClient(CrossEncoderClient):

--- a/graphiti_core/llm_client/gemini_client.py
+++ b/graphiti_core/llm_client/gemini_client.py
@@ -45,7 +45,7 @@ else:
 logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL = 'gemini-2.5-flash'
-DEFAULT_SMALL_MODEL = 'gemini-2.5-flash-lite-preview-06-17'
+DEFAULT_SMALL_MODEL = 'gemini-2.5-flash-lite'
 
 # Maximum output tokens for different Gemini models
 GEMINI_MODEL_MAX_TOKENS = {
@@ -53,7 +53,6 @@ GEMINI_MODEL_MAX_TOKENS = {
     'gemini-2.5-pro': 65536,
     'gemini-2.5-flash': 65536,
     'gemini-2.5-flash-lite': 64000,
-    'models/gemini-2.5-flash-lite-preview-06-17': 64000,
     # Gemini 2.0 models
     'gemini-2.0-flash': 8192,
     'gemini-2.0-flash-lite': 8192,

--- a/tests/llm_client/test_gemini_client.py
+++ b/tests/llm_client/test_gemini_client.py
@@ -455,7 +455,6 @@ class TestGeminiClientGenerateResponse:
             ('gemini-2.5-flash', 65536),
             ('gemini-2.5-pro', 65536),
             ('gemini-2.5-flash-lite', 64000),
-            ('models/gemini-2.5-flash-lite-preview-06-17', 64000),
             ('gemini-2.0-flash', 8192),
             ('gemini-1.5-pro', 8192),
             ('gemini-1.5-flash', 8192),


### PR DESCRIPTION
…ni-2.5-flash-lite

Updated all references to the deprecated Gemini model in:
- graphiti_core/llm_client/gemini_client.py
- graphiti_core/cross_encoder/gemini_reranker_client.py
- tests/llm_client/test_gemini_client.py
- README.md

This resolves 404 errors when using Gemini clients.

Fixes #1075

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
**For new features and performance improvements:** Clearly describe the objective and rationale for this change.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

## Breaking Changes
- [ ] This PR contains breaking changes

If this is a breaking change, describe:
- What functionality is affected
- Migration path for existing users

## Checklist
- [ ] Code follows project style guidelines (`make lint` passes)
- [ ] Self-review completed
- [ ] Documentation updated where necessary
- [ ] No secrets or sensitive information committed

## Related Issues
Closes #[issue number]