### PR TITLE
fix(falkordb): Clone driver for single group_id search

### DIFF
--- a/graphiti_core/decorators.py
+++ b/graphiti_core/decorators.py
@@ -44,13 +44,14 @@ def handle_multiple_group_ids(func: F) -> F:
         if group_ids is None and group_ids_pos is not None and len(args) > group_ids_pos:
             group_ids = args[group_ids_pos]
 
-        # Only handle FalkorDB with multiple group_ids
+        # Handle FalkorDB where each group_id maps to a separate graph (database)
+        # For FalkorDB, we need to clone the driver to use the correct graph even for a single group_id
         if (
             hasattr(self, 'clients')
             and hasattr(self.clients, 'driver')
             and self.clients.driver.provider == GraphProvider.FALKORDB
             and group_ids
-            and len(group_ids) > 1
+            and len(group_ids) >= 1
         ):
             # Execute for each group_id concurrently
             driver = self.clients.driver


### PR DESCRIPTION
## Summary
- Fix FalkorDB search failing when using a single group_id
- Change decorator condition from `len(group_ids) > 1` to `len(group_ids) >= 1`
- Update comments to clarify FalkorDB's multi-graph architecture

## Type of Change
- [x] Bug fix

## Objective
FalkorDB stores each `group_id` as a separate graph (database), not as a property within a single graph. The `handle_multiple_group_ids` decorator was only cloning the driver when multiple group_ids were specified, causing searches with a single group_id to execute against `default_db` instead of the target graph.

## Testing
- [x] Verified fix resolves the issue locally with FalkorDB
- [x] All existing tests pass

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No secrets or sensitive information committed

## Related Issues
Closes #1161
