### PR TITLE
fix(search): use OR syntax for FalkorDB multi-label node filters

### DIFF
--- a/graphiti_core/search/search_filters.py
+++ b/graphiti_core/search/search_filters.py
@@ -87,6 +87,9 @@ def node_search_filter_query_constructor(
         if provider == GraphProvider.KUZU:
             node_label_filter = 'list_has_all(n.labels, $labels)'
             filter_params['labels'] = filters.node_labels
+        elif provider == GraphProvider.FALKORDB:
+            parts = [f'n:{label}' for label in filters.node_labels]
+            node_label_filter = '(' + ' OR '.join(parts) + ')'
         else:
             node_labels = '|'.join(filters.node_labels)
             node_label_filter = 'n:' + node_labels
@@ -130,6 +133,12 @@ def edge_search_filter_query_constructor(
                 'list_has_all(n.labels, $labels) AND list_has_all(m.labels, $labels)'
             )
             filter_params['labels'] = filters.node_labels
+        elif provider == GraphProvider.FALKORDB:
+            n_parts = [f'n:{label}' for label in filters.node_labels]
+            m_parts = [f'm:{label}' for label in filters.node_labels]
+            node_label_filter = (
+                '(' + ' OR '.join(n_parts) + ') AND (' + ' OR '.join(m_parts) + ')'
+            )
         else:
             node_labels = '|'.join(filters.node_labels)
             node_label_filter = 'n:' + node_labels + ' AND m:' + node_labels

--- a/tests/utils/search/test_search_filters.py
+++ b/tests/utils/search/test_search_filters.py
@@ -1,0 +1,129 @@
+"""Tests for search_filters.py — node/edge label filter query construction."""
+
+import pytest
+
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.search.search_filters import (
+    SearchFilters,
+    edge_search_filter_query_constructor,
+    node_search_filter_query_constructor,
+)
+
+
+# ── node_search_filter_query_constructor ──────────────────────────────
+
+
+class TestNodeSearchFilterSingleLabel:
+    """Single-label filter should work identically across providers."""
+
+    @pytest.mark.parametrize(
+        "provider",
+        [GraphProvider.NEO4J, GraphProvider.FALKORDB, GraphProvider.NEPTUNE],
+    )
+    def test_single_label(self, provider: GraphProvider):
+        filters = SearchFilters(node_labels=["Aircraft"])
+        queries, _ = node_search_filter_query_constructor(filters, provider)
+        assert len(queries) == 1
+        assert "Aircraft" in queries[0]
+
+    def test_single_label_kuzu(self):
+        filters = SearchFilters(node_labels=["Aircraft"])
+        queries, params = node_search_filter_query_constructor(filters, GraphProvider.KUZU)
+        assert queries == ["list_has_all(n.labels, $labels)"]
+        assert params["labels"] == ["Aircraft"]
+
+
+class TestNodeSearchFilterMultiLabel:
+    """Multi-label filter must use provider-appropriate syntax."""
+
+    def test_neo4j_uses_pipe_syntax(self):
+        filters = SearchFilters(node_labels=["Occurrence", "Operator"])
+        queries, params = node_search_filter_query_constructor(filters, GraphProvider.NEO4J)
+        assert queries == ["n:Occurrence|Operator"]
+        assert params == {}
+
+    def test_falkordb_uses_or_syntax(self):
+        filters = SearchFilters(node_labels=["Occurrence", "Operator"])
+        queries, params = node_search_filter_query_constructor(filters, GraphProvider.FALKORDB)
+        assert len(queries) == 1
+        assert queries[0] == "(n:Occurrence OR n:Operator)"
+        assert params == {}
+
+    def test_falkordb_three_labels(self):
+        filters = SearchFilters(node_labels=["Aircraft", "Occurrence", "Operator"])
+        queries, _ = node_search_filter_query_constructor(filters, GraphProvider.FALKORDB)
+        assert queries[0] == "(n:Aircraft OR n:Occurrence OR n:Operator)"
+
+    def test_kuzu_uses_list_has_all(self):
+        filters = SearchFilters(node_labels=["Occurrence", "Operator"])
+        queries, params = node_search_filter_query_constructor(filters, GraphProvider.KUZU)
+        assert queries == ["list_has_all(n.labels, $labels)"]
+        assert params["labels"] == ["Occurrence", "Operator"]
+
+
+class TestNodeSearchFilterEmpty:
+    """No node_labels → no filter."""
+
+    def test_none_labels(self):
+        filters = SearchFilters(node_labels=None)
+        queries, params = node_search_filter_query_constructor(filters, GraphProvider.FALKORDB)
+        assert queries == []
+        assert params == {}
+
+
+# ── edge_search_filter_query_constructor ──────────────────────────────
+
+
+class TestEdgeSearchFilterMultiLabel:
+    """Multi-label node filter within edge queries."""
+
+    def test_neo4j_uses_pipe_syntax(self):
+        filters = SearchFilters(node_labels=["Occurrence", "Operator"])
+        queries, _ = edge_search_filter_query_constructor(filters, GraphProvider.NEO4J)
+        assert len(queries) == 1
+        assert queries[0] == "n:Occurrence|Operator AND m:Occurrence|Operator"
+
+    def test_falkordb_uses_or_syntax(self):
+        filters = SearchFilters(node_labels=["Occurrence", "Operator"])
+        queries, params = edge_search_filter_query_constructor(filters, GraphProvider.FALKORDB)
+        assert len(queries) == 1
+        assert queries[0] == "(n:Occurrence OR n:Operator) AND (m:Occurrence OR m:Operator)"
+        assert params == {}
+
+    def test_falkordb_three_labels(self):
+        filters = SearchFilters(node_labels=["Aircraft", "Occurrence", "Operator"])
+        queries, _ = edge_search_filter_query_constructor(filters, GraphProvider.FALKORDB)
+        assert queries[0] == (
+            "(n:Aircraft OR n:Occurrence OR n:Operator) AND "
+            "(m:Aircraft OR m:Occurrence OR m:Operator)"
+        )
+
+    def test_kuzu_uses_list_has_all(self):
+        filters = SearchFilters(node_labels=["Occurrence", "Operator"])
+        queries, params = edge_search_filter_query_constructor(filters, GraphProvider.KUZU)
+        assert "list_has_all" in queries[0]
+        assert params["labels"] == ["Occurrence", "Operator"]
+
+
+class TestEdgeSearchFilterSingleLabel:
+    """Single-label node filter in edge queries works across providers."""
+
+    @pytest.mark.parametrize(
+        "provider",
+        [GraphProvider.NEO4J, GraphProvider.FALKORDB, GraphProvider.NEPTUNE],
+    )
+    def test_single_label(self, provider: GraphProvider):
+        filters = SearchFilters(node_labels=["Aircraft"])
+        queries, _ = edge_search_filter_query_constructor(filters, provider)
+        assert len(queries) == 1
+        assert "Aircraft" in queries[0]
+
+
+class TestEdgeSearchFilterEdgeTypes:
+    """edge_types filter is provider-agnostic."""
+
+    def test_edge_types_filter(self):
+        filters = SearchFilters(edge_types=["OPERATED_BY", "LOCATED_IN"])
+        queries, params = edge_search_filter_query_constructor(filters, GraphProvider.FALKORDB)
+        assert "e.name in $edge_types" in queries
+        assert params["edge_types"] == ["OPERATED_BY", "LOCATED_IN"]


### PR DESCRIPTION
## Summary

- FalkorDB rejects Neo4j pipe syntax (`n:Label1|Label2`) when filtering by multiple node labels. This adds FalkorDB-specific branches in both `node_search_filter_query_constructor` and `edge_search_filter_query_constructor` that generate `(n:Label1 OR n:Label2)` instead.

## Problem

`search_filters.py` has an `else` branch that uses `'|'.join(filters.node_labels)` to build label filters. This works for Neo4j but FalkorDB doesn't support the pipe multi-label syntax:

```
Invalid input '|': expected an expression (line 1, column 66 (offset: 65))
"... WHERE n:Occurrence|Operator ..."
```

The bug only manifests with 2+ labels — single-label filters work because `'|'.join(["Label"])` produces `"Label"` which is valid on all providers.

## Fix

Added `elif provider == GraphProvider.FALKORDB` branches that generate OR-based syntax:
- Node search: `(n:Label1 OR n:Label2)`
- Edge search: `(n:Label1 OR n:Label2) AND (m:Label1 OR m:Label2)`

## Test plan

- [x] 17 new unit tests covering single-label, multi-label (2 and 3 labels), and empty label cases across all providers (Neo4j, FalkorDB, KUZU, Neptune)
- [x] Existing search_utils tests still pass
- [x] Verified fix against live FalkorDB instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)