### PR TITLE
fix(mcp): use load_dotenv(override=True) to prioritize .env over shell vars

### DIFF
--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -36,13 +36,14 @@ from services.queue_service import QueueService
 from utils.formatting import format_fact_result
 
 # Load .env file from mcp_server directory
+# Use override=True to ensure .env takes precedence over shell env vars
 mcp_server_dir = Path(__file__).parent.parent
 env_file = mcp_server_dir / '.env'
 if env_file.exists():
-    load_dotenv(env_file)
+    load_dotenv(env_file, override=True)
 else:
     # Try current working directory as fallback
-    load_dotenv()
+    load_dotenv(override=True)
 
 
 # Semaphore limit for concurrent Graphiti operations.


### PR DESCRIPTION
## Summary
- Fixed MCP server connecting to wrong Neo4j database when shell has conflicting `NEO4J_URI`

## Problem
When the shell environment has `NEO4J_URI` set (e.g., from `.zshrc`), the default `load_dotenv()` behavior doesn't override it. This causes the MCP server to connect to the wrong database.

## Solution
Added `override=True` to `load_dotenv()` calls, ensuring the `.env` file credentials take precedence over any pre-existing shell environment variables.

## Test plan
- [x] Verified MCP server connects to correct database specified in `.env`
- [x] Tested with conflicting `NEO4J_URI` in shell environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)