### PR TITLE
Fix FalkorDB sanitize to handle forward slash character

### DIFF
--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -289,7 +289,7 @@ class FalkorDriver(GraphDriver):
     def sanitize(self, query: str) -> str:
         """
         Replace FalkorDB special characters with whitespace.
-        Based on FalkorDB tokenization rules: ,.<>{}[]"':;!@#$%^&*()-+=~
+        Based on FalkorDB tokenization rules: ,.<>{}[]"':;!@#$%^&*()-+=~/?
         """
         # FalkorDB separator characters that break text into tokens
         separator_map = str.maketrans(
@@ -321,6 +321,7 @@ class FalkorDriver(GraphDriver):
                 '=': ' ',
                 '~': ' ',
                 '?': ' ',
+                '/': ' ',
             }
         )
         sanitized = query.translate(separator_map)


### PR DESCRIPTION
## Summary
- Fixes RediSearch query syntax errors when entity names contain forward slashes
- Adds `/` to the separator map in FalkorDB's `sanitize()` method

## Problem
When entity names contained forward slashes (e.g., "Cruise / En route"), RediSearch queries were failing with syntax errors because the forward slash was not being sanitized. This resulted in malformed queries like:
```
(@group_id:\_) (Cruise | / | En | route)
```

## Solution
Added `/` to the `separator_map` in the `sanitize()` method (line 324 in `falkordb_driver.py`), treating it like other special characters by replacing it with whitespace.

Now "Cruise / En route" is sanitized to "Cruise En route", which produces valid RediSearch queries.

## Testing
Verified that:
- "Cruise / En route" → "Cruise En route" 
- "Landing/Taxi" → "Landing Taxi"
- Multiple slashes are handled correctly

Fixes data insertion issues when using FalkorDB backend with forward slash characters in entity names.