### PR TITLE
fix(falkordb): sanitize pipe and slash chars in fulltext queries

### DIFF
--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -321,6 +321,9 @@ class FalkorDriver(GraphDriver):
                 '=': ' ',
                 '~': ' ',
                 '?': ' ',
+                '|': ' ',
+                '/': ' ',
+                '\\': ' ',
             }
         )
         sanitized = query.translate(separator_map)
@@ -348,9 +351,9 @@ class FalkorDriver(GraphDriver):
 
         sanitized_query = self.sanitize(query)
 
-        # Remove stopwords from the sanitized query
+        # Remove stopwords and empty tokens from the sanitized query
         query_words = sanitized_query.split()
-        filtered_words = [word for word in query_words if word.lower() not in STOPWORDS]
+        filtered_words = [word for word in query_words if word and word.lower() not in STOPWORDS]
         sanitized_query = ' | '.join(filtered_words)
 
         # If the query is too long return no query


### PR DESCRIPTION
## Summary

- Add `|`, `/`, `\` to the FalkorDB `sanitize()` character map in `build_fulltext_query()`
- Filter empty strings before pipe-joining as defense-in-depth

## Problem

Episode text containing shell commands like `curl -fsSL https://claude.ai/install.sh | bash` causes `RediSearch: Syntax error` because:

1. `sanitize()` replaces special chars with spaces, but `|` (pipe) was **not** in the map
2. `build_fulltext_query()` splits on whitespace and joins with `' | '` as RediSearch OR separator
3. A literal `|` in the input becomes an empty token: `sh | | | bash`
4. RediSearch rejects empty tokens between pipe delimiters

```
Input:  "install.sh | bash"
After sanitize():  "install sh | bash"     ← pipe survives
After split():     ['install', 'sh', '|', 'bash']
After join(' | '): "install | sh | | | bash"
                                 ^^^
                           Empty token → Syntax error
```

## Fix

Add `|`, `/`, `\` to the `separator_map` in `sanitize()` so they are replaced with spaces before tokenization. Also filter empty strings in `build_fulltext_query()` as a safety net.

## Test plan

- [x] Reproduced in production: episodes with `install.sh | bash` triggered `RediSearch: Syntax error at offset 178 near sh`
- [x] After fix: Graphiti container healthy, episodes processing normally
- [x] Verified `sanitize("install.sh | bash")` → `"install sh bash"` (no pipe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)