### PR TITLE
feat(search): add summary_embedding semantic search for nodes

### DIFF
--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -473,6 +473,9 @@ class EpisodicNode(Node):
 
 class EntityNode(Node):
     name_embedding: list[float] | None = Field(default=None, description='embedding of the name')
+    summary_embedding: list[float] | None = Field(
+        default=None, description='embedding of the summary'
+    )
     summary: str = Field(description='regional summary of surrounding edges', default_factory=str)
     attributes: dict[str, Any] = Field(
         default={}, description='Additional attributes of the node. Dependent on node labels'
@@ -486,6 +489,18 @@ class EntityNode(Node):
         logger.debug(f'embedded {text} in {end - start} ms')
 
         return self.name_embedding
+
+    async def generate_summary_embedding(self, embedder: EmbedderClient):
+        if not self.summary or not self.summary.strip():
+            return None
+
+        start = time()
+        text = self.summary.replace('\n', ' ')
+        self.summary_embedding = await embedder.create(input_data=[text])
+        end = time()
+        logger.debug(f'embedded summary for {self.name} in {end - start} ms')
+
+        return self.summary_embedding
 
     async def load_name_embedding(self, driver: GraphDriver):
         if driver.graph_operations_interface:
@@ -516,6 +531,28 @@ class EntityNode(Node):
 
         self.name_embedding = records[0]['name_embedding']
 
+    async def load_summary_embedding(self, driver: GraphDriver):
+        if driver.provider == GraphProvider.NEPTUNE:
+            query: LiteralString = """
+                MATCH (n:Entity {uuid: $uuid})
+                RETURN [x IN split(n.summary_embedding, ",") | toFloat(x)] as summary_embedding
+            """
+        else:
+            query: LiteralString = """
+                MATCH (n:Entity {uuid: $uuid})
+                RETURN n.summary_embedding AS summary_embedding
+            """
+        records, _, _ = await driver.execute_query(
+            query,
+            uuid=self.uuid,
+            routing_='r',
+        )
+
+        if len(records) == 0:
+            raise NodeNotFoundError(self.uuid)
+
+        self.summary_embedding = records[0]['summary_embedding']
+
     async def save(self, driver: GraphDriver):
         if driver.graph_operations_interface:
             try:
@@ -527,6 +564,7 @@ class EntityNode(Node):
             'uuid': self.uuid,
             'name': self.name,
             'name_embedding': self.name_embedding,
+            'summary_embedding': self.summary_embedding,
             'group_id': self.group_id,
             'summary': self.summary,
             'created_at': self.created_at,
@@ -655,6 +693,9 @@ class EntityNode(Node):
 
 class CommunityNode(Node):
     name_embedding: list[float] | None = Field(default=None, description='embedding of the name')
+    summary_embedding: list[float] | None = Field(
+        default=None, description='embedding of the summary'
+    )
     summary: str = Field(description='region summary of member nodes', default_factory=str)
 
     async def save(self, driver: GraphDriver):
@@ -676,6 +717,7 @@ class CommunityNode(Node):
             group_id=self.group_id,
             summary=self.summary,
             name_embedding=self.name_embedding,
+            summary_embedding=self.summary_embedding,
             created_at=self.created_at,
         )
 
@@ -691,6 +733,18 @@ class CommunityNode(Node):
         logger.debug(f'embedded {text} in {end - start} ms')
 
         return self.name_embedding
+
+    async def generate_summary_embedding(self, embedder: EmbedderClient):
+        if not self.summary or not self.summary.strip():
+            return None
+
+        start = time()
+        text = self.summary.replace('\n', ' ')
+        self.summary_embedding = await embedder.create(input_data=[text])
+        end = time()
+        logger.debug(f'embedded summary for {self.name} in {end - start} ms')
+
+        return self.summary_embedding
 
     async def load_name_embedding(self, driver: GraphDriver):
         if driver.provider == GraphProvider.NEPTUNE:
@@ -714,6 +768,29 @@ class CommunityNode(Node):
             raise NodeNotFoundError(self.uuid)
 
         self.name_embedding = records[0]['name_embedding']
+
+    async def load_summary_embedding(self, driver: GraphDriver):
+        if driver.provider == GraphProvider.NEPTUNE:
+            query: LiteralString = """
+                MATCH (c:Community {uuid: $uuid})
+                RETURN [x IN split(c.summary_embedding, ",") | toFloat(x)] as summary_embedding
+            """
+        else:
+            query: LiteralString = """
+            MATCH (c:Community {uuid: $uuid})
+            RETURN c.summary_embedding AS summary_embedding
+            """
+
+        records, _, _ = await driver.execute_query(
+            query,
+            uuid=self.uuid,
+            routing_='r',
+        )
+
+        if len(records) == 0:
+            raise NodeNotFoundError(self.uuid)
+
+        self.summary_embedding = records[0]['summary_embedding']
 
     @classmethod
     async def get_by_uuid(cls, driver: GraphDriver, uuid: str):
