### PR TITLE
fix: Handle EquivalentSchemaRuleAlreadyExists errors in Neo4j driver

### DIFF
--- a/graphiti_core/driver/neo4j_driver.py
+++ b/graphiti_core/driver/neo4j_driver.py
@@ -18,6 +18,7 @@ import logging
 from collections.abc import Coroutine
 from typing import Any
 
+import neo4j.exceptions
 from neo4j import AsyncGraphDatabase, EagerResult
 from typing_extensions import LiteralString
 
@@ -70,6 +71,15 @@ class Neo4jDriver(GraphDriver):
 
         try:
             result = await self.client.execute_query(cypher_query_, parameters_=params, **kwargs)
+        except neo4j.exceptions.ClientError as e:
+            # Handle race condition when creating indices/constraints in parallel
+            # Neo4j 5.26+ may throw EquivalentSchemaRuleAlreadyExists even with IF NOT EXISTS
+            if 'EquivalentSchemaRuleAlreadyExists' in str(e):
+                logger.info(f'Index or constraint already exists, continuing: {cypher_query_}')
+                # Return empty result to indicate success (index exists)
+                return EagerResult([], None, None)  # type: ignore
+            logger.error(f'Error executing Neo4j query: {e}\n{cypher_query_}\n{params}')
+            raise
         except Exception as e:
             logger.error(f'Error executing Neo4j query: {e}\n{cypher_query_}\n{params}')
             raise


### PR DESCRIPTION
## Summary

Fixes #1079

Neo4j 5.26+ throws `EquivalentSchemaRuleAlreadyExists` errors when creating indices in parallel, even with `IF NOT EXISTS` clause. This causes Docker Compose deployments to fail on startup.

## Changes

- Added error handling in `Neo4jDriver.execute_query()` to catch `neo4j.exceptions.ClientError`
- Specifically checks for `EquivalentSchemaRuleAlreadyExists` error code  
- Logs the occurrence as info instead of error
- Returns empty result to indicate success (index/constraint already exists)

## Technical Details

The race condition occurs when multiple `CREATE INDEX IF NOT EXISTS` queries run concurrently via `semaphore_gather` in `build_indices_and_constraints()`. Neo4j 5.26+ returns an error even though the index creation succeeds.

This solution follows the same pattern already implemented in the FalkorDB driver for handling "already indexed" errors (see `FalkorDriver.execute_query()` lines 177-180).

## Test Plan

- [x] Code passes `make lint` (ruff + pyright)
- [x] Follows existing error handling pattern from FalkorDB driver
- [ ] Integration tests require Neo4j instance (will be validated by CI)

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are focused on fixing the specific issue  
- [x] Error handling is consistent with existing patterns
- [x] Appropriate logging added

🤖 Generated with [Claude Code](https://claude.com/claude-code)