### PR TITLE
Fix: move AsyncWorker start to app lifespan to resolve FastAPI router…

### DIFF
--- a/server/graph_service/main.py
+++ b/server/graph_service/main.py
@@ -5,6 +5,7 @@ from fastapi.responses import JSONResponse
 
 from graph_service.config import get_settings
 from graph_service.routers import ingest, retrieve
+from graph_service.routers.ingest import async_worker
 from graph_service.zep_graphiti import initialize_graphiti
 
 
@@ -12,7 +13,14 @@ from graph_service.zep_graphiti import initialize_graphiti
 async def lifespan(_: FastAPI):
     settings = get_settings()
     await initialize_graphiti(settings)
+    
+    # Start the async worker for processing messages
+    await async_worker.start()
+    
     yield
+    
+    # Shutdown worker
+    await async_worker.stop()
     # Shutdown
     # No need to close Graphiti here, as it's handled per-request
 

--- a/server/graph_service/routers/ingest.py
+++ b/server/graph_service/routers/ingest.py
@@ -1,36 +1,59 @@
 import asyncio
-from contextlib import asynccontextmanager
+import logging
 from functools import partial
 
-from fastapi import APIRouter, FastAPI, status
+from fastapi import APIRouter, status
 from graphiti_core.nodes import EpisodeType  # type: ignore
-from graphiti_core.utils.maintenance.graph_data_operations import clear_data  # type: ignore
 
-from graph_service.dto import AddEntityNodeRequest, AddMessagesRequest, Message, Result
-from graph_service.zep_graphiti import ZepGraphitiDep
+from graph_service.dto import AddMessagesRequest, Message, Result, AddEntityNodeRequest
+from graph_service.zep_graphiti import ZepGraphiti, ZepGraphitiDep
+from graph_service.config import get_settings
+from graphiti_core.utils.maintenance.graph_data_operations import clear_data # type: ignore
+
+logger = logging.getLogger(__name__)
 
 
 class AsyncWorker:
     def __init__(self):
         self.queue = asyncio.Queue()
         self.task = None
+        self.graphiti = None
 
     async def worker(self):
         while True:
             try:
-                print(f'Got a job: (size of remaining queue: {self.queue.qsize()})')
                 job = await self.queue.get()
                 await job()
             except asyncio.CancelledError:
                 break
+            except Exception as e:
+                logger.error(f'AsyncWorker error in worker loop: {e}', exc_info=True)
+            finally:
+                if 'job' in locals():
+                    self.queue.task_done()
 
     async def start(self):
+        settings = get_settings()
+        self.graphiti = ZepGraphiti(
+            uri=settings.neo4j_uri,
+            user=settings.neo4j_user,
+            password=settings.neo4j_password
+        )
+        if settings.openai_base_url:
+            self.graphiti.llm_client.config.base_url = settings.openai_base_url
+        if settings.openai_api_key:
+            self.graphiti.llm_client.config.api_key = settings.openai_api_key
+        if settings.model_name:
+            self.graphiti.llm_client.model = settings.model_name
+            
         self.task = asyncio.create_task(self.worker())
 
     async def stop(self):
         if self.task:
             self.task.cancel()
             await self.task
+        if self.graphiti:
+            await self.graphiti.close()
         while not self.queue.empty():
             self.queue.get_nowait()
 
@@ -38,31 +61,24 @@ class AsyncWorker:
 async_worker = AsyncWorker()
 
 
-@asynccontextmanager
-async def lifespan(_: FastAPI):
-    await async_worker.start()
-    yield
-    await async_worker.stop()
-
-
-router = APIRouter(lifespan=lifespan)
+router = APIRouter()
 
 
 @router.post('/messages', status_code=status.HTTP_202_ACCEPTED)
 async def add_messages(
     request: AddMessagesRequest,
-    graphiti: ZepGraphitiDep,
 ):
     async def add_messages_task(m: Message):
-        await graphiti.add_episode(
-            uuid=m.uuid,
-            group_id=request.group_id,
-            name=m.name,
-            episode_body=f'{m.role or ""}({m.role_type}): {m.content}',
-            reference_time=m.timestamp,
-            source=EpisodeType.message,
-            source_description=m.source_description,
-        )
+        if async_worker.graphiti:
+            await async_worker.graphiti.add_episode(
+                uuid=m.uuid,
+                group_id=request.group_id,
+                name=m.name,
+                episode_body=f'{m.role or ""}({m.role_type}): {m.content}',
+                reference_time=m.timestamp,
+                source=EpisodeType.message,
+                source_description=m.source_description,
+            )
 
     for m in request.messages:
         await async_worker.queue.put(partial(add_messages_task, m))


### PR DESCRIPTION
… bug

## Summary
Moves the AsyncWorker lifecycle management to the FastAPI application lifespan and ensures the background worker maintains its own persistent database client.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
The previous implementation attempted to start the background worker within an APIRouter lifespan. In certain FastAPI configurations, this can lead to race conditions where the worker fails to start. Furthermore, using request-scoped database clients within background tasks often resulted in "connection closed" errors, as the request context frequently concludes before the worker queue finishes processing.

This change:

Migrates worker start/stop to the global FastAPI lifespan in main.py.
Provides the AsyncWorker with its own persistent ZepGraphiti client.
Hardens the worker loop with error handling to ensure continuous operation even if a single job fails.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

## Breaking Changes
- [ ] This PR contains breaking changes

If this is a breaking change, describe:
- What functionality is affected
- Migration path for existing users

## Checklist
- [ ] Code follows project style guidelines (`make lint` passes)
- [ ] Self-review completed
- [ ] Documentation updated where necessary
- [ ] No secrets or sensitive information committed

## Related Issues
Closes #[issue number]