### PR TITLE
chore: bump version to 0.27.0pre2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "graphiti-core"
 description = "A temporal graph building library"
-version = "0.27.0pre1"
+version = "0.27.0pre2"
 authors = [
     { name = "Paul Paliychuk", email = "paul@getzep.com" },
     { name = "Preston Rasmussen", email = "preston@getzep.com" },


### PR DESCRIPTION
## Summary
- Bump graphiti-core version from 0.27.0pre1 to 0.27.0pre2
- Update mcp_server dependency to use 0.27.0pre2

## Test plan
- [ ] Verify package builds correctly
- [ ] Verify mcp_server installs with updated dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)