### PR TITLE
fix(docker): install anthropic package for Claude support

### DIFF
--- a/mcp_server/docker/Dockerfile
+++ b/mcp_server/docker/Dockerfile
@@ -52,6 +52,10 @@ RUN sed -i '/\[tool\.uv\.sources\]/,/graphiti-core/d' pyproject.toml && \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --no-group dev
 
+# Install anthropic for Claude support (not in default deps)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install anthropic>=0.49.0
+
 # Store graphiti-core version
 RUN echo "${GRAPHITI_CORE_VERSION}" > /app/mcp/.graphiti-core-version
 


### PR DESCRIPTION
## Summary

The MCP server Docker image cannot use the Anthropic LLM provider because the `anthropic` package is not installed. It's defined as an optional dependency under `[project.optional-dependencies].providers` but the Dockerfile only runs `uv sync --no-group dev`.

## Problem

When configuring `llm.provider: anthropic` in config.yaml, the server fails because `AnthropicClient` cannot be imported.

## Solution

Install only the `anthropic` package directly instead of using `--extra providers`, which would pull in heavy dependencies like `torch` and `transformers` from other providers (Voyage, etc.).

```dockerfile
# Install anthropic for Claude support (not in default deps)
RUN --mount=type=cache,target=/root/.cache/uv \
    uv pip install anthropic>=0.49.0
```

## Alternatives Considered

- `--extra providers`: Rejected because it installs all providers including torch/transformers (~500MB+)
- Build argument for provider selection: More complex, could be future enhancement

## Test Plan

- [x] Built Docker image with this change
- [x] Configured MCP server with `llm.provider: anthropic`
- [x] Successfully processed episodes using Claude via Anthropic API

🤖 Generated with [Claude Code](https://claude.com/claude-code)