### PR TITLE
fix(mcp): pass base_url to Anthropic LLM and OpenAI Embedder clients

### DIFF
--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -205,6 +205,7 @@ class LLMClientFactory:
 
                 llm_config = GraphitiLLMConfig(
                     api_key=api_key,
+                    base_url=config.providers.anthropic.api_url,
                     model=config.model,
                     temperature=config.temperature,
                     max_tokens=config.max_tokens,
@@ -274,6 +275,7 @@ class EmbedderFactory:
 
                 embedder_config = OpenAIEmbedderConfig(
                     api_key=api_key,
+                    base_url=config.providers.openai.api_url,
                     embedding_model=config.model,
                 )
                 return OpenAIEmbedder(config=embedder_config)


### PR DESCRIPTION
## Summary

The `LLMClientFactory` and `EmbedderFactory` in `factories.py` read the `api_url` from config but don't pass it to the client constructors. This causes:

- `AnthropicClient` to always use `https://api.anthropic.com` instead of configured URL
- `OpenAIEmbedder` to always use `https://api.openai.com/v1` instead of configured URL

This breaks self-hosted/proxy setups where users want to route requests through custom endpoints.

## Changes

- Pass `base_url=config.providers.anthropic.api_url` to `GraphitiLLMConfig` for Anthropic
- Pass `base_url=config.providers.openai.api_url` to `OpenAIEmbedderConfig` for OpenAI embedder

## Test Plan

- [x] Tested with CLIProxyAPI (Anthropic-compatible proxy) - requests now correctly route to custom endpoint
- [x] Tested with Ollama (OpenAI-compatible embeddings) - embeddings now correctly use custom endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)