### PR TITLE
Move saga logic into retrieve_episodes utility function

### DIFF
--- a/graphiti_core/driver/graph_operations/graph_operations.py
+++ b/graphiti_core/driver/graph_operations/graph_operations.py
@@ -186,6 +186,18 @@ class GraphOperationsInterface(BaseModel):
         """Retrieve episodic nodes by group IDs with optional pagination."""
         raise NotImplementedError
 
+    async def retrieve_episodes(
+        self,
+        driver: Any,
+        reference_time: Any,
+        last_n: int = 3,
+        group_ids: list[str] | None = None,
+        source: Any | None = None,
+        saga: str | None = None,
+    ) -> list[Any]:
+        """Retrieve the last n episodic nodes from the graph."""
+        raise NotImplementedError
+
     # -----------------------
     # CommunityNode: Save/Delete
     # -----------------------

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -746,56 +746,15 @@ class Graphiti:
         if driver is None:
             driver = self.clients.driver
 
-        # If saga is provided, retrieve episodes from that saga only
-        if saga is not None:
-            from graphiti_core.helpers import parse_db_date
-
-            group_id = group_ids[0] if group_ids else None
-            source_filter = 'AND e.source = $source' if source is not None else ''
-
-            records, _, _ = await driver.execute_query(
-                f"""
-                MATCH (s:Saga {{name: $saga_name, group_id: $group_id}})-[:HAS_EPISODE]->(e:Episodic)
-                WHERE e.valid_at <= $reference_time
-                {source_filter}
-                RETURN e.uuid AS uuid,
-                       e.name AS name,
-                       e.group_id AS group_id,
-                       e.source AS source,
-                       e.source_description AS source_description,
-                       e.content AS content,
-                       e.created_at AS created_at,
-                       e.valid_at AS valid_at,
-                       e.entity_edges AS entity_edges
-                ORDER BY e.valid_at DESC
-                LIMIT $last_n
-                """,
-                saga_name=saga,
-                group_id=group_id,
-                reference_time=reference_time,
-                source=source.value if source else None,
-                last_n=last_n,
-                routing_='r',
-            )
-
-            episodes = []
-            for record in records:
-                episodes.append(
-                    EpisodicNode(
-                        uuid=record['uuid'],
-                        name=record['name'],
-                        group_id=record['group_id'],
-                        source=EpisodeType.from_str(record['source']),
-                        source_description=record['source_description'],
-                        content=record['content'],
-                        created_at=parse_db_date(record['created_at']),  # type: ignore
-                        valid_at=parse_db_date(record['valid_at']),  # type: ignore
-                        entity_edges=record['entity_edges'] or [],
-                    )
+        if driver.graph_operations_interface:
+            try:
+                return await driver.graph_operations_interface.retrieve_episodes(
+                    driver, reference_time, last_n, group_ids, source, saga
                 )
-            return episodes
+            except NotImplementedError:
+                pass
 
-        return await retrieve_episodes(driver, reference_time, last_n, group_ids, source)
+        return await retrieve_episodes(driver, reference_time, last_n, group_ids, source, saga)
 
     async def add_episode(
         self,

--- a/graphiti_core/utils/maintenance/graph_data_operations.py
+++ b/graphiti_core/utils/maintenance/graph_data_operations.py
@@ -64,6 +64,7 @@ async def retrieve_episodes(
     last_n: int = EPISODE_WINDOW_LEN,
     group_ids: list[str] | None = None,
     source: EpisodeType | None = None,
+    saga: str | None = None,
 ) -> list[EpisodicNode]:
     """
     Retrieve the last n episodic nodes from the graph.
@@ -75,10 +76,42 @@ async def retrieve_episodes(
                                    querying the graph's state at a specific point in time.
         last_n (int, optional): The number of most recent episodes to retrieve, relative to the reference_time.
         group_ids (list[str], optional): The list of group ids to return data from.
+        source (EpisodeType, optional): Filter episodes by source type.
+        saga (str, optional): If provided, only retrieve episodes that belong to the saga with this name.
 
     Returns:
         list[EpisodicNode]: A list of EpisodicNode objects representing the retrieved episodes.
     """
+    # If saga is provided, retrieve episodes from that saga only
+    if saga is not None:
+        group_id = group_ids[0] if group_ids else None
+        source_filter = 'AND e.source = $source' if source is not None else ''
+
+        records, _, _ = await driver.execute_query(
+            f"""
+            MATCH (s:Saga {{name: $saga_name, group_id: $group_id}})-[:HAS_EPISODE]->(e:Episodic)
+            WHERE e.valid_at <= $reference_time
+            {source_filter}
+            RETURN
+            """
+            + (
+                EPISODIC_NODE_RETURN_NEPTUNE
+                if driver.provider == GraphProvider.NEPTUNE
+                else EPISODIC_NODE_RETURN
+            )
+            + """
+            ORDER BY e.valid_at DESC
+            LIMIT $num_episodes
+            """,
+            saga_name=saga,
+            group_id=group_id,
+            reference_time=reference_time,
+            source=source.name if source else None,
+            num_episodes=last_n,
+        )
+
+        episodes = [get_episodic_node_from_record(record) for record in records]
+        return list(reversed(episodes))  # Return in chronological order
 
     query_params: dict = {}
     query_filter = ''


### PR DESCRIPTION
## Summary
- Add `saga` parameter to `retrieve_episodes()` function in `graph_data_operations.py`, moving the saga-specific query logic from `Graphiti.retrieve_episodes()`
- Add `retrieve_episodes` stub method to `GraphOperationsInterface` for custom implementations
- Update `Graphiti.retrieve_episodes()` to first try the interface method with fallback to the utility function

## Test plan
- [ ] Verify `retrieve_episodes()` works without saga parameter (existing behavior)
- [ ] Verify `retrieve_episodes()` works with saga parameter
- [ ] Verify custom `GraphOperationsInterface` implementations can override `retrieve_episodes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)