### PR TITLE
feat(mcp): add transport security configuration for remote access

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -171,6 +171,62 @@ database:
   provider: "falkordb"  # Default. Options: "falkordb", "neo4j"
 ```
 
+### Transport Security (Remote Access)
+
+When deploying the MCP server behind a reverse proxy (like Nginx, Traefik, or Caddy) or accessing it from a different host, you need to configure the transport security settings to allow the Host and Origin headers.
+
+By default, the MCP SDK enables DNS rebinding protection which only allows requests from localhost variants. This will cause "Invalid Host header" (421) errors when accessing the server via a custom domain.
+
+Configure allowed hosts and origins in `config.yaml`:
+
+```yaml
+server:
+  transport: "http"
+  host: "0.0.0.0"
+  port: 8000
+
+  # Transport security settings for remote access
+  allowed_hosts:
+    - "localhost:8000"
+    - "graphiti.example.com"
+    - "graphiti.example.com:8000"
+  allowed_origins:
+    - "http://localhost:3000"
+    - "https://app.example.com"
+  enable_dns_rebinding_protection: true  # Default: true
+```
+
+**Configuration Options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `allowed_hosts` | list | None | Allowed Host header values. If not set, uses SDK defaults (localhost variants only). |
+| `allowed_origins` | list | None | Allowed CORS origins. If not set, uses SDK defaults. |
+| `enable_dns_rebinding_protection` | bool | true | Enable DNS rebinding protection by validating Host headers. |
+
+**Environment Variables:**
+
+You can also configure these via environment variables:
+
+```bash
+SERVER__ALLOWED_HOSTS='["graphiti.example.com", "localhost:8000"]'
+SERVER__ALLOWED_ORIGINS='["https://app.example.com"]'
+SERVER__ENABLE_DNS_REBINDING_PROTECTION=true
+```
+
+**Example: Traefik Reverse Proxy:**
+
+If your Graphiti MCP server is accessible via `graphiti.marakanda.biz` through Traefik:
+
+```yaml
+server:
+  allowed_hosts:
+    - "graphiti.marakanda.biz"
+    - "localhost:8000"  # Keep for local development
+```
+
+**Security Note:** Only add hosts that you trust. The DNS rebinding protection helps prevent malicious websites from accessing your MCP server.
+
 ### Using Ollama for Local LLM
 
 To use Ollama with the MCP server, configure it as an OpenAI-compatible endpoint:

--- a/mcp_server/config/config.yaml
+++ b/mcp_server/config/config.yaml
@@ -9,7 +9,17 @@ server:
   transport: "http"  # Options: stdio, sse (deprecated), http
   host: "0.0.0.0"
   port: 8000
-  
+
+  # Transport security settings for remote access (behind reverse proxy)
+  # Uncomment and configure if accessing via custom domain:
+  # allowed_hosts:
+  #   - "localhost:8000"
+  #   - "graphiti.example.com"
+  # allowed_origins:
+  #   - "http://localhost:3000"
+  #   - "https://app.example.com"
+  # enable_dns_rebinding_protection: true  # Default: true
+
 llm:
   provider: "openai"  # Options: openai, azure_openai, anthropic, gemini, groq
   model: "gpt-4o-mini"

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -5,7 +5,7 @@ description = "Graphiti MCP Server"
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
-    "mcp>=1.9.4",
+    "mcp>=1.23.0",
     "openai>=1.91.0",
     "graphiti-core[falkordb]==0.28.1",
     "pydantic-settings>=2.0.0",

--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -83,6 +83,21 @@ class ServerConfig(BaseModel):
     host: str = Field(default='0.0.0.0', description='Server host')
     port: int = Field(default=8000, description='Server port')
 
+    # Transport security settings (for HTTP transport)
+    allowed_hosts: list[str] | None = Field(
+        default=None,
+        description='Allowed Host header values (e.g., ["localhost:8000", "myservice.example.com"]). '
+        'If None, defaults to localhost variants only.',
+    )
+    allowed_origins: list[str] | None = Field(
+        default=None,
+        description='Allowed CORS origins. If None, defaults to localhost variants only.',
+    )
+    enable_dns_rebinding_protection: bool = Field(
+        default=True,
+        description='Enable DNS rebinding protection by validating Host headers.',
+    )
+
 
 class OpenAIProviderConfig(BaseModel):
     """OpenAI provider configuration."""

--- a/mcp_server/uv.lock
+++ b/mcp_server/uv.lock
@@ -1164,7 +1164,7 @@ requires-dist = [
     { name = "google-genai", marker = "extra == 'providers'", specifier = ">=1.62.0" },
     { name = "graphiti-core", extras = ["falkordb"], specifier = "==0.28.1" },
     { name = "groq", marker = "extra == 'providers'", specifier = ">=0.2.0" },
-    { name = "mcp", specifier = ">=1.9.4" },
+    { name = "mcp", specifier = ">=1.23.0" },
     { name = "openai", specifier = ">=1.91.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },


### PR DESCRIPTION
## Summary

This PR adds support for configuring transport security settings (allowed hosts and origins) when deploying the MCP server behind a reverse proxy like Nginx, Traefik, or Caddy.

**Problem:** The MCP server returns "Invalid Host header" (421) errors when accessed via a custom domain because the MCP SDK's DNS rebinding protection only allows localhost by default.

**Solution:** Make `allowed_hosts`, `allowed_origins`, and `enable_dns_rebinding_protection` configurable via `config.yaml`.

### Changes

- Add transport security fields to `ServerConfig` schema (`allowed_hosts`, `allowed_origins`, `enable_dns_rebinding_protection`)
- Add `build_transport_security()` helper function that creates `TransportSecuritySettings` from config
- Integrate transport security configuration in server initialization via `mcp.settings.transport_security`
- Update MCP SDK requirement to `>=1.23.0` (required for `TransportSecuritySettings` support)
- Add unit tests for transport security configuration
- Document transport security options in README.md
- Add commented example in config.yaml

### Example Configuration

```yaml
server:
  transport: http
  host: 0.0.0.0
  port: 8000
  
  # Transport security settings for remote access
  allowed_hosts:
    - "localhost:8000"
    - "graphiti.example.com"
  allowed_origins:
    - "http://localhost:3000"
    - "https://app.example.com"
  enable_dns_rebinding_protection: true  # Default: true
```

## Test plan

- [x] Unit tests added for `build_transport_security()` function
- [x] Unit tests added for `ServerConfig` schema with new fields
- [x] Unit tests added for environment variable overrides
- [x] All existing tests pass (`uv run python tests/test_configuration.py`)
- [ ] Manual testing with reverse proxy (Traefik)

## Related

- Addresses DNS rebinding protection (CVE-2025-66416)
- References: [MCP SDK Issue #1798](https://github.com/modelcontextprotocol/python-sdk/issues/1798)

🤖 Generated with [Claude Code](https://claude.com/claude-code)