### PR TITLE
Fix: Flatten results from update_community calls

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -778,13 +778,17 @@ class Graphiti:
                 communities = []
                 community_edges = []
                 if update_communities:
-                    communities, community_edges = await semaphore_gather(
+                    results = await semaphore_gather(
                         *[
                             update_community(self.driver, self.llm_client, self.embedder, node)
                             for node in nodes
                         ],
                         max_coroutines=self.max_coroutines,
                     )
+                    # Flatten results from multiple update_community calls
+                    for community_list, edge_list in results:
+                        communities.extend(community_list)
+                        community_edges.extend(edge_list)
 
                 end = time()
 


### PR DESCRIPTION
## Summary
Fixed ValueError when `update_communities=True` is passed to `add_episode()`. The bug was caused by incorrect unpacking of `semaphore_gather` results, which returns a list of tuples rather than a single tuple.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
Fix the `ValueError: not enough values to unpack (expected 2, got 1)` error that occurs when calling `add_episode()` with `update_communities=True`.

**Root Cause:**
In `graphiti.py` lines 781-787, the code attempts to directly unpack `semaphore_gather` results:
```python
communities, community_edges = await semaphore_gather(
    *[update_community(self.driver, self.llm_client, self.embedder, node) for node in nodes],
    max_coroutines=self.max_coroutines,
)

However, semaphore_gather returns a list of tuples, not a single tuple:
[(communities, edges), (communities, edges), ...]