### PR TITLE
Fix/model name config

### DIFF
--- a/graphiti_core/llm_client/openai_base_client.py
+++ b/graphiti_core/llm_client/openai_base_client.py
@@ -31,8 +31,8 @@ from .errors import RateLimitError, RefusalError
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = 'gpt-5-mini'
-DEFAULT_SMALL_MODEL = 'gpt-5-nano'
+DEFAULT_MODEL = 'gpt-4o-mini'
+DEFAULT_SMALL_MODEL = 'gpt-4o-mini'
 DEFAULT_REASONING = 'minimal'
 DEFAULT_VERBOSITY = 'low'
 

--- a/mcp_server/config/config-docker-falkordb-combined.yaml
+++ b/mcp_server/config/config-docker-falkordb-combined.yaml
@@ -8,7 +8,7 @@ server:
 
 llm:
   provider: "openai"  # Options: openai, azure_openai, anthropic, gemini, groq
-  model: "gpt-5-mini"
+  model: "gpt-4o-mini"
   max_tokens: 4096
 
   providers:

--- a/mcp_server/config/config-docker-falkordb.yaml
+++ b/mcp_server/config/config-docker-falkordb.yaml
@@ -8,7 +8,7 @@ server:
   
 llm:
   provider: "openai"  # Options: openai, azure_openai, anthropic, gemini, groq
-  model: "gpt-5-mini"
+  model: "gpt-4o-mini"
   max_tokens: 4096
   
   providers:

--- a/mcp_server/config/config-docker-neo4j.yaml
+++ b/mcp_server/config/config-docker-neo4j.yaml
@@ -8,7 +8,7 @@ server:
   
 llm:
   provider: "openai"  # Options: openai, azure_openai, anthropic, gemini, groq
-  model: "gpt-5-mini"
+  model: "gpt-4o-mini"
   max_tokens: 4096
   
   providers:

--- a/mcp_server/config/config.yaml
+++ b/mcp_server/config/config.yaml
@@ -12,7 +12,7 @@ server:
   
 llm:
   provider: "openai"  # Options: openai, azure_openai, anthropic, gemini, groq
-  model: "gpt-5-mini"
+  model: "gpt-4o-mini"
   max_tokens: 4096
   
   providers:

--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -147,7 +147,7 @@ class LLMConfig(BaseModel):
     """LLM configuration."""
 
     provider: str = Field(default='openai', description='LLM provider')
-    model: str = Field(default='gpt-4.1', description='Model name')
+    model: str = Field(default='gpt-4o-mini', description='Model name')
     temperature: float | None = Field(
         default=None, description='Temperature (optional, defaults to None for reasoning models)'
     )


### PR DESCRIPTION
  ## Summary

  This PR fixes two critical issues that prevent Graphiti from working with default configurations:

  1. **Invalid model names**: Hardcoded non-existent model names (`gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`) replaced
  with valid `gpt-4o-mini`
  2. **Neo4j startup race condition**: Concurrent `CREATE INDEX IF NOT EXISTS` queries can fail even though the
  index exists

  ## Problem

  ### Issue 1: Invalid Model Names
  Current versions hardcode non-existent model names as defaults:
  - `gpt-5-mini` (DEFAULT_MODEL in openai_base_client.py)
  - `gpt-5-nano` (DEFAULT_SMALL_MODEL in openai_base_client.py)  
  - `gpt-4.1` (default in LLMConfig schema)

  This causes API errors when users run Graphiti with default settings:
  ERROR - The model 'gpt-5-mini' does not exist or you do not have access to it.

  ### Issue 2: Neo4j Index Race Condition
  When `build_indices_and_constraints` runs via `semaphore_gather`, multiple concurrent `CREATE INDEX IF NOT
  EXISTS` queries race and Neo4j raises `EquivalentSchemaRuleAlreadyExists` even when the index exists.

  ## Solution

  ### Fix 1: Valid Model Names
  Replace all hardcoded non-existent model names with `gpt-4o-mini`.

  ### Fix 2: Index Race Condition Handler
  Added `_execute_index_query` helper that catches and ignores `EquivalentSchemaRuleAlreadyExists` errors.

  ## Changes Made

  **Core Library:**
  - `graphiti_core/llm_client/openai_base_client.py`: Changed DEFAULT_MODEL and DEFAULT_SMALL_MODEL
  - `graphiti_core/driver/neo4j_driver.py`: Added race condition handler

  **Configuration:**
  - `mcp_server/src/config/schema.py`: Changed LLMConfig default
  - Updated all 4 YAML config files in `mcp_server/config/`

  ## Testing

  - ✅ MCP server starts without errors
  - ✅ Neo4j connection works
  - ✅ SSE transport functional
  - ✅ add_memory operation succeeds