@@ -1000,6 +1077,7 @@ def get_entity_node_from_record(record: Any, provider: GraphProvider) -> EntityN
         attributes.pop('name', None)
         attributes.pop('group_id', None)
         attributes.pop('name_embedding', None)
+        attributes.pop('summary_embedding', None)
         attributes.pop('summary', None)
         attributes.pop('created_at', None)
         attributes.pop('labels', None)
@@ -1013,6 +1091,7 @@ def get_entity_node_from_record(record: Any, provider: GraphProvider) -> EntityN
         uuid=record['uuid'],
         name=record['name'],
         name_embedding=record.get('name_embedding'),
+        summary_embedding=record.get('summary_embedding'),
         group_id=group_id,
         labels=labels,
         created_at=parse_db_date(record['created_at']),  # type: ignore
@@ -1029,6 +1108,7 @@ def get_community_node_from_record(record: Any) -> CommunityNode:
         name=record['name'],
         group_id=record['group_id'],
         name_embedding=record['name_embedding'],
+        summary_embedding=record.get('summary_embedding'),
         created_at=parse_db_date(record['created_at']),  # type: ignore
         summary=record['summary'],
     )
@@ -1053,3 +1133,12 @@ async def create_entity_node_embeddings(embedder: EmbedderClient, nodes: list[En
     name_embeddings = await embedder.create_batch([node.name for node in filtered_nodes])
     for node, name_embedding in zip(filtered_nodes, name_embeddings, strict=True):
         node.name_embedding = name_embedding
+
+    # Generate summary embeddings for nodes with non-empty summaries
+    nodes_with_summary = [node for node in filtered_nodes if node.summary and node.summary.strip()]
+    if nodes_with_summary:
+        summary_embeddings = await embedder.create_batch(
+            [node.summary for node in nodes_with_summary]
+        )
+        for node, summary_embedding in zip(nodes_with_summary, summary_embeddings, strict=True):
+            node.summary_embedding = summary_embedding

--- a/graphiti_core/search/search.py
+++ b/graphiti_core/search/search.py
@@ -59,6 +59,7 @@ from graphiti_core.search.search_utils import (
     node_distance_reranker,
     node_fulltext_search,
     node_similarity_search,
+    node_summary_similarity_search,
     rrf,
 )
 
@@ -92,6 +93,8 @@ async def search(
         and EdgeReranker.mmr == config.edge_config.reranker
         or config.node_config
         and NodeSearchMethod.cosine_similarity in config.node_config.search_methods
+        or config.node_config
+        and NodeSearchMethod.summary_similarity in config.node_config.search_methods
         or config.node_config
         and NodeReranker.mmr == config.node_config.reranker
         or (
@@ -331,6 +334,17 @@ async def node_search(
     if NodeSearchMethod.cosine_similarity in config.search_methods:
         search_tasks.append(
             node_similarity_search(
+                driver,
+                query_vector,
+                search_filter,
+                group_ids,
+                2 * limit,
+                config.sim_min_score,
+            )
+        )
+    if NodeSearchMethod.summary_similarity in config.search_methods:
+        search_tasks.append(
+            node_summary_similarity_search(
                 driver,
                 query_vector,
                 search_filter,

--- a/graphiti_core/search/search_config.py
+++ b/graphiti_core/search/search_config.py
@@ -37,6 +37,7 @@ class EdgeSearchMethod(Enum):
 
 class NodeSearchMethod(Enum):
     cosine_similarity = 'cosine_similarity'
+    summary_similarity = 'summary_similarity'
     bm25 = 'bm25'
     bfs = 'breadth_first_search'
 

--- a/graphiti_core/search/search_config_recipes.py
+++ b/graphiti_core/search/search_config_recipes.py
@@ -37,7 +37,11 @@ COMBINED_HYBRID_SEARCH_RRF = SearchConfig(
         reranker=EdgeReranker.rrf,
     ),
     node_config=NodeSearchConfig(
-        search_methods=[NodeSearchMethod.bm25, NodeSearchMethod.cosine_similarity],
+        search_methods=[
+            NodeSearchMethod.bm25,
+            NodeSearchMethod.cosine_similarity,
+            NodeSearchMethod.summary_similarity,
+        ],
         reranker=NodeReranker.rrf,
     ),
     episode_config=EpisodeSearchConfig(
@@ -60,7 +64,11 @@ COMBINED_HYBRID_SEARCH_MMR = SearchConfig(
         mmr_lambda=1,
     ),
     node_config=NodeSearchConfig(
-        search_methods=[NodeSearchMethod.bm25, NodeSearchMethod.cosine_similarity],
+        search_methods=[
+            NodeSearchMethod.bm25,
+            NodeSearchMethod.cosine_similarity,
+            NodeSearchMethod.summary_similarity,
+        ],
         reranker=NodeReranker.mmr,
         mmr_lambda=1,
     ),
@@ -91,6 +99,7 @@ COMBINED_HYBRID_SEARCH_CROSS_ENCODER = SearchConfig(
         search_methods=[
             NodeSearchMethod.bm25,
             NodeSearchMethod.cosine_similarity,
+            NodeSearchMethod.summary_similarity,
             NodeSearchMethod.bfs,
         ],
         reranker=NodeReranker.cross_encoder,
@@ -155,7 +164,11 @@ EDGE_HYBRID_SEARCH_CROSS_ENCODER = SearchConfig(
 # performs a hybrid search over nodes with rrf reranking
 NODE_HYBRID_SEARCH_RRF = SearchConfig(
     node_config=NodeSearchConfig(
-        search_methods=[NodeSearchMethod.bm25, NodeSearchMethod.cosine_similarity],
+        search_methods=[
+            NodeSearchMethod.bm25,
+            NodeSearchMethod.cosine_similarity,
+            NodeSearchMethod.summary_similarity,
+        ],
         reranker=NodeReranker.rrf,
     )
 )
@@ -163,7 +176,11 @@ NODE_HYBRID_SEARCH_RRF = SearchConfig(
 # performs a hybrid search over nodes with mmr reranking
 NODE_HYBRID_SEARCH_MMR = SearchConfig(
     node_config=NodeSearchConfig(
-        search_methods=[NodeSearchMethod.bm25, NodeSearchMethod.cosine_similarity],
+        search_methods=[
+            NodeSearchMethod.bm25,
+            NodeSearchMethod.cosine_similarity,
+            NodeSearchMethod.summary_similarity,
+        ],
         reranker=NodeReranker.mmr,
     )
 )
@@ -171,7 +188,11 @@ NODE_HYBRID_SEARCH_MMR = SearchConfig(
 # performs a hybrid search over nodes with node distance reranking
 NODE_HYBRID_SEARCH_NODE_DISTANCE = SearchConfig(
     node_config=NodeSearchConfig(
-        search_methods=[NodeSearchMethod.bm25, NodeSearchMethod.cosine_similarity],
+        search_methods=[
+            NodeSearchMethod.bm25,
+            NodeSearchMethod.cosine_similarity,
+            NodeSearchMethod.summary_similarity,
+        ],
         reranker=NodeReranker.node_distance,
     )
 )
@@ -179,17 +200,22 @@ NODE_HYBRID_SEARCH_NODE_DISTANCE = SearchConfig(
 # performs a hybrid search over nodes with episode mentions reranking
 NODE_HYBRID_SEARCH_EPISODE_MENTIONS = SearchConfig(
     node_config=NodeSearchConfig(
-        search_methods=[NodeSearchMethod.bm25, NodeSearchMethod.cosine_similarity],
+        search_methods=[
+            NodeSearchMethod.bm25,
+            NodeSearchMethod.cosine_similarity,
+            NodeSearchMethod.summary_similarity,
+        ],
         reranker=NodeReranker.episode_mentions,
     )
 )
 
-# performs a hybrid search over nodes with episode mentions reranking
+# performs a hybrid search over nodes with cross encoder reranking
 NODE_HYBRID_SEARCH_CROSS_ENCODER = SearchConfig(
     node_config=NodeSearchConfig(
         search_methods=[
             NodeSearchMethod.bm25,
             NodeSearchMethod.cosine_similarity,
+            NodeSearchMethod.summary_similarity,
             NodeSearchMethod.bfs,
         ],
         reranker=NodeReranker.cross_encoder,


### PR DESCRIPTION
## Summary

- Adds `summary_embedding` field to `EntityNode` for semantic search over node summaries
- Introduces new `NodeSearchMethod.summary_similarity` for querying nodes by summary content
- Enables finding nodes when query terms appear in summaries but not in names

**Example:** Query "when to write unit tests" now finds a node named "Software Testing Best Practices" with summary "describes when to write unit tests, integration tests, e2e tests".

## Changes

### Data Model (`nodes.py`)
- Added `summary_embedding: list[float] | None` field to `EntityNode`
- Added `generate_summary_embedding()` method (mirrors `generate_name_embedding()`)
- Added `load_summary_embedding()` method for all providers
- Extended `create_entity_node_embeddings()` for batch generation
- Same changes applied to `CommunityNode` for consistency

### Search (`search_config.py`, `search_utils.py`, `search.py`)
- Added `NodeSearchMethod.summary_similarity` enum value
- Implemented `node_summary_similarity_search()` function
- Integrated into `node_search()` dispatch

### Persistence (`node_db_queries.py`)
- Updated save queries for all 4 providers (Neo4j, FalkorDB, Neptune, Kuzu)

### Recipes (`search_config_recipes.py`)
- Added `summary_similarity` to all node-related search recipes (RRF, MMR, etc.)

## Test plan

- [x] Lint passes (`make lint`)
- [x] Type checking passes (`pyright`)
- [x] Manual testing via MCP server confirms semantic search over summaries works
- [x] Backward compatible - `summary_embedding` is optional (`None` by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)