### PR TITLE
feat(mcp): add username support for FalkorDB authentication

### DIFF
--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -187,6 +187,7 @@ class FalkorDBProviderConfig(BaseModel):
     """FalkorDB provider configuration."""
 
     uri: str = 'redis://localhost:6379'
+    username: str | None = None
     password: str | None = None
     database: str = 'default_db'
 

--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -218,6 +218,7 @@ class GraphitiService:
                     falkor_driver = FalkorDriver(
                         host=db_config['host'],
                         port=db_config['port'],
+                        username=db_config.get('username'),
                         password=db_config['password'],
                         database=db_config['database'],
                     )

--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -418,6 +418,7 @@ class DatabaseDriverFactory:
                 from urllib.parse import urlparse
 
                 uri = os.environ.get('FALKORDB_URI', falkor_config.uri)
+                username = os.environ.get('FALKORDB_USERNAME', falkor_config.username)
                 password = os.environ.get('FALKORDB_PASSWORD', falkor_config.password)
 
                 # Parse the URI to extract host and port
@@ -429,6 +430,7 @@ class DatabaseDriverFactory:
                     'driver': 'falkordb',
                     'host': host,
                     'port': port,
+                    'username': username,
                     'password': password,
                     'database': falkor_config.database,
                 }


### PR DESCRIPTION
## Summary

Adds optional `username` parameter to FalkorDB configuration to support authentication in FalkorDB instances that require username+password authentication.

## Problem

Previously, the MCP server's FalkorDB configuration only supported the `password` field, making it impossible to connect to FalkorDB instances that require both username and password for authentication.

## Solution

This PR adds username support across the MCP server configuration chain:

- **`src/config/schema.py`**: Add optional `username` field to `FalkorDBProviderConfig`
- **`src/services/factories.py`**: Extract `username` from config or `FALKORDB_USERNAME` environment variable
- **`src/graphiti_mcp_server.py`**: Pass `username` parameter to `FalkorDriver` constructor

## Configuration Example

```yaml
database:
  provider: "falkordb"
  providers:
    falkordb:
      uri: "redis://localhost:6379"
      username: "myuser"          # NEW: optional username
      password: "mypassword"
      database: "my-graph"
```

Or via environment variable:
```bash
export FALKORDB_USERNAME="myuser"
export FALKORDB_PASSWORD="mypassword"
```

## Backwards Compatibility

The `username` parameter is optional (`str | None = None`), maintaining full backwards compatibility with existing configurations that only use password authentication.

## Testing

Tested with FalkorDB instance requiring username+password authentication. The MCP server successfully connects and performs all operations (search, add_memory, get_episodes).