### PR TITLE
feat(mcp): add multi-tenant FalkorDB search and discovery tools

### DIFF
--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -117,13 +117,13 @@ GRAPHITI_MCP_INSTRUCTIONS = """
 Graphiti is a memory service for AI agents built on a knowledge graph. Graphiti performs well
 with dynamic data such as user interactions, changing enterprise data, and external information.
 
-Graphiti transforms information into a richly connected knowledge network, allowing you to 
-capture relationships between concepts, entities, and information. The system organizes data as episodes 
-(content snippets), nodes (entities), and facts (relationships between entities), creating a dynamic, 
-queryable memory store that evolves with new information. Graphiti supports multiple data formats, including 
+Graphiti transforms information into a richly connected knowledge network, allowing you to
+capture relationships between concepts, entities, and information. The system organizes data as episodes
+(content snippets), nodes (entities), and facts (relationships between entities), creating a dynamic,
+queryable memory store that evolves with new information. Graphiti supports multiple data formats, including
 structured JSON data, enabling seamless integration with existing data pipelines and systems.
 
-Facts contain temporal metadata, allowing you to track the time of creation and whether a fact is invalid 
+Facts contain temporal metadata, allowing you to track the time of creation and whether a fact is invalid
 (superseded by new information).
 
 Key capabilities:
@@ -133,14 +133,25 @@ Key capabilities:
 4. Retrieve specific entity edges or episodes by UUID
 5. Manage the knowledge graph with tools like delete_episode, delete_entity_edge, and clear_graph
 
-The server connects to a database for persistent storage and uses language models for certain operations. 
+The server connects to a database for persistent storage and uses language models for certain operations.
 Each piece of information is organized by group_id, allowing you to maintain separate knowledge domains.
 
-When adding information, provide descriptive names and detailed content to improve search quality. 
+When adding information, provide descriptive names and detailed content to improve search quality.
 When searching, use specific queries and consider filtering by group_id for more relevant results.
 
-For optimal performance, ensure the database is properly configured and accessible, and valid 
+For optimal performance, ensure the database is properly configured and accessible, and valid
 API keys are provided for any language model operations.
+
+IMPORTANT - Before searching:
+1. Call list_group_ids() first to see available topics/projects
+2. This shows what group_ids you can search and helps target your search
+3. Then use search_nodes/search_facts with specific group_ids for better results
+
+Example workflow:
+- User: "Search for API information"
+- Assistant: First calls list_group_ids() to see available topics
+- Assistant: Sees "prefiltering", "spark-v1", "github-actions", etc.
+- Assistant: Calls search_nodes(query="API", group_ids=["prefiltering", "spark-v1"])
 """
 
 # MCP server instance


### PR DESCRIPTION
## Summary

This PR enhances the MCP server to properly support FalkorDB's multi-tenant architecture by implementing cross-database search capabilities and adding discovery tools for better user experience.

### Problem

The MCP server's search functions (`search_nodes`, `search_memory_facts`, `get_episodes`) only searched the default database, even when `group_ids` parameter was provided. In FalkorDB's multi-tenant architecture, each group_id can correspond to a separate database/graph, making it impossible to search across different topics or projects.

Additionally, users had no way to discover what group_ids were available for searching, leading to confusion about what data could be queried.

### Solution

**Multi-Tenant Search Support:**
- Modified `search_nodes`, `search_memory_facts`, and `get_episodes` to clone the driver for each group_id and search the corresponding FalkorDB database
- Results from multiple databases are aggregated and returned as a unified response
- Maintains backward compatibility with single-database searches

**Discovery Tools:**
1. **list_graphs()** - Lists all FalkorDB databases with node/edge counts and sample data
2. **list_group_ids()** - Shows all available group_ids across databases with node counts, enabling users to discover searchable topics

**Improved UX:**
- Updated MCP server instructions to automatically prompt AI assistants to call `list_group_ids()` before searching
- This helps users understand what data is available and target their searches effectively

## Changes

### Core Functionality
- **search_nodes**: Added multi-database search loop when using FalkorDB with group_ids
- **search_memory_facts**: Added multi-database search loop for facts across databases  
- **get_episodes**: Added multi-database retrieval for episodes across databases

### New Tools
- **list_graphs**: Explore all FalkorDB databases using redis-cli subprocess and execute_query
- **list_group_ids**: Discover available topics/projects for targeted searching

### Documentation
- Updated `GRAPHITI_MCP_INSTRUCTIONS` to guide AI assistants to call list_group_ids() before searching

## Technical Details

### Driver Cloning Pattern
```python
if client.driver.provider == GraphProvider.FALKORDB and effective_group_ids:
    for group_id in effective_group_ids:
        if group_id != client.driver._database:
            cloned_driver = client.driver.clone(database=group_id)
        else:
            cloned_driver = client.driver
        
        results = await client.search_(
            query=query,
            driver=cloned_driver,
            group_ids=[group_id],
            # ... other params
        )
```

### Database Discovery
- `list_graphs()` uses Redis `GRAPH.LIST` command via subprocess
- Statistics gathered using `execute_query()` for proper result parsing
- `list_group_ids()` aggregates group_ids from all databases with deduplication

## Testing

Tested with production FalkorDB instance containing:
- 8 separate databases with different topics (spark-v1, prefiltering, glamdring, etc.)
- 1,100+ total nodes across databases
- Multi-tenant searches successfully return results from appropriate databases
- Discovery tools correctly list all available group_ids

## Impact

- **Breaking Changes**: None - maintains full backward compatibility
- **New Features**: Multi-tenant search, database discovery, group_id discovery
- **Bug Fixes**: Resolves issue where searches with group_ids returned no results in multi-tenant setups

## Related

This addresses the architectural pattern established in commit c144ff5 where `add_episode` automatically creates separate FalkorDB databases per group_id, but search functions didn't follow the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)