### PR TITLE
fix(falkordb): escape group_ids in RediSearch fulltext queries

### DIFF
--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -343,7 +343,10 @@ class FalkorDriver(GraphDriver):
         if group_ids is None or len(group_ids) == 0:
             group_filter = ''
         else:
-            group_values = '|'.join(group_ids)
+            # Escape group_ids with quotes to prevent RediSearch syntax errors
+            # with reserved words like "main" or special characters like hyphens
+            escaped_group_ids = [f'"{gid}"' for gid in group_ids]
+            group_values = '|'.join(escaped_group_ids)
             group_filter = f'(@group_id:{group_values})'
 
         sanitized_query = self.sanitize(query)


### PR DESCRIPTION
## Summary

- Group IDs like "main" are reserved words in RediSearch and cause syntax errors when used unquoted
- Group IDs with hyphens (e.g., "project-name") also need escaping
- This fix wraps all group_ids in double quotes in the fulltext query

**Before:** `(@group_id:main|project-name)`
**After:** `(@group_id:"main"|"project-name")`

## Problem

Intermittent errors like:
```
RediSearch: Syntax error at offset 20 near main
```

## Solution

Simple 4-line fix in `graphiti_core/driver/falkordb_driver.py`:
```python
escaped_group_ids = [f'"{gid}"' for gid in group_ids]
group_values = '|'.join(escaped_group_ids)
```

## Test plan

- [x] Tested with group_id "main" - no more syntax errors
- [x] Tested with group_id "Milofax-infrastructure" - works correctly
- [x] Tested with multiple group_ids - proper OR query generated

🤖 Generated with [Claude Code](https://claude.ai/code)