### PR TITLE
Add SEO keyword to Zep link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ while handling changing relationships and maintaining historical context.
 
 ## Graphiti and Zep's Context Engineering Platform.
 
-Graphiti powers the core of [Zep](https://www.getzep.com), a turn-key context engineering platform for AI Agents. Zep
+Graphiti powers the core of [Zep's context engineering platform](https://www.getzep.com) for AI Agents. Zep
 offers agent memory, Graph RAG for dynamic data, and context retrieval and assembly.
 
 Using Graphiti, we've demonstrated Zep is


### PR DESCRIPTION
## Summary
Updated the Zep link anchor text in the README to include the SEO keyword "context engineering" for better search visibility while maintaining the link to www.getzep.com.

## Type of Change
- [x] Documentation/Tests

## Objective
Improve SEO by using "context engineering" as the anchor text when linking to the Zep website, making the link more descriptive and search engine friendly.

## Checklist
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed