### PR TITLE
fix(search): allow BFS traversal when query is empty but origin UUIDs provided

### DIFF
--- a/graphiti_core/search/search.py
+++ b/graphiti_core/search/search.py
@@ -82,10 +82,15 @@ async def search(
     embedder = clients.embedder
     cross_encoder = clients.cross_encoder
 
-    if query.strip() == '':
+    # Only bail on empty query when there's no BFS fallback.
+    # BFS traversal doesn't need a text query — only origin UUIDs.
+    if query.strip() == '' and not bfs_origin_node_uuids:
         return SearchResults()
 
-    if (
+    # Skip embedding API call when query is empty (BFS-only path)
+    if query.strip() == '':
+        search_vector = [0.0] * EMBEDDING_DIM
+    elif (
         config.edge_config
         and EdgeSearchMethod.cosine_similarity in config.edge_config.search_methods
         or config.edge_config

--- a/tests/utils/search/test_search_empty_query_bfs.py
+++ b/tests/utils/search/test_search_empty_query_bfs.py
@@ -1,0 +1,145 @@
+"""Tests for search() behavior with empty query + BFS origin UUIDs.
+
+Regression test: search() must not bail on empty query when bfs_origin_node_uuids
+is provided. BFS traversal doesn't need a text query — only origin UUIDs.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graphiti_core.edges import EntityEdge
+from graphiti_core.nodes import EntityNode
+from graphiti_core.search.search import search
+from graphiti_core.search.search_config import (
+    EdgeReranker,
+    EdgeSearchConfig,
+    EdgeSearchMethod,
+    NodeReranker,
+    NodeSearchConfig,
+    NodeSearchMethod,
+    SearchConfig,
+)
+from graphiti_core.search.search_filters import SearchFilters
+
+
+def _make_clients():
+    """Build a minimal GraphitiClients mock."""
+    clients = MagicMock()
+    clients.driver = MagicMock()
+    clients.driver.provider = MagicMock()
+    clients.driver.search_interface = None
+    clients.embedder = AsyncMock()
+    clients.cross_encoder = AsyncMock()
+    return clients
+
+
+def _bfs_only_config():
+    """SearchConfig that only uses BFS — no embedding needed."""
+    return SearchConfig(
+        edge_config=EdgeSearchConfig(
+            search_methods=[EdgeSearchMethod.bfs],
+            reranker=EdgeReranker.rrf,
+            bfs_max_depth=2,
+        ),
+        node_config=NodeSearchConfig(
+            search_methods=[NodeSearchMethod.bfs],
+            reranker=NodeReranker.rrf,
+            bfs_max_depth=2,
+        ),
+        limit=10,
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_query_no_bfs_returns_empty():
+    """Empty query with no BFS origins should still return empty."""
+    clients = _make_clients()
+    result = await search(clients, '', None, _bfs_only_config(), SearchFilters())
+    assert result.nodes == []
+    assert result.edges == []
+
+
+@pytest.mark.asyncio
+async def test_empty_query_with_bfs_origins_runs_bfs():
+    """Empty query with bfs_origin_node_uuids must NOT bail — BFS should execute."""
+    clients = _make_clients()
+
+    bfs_node = EntityNode(uuid='node-1', name='Vueling Airlines', labels=['Operator'], group_id='g1')
+    bfs_edge = EntityEdge(
+        uuid='edge-1',
+        name='OPERATED_BY',
+        fact='Vueling Airlines operates EC-MYT',
+        source_node_uuid='node-2',
+        target_node_uuid='node-1',
+        group_id='g1',
+        created_at=datetime.now(timezone.utc),
+    )
+
+    with (
+        patch('graphiti_core.search.search.node_bfs_search', new_callable=AsyncMock) as mock_node_bfs,
+        patch('graphiti_core.search.search.edge_bfs_search', new_callable=AsyncMock) as mock_edge_bfs,
+        patch('graphiti_core.search.search.node_fulltext_search', new_callable=AsyncMock) as mock_node_ft,
+        patch('graphiti_core.search.search.edge_fulltext_search', new_callable=AsyncMock) as mock_edge_ft,
+        patch('graphiti_core.search.search.node_similarity_search', new_callable=AsyncMock) as mock_node_sim,
+        patch('graphiti_core.search.search.edge_similarity_search', new_callable=AsyncMock) as mock_edge_sim,
+        patch('graphiti_core.search.search.episode_fulltext_search', new_callable=AsyncMock) as mock_ep_ft,
+        patch('graphiti_core.search.search.community_fulltext_search', new_callable=AsyncMock) as mock_comm_ft,
+        patch('graphiti_core.search.search.community_similarity_search', new_callable=AsyncMock) as mock_comm_sim,
+    ):
+        mock_node_bfs.return_value = [bfs_node]
+        mock_edge_bfs.return_value = [bfs_edge]
+        # All other search methods return empty (no text to search)
+        for m in [mock_node_ft, mock_edge_ft, mock_node_sim, mock_edge_sim,
+                  mock_ep_ft, mock_comm_ft, mock_comm_sim]:
+            m.return_value = []
+
+        result = await search(
+            clients,
+            '',  # empty query
+            ['g1'],
+            _bfs_only_config(),
+            SearchFilters(),
+            center_node_uuid='node-1',
+            bfs_origin_node_uuids=['node-1'],
+        )
+
+        # BFS must have been called
+        mock_node_bfs.assert_called_once()
+        mock_edge_bfs.assert_called_once()
+
+        # Results must include BFS-discovered nodes and edges
+        assert len(result.nodes) >= 1
+        assert result.nodes[0].uuid == 'node-1'
+        assert len(result.edges) >= 1
+        assert result.edges[0].uuid == 'edge-1'
+
+
+@pytest.mark.asyncio
+async def test_empty_query_with_bfs_skips_embedding_call():
+    """When query is empty, should NOT call the embedder API — use zero vector instead."""
+    clients = _make_clients()
+
+    with (
+        patch('graphiti_core.search.search.node_bfs_search', new_callable=AsyncMock, return_value=[]),
+        patch('graphiti_core.search.search.edge_bfs_search', new_callable=AsyncMock, return_value=[]),
+        patch('graphiti_core.search.search.node_fulltext_search', new_callable=AsyncMock, return_value=[]),
+        patch('graphiti_core.search.search.edge_fulltext_search', new_callable=AsyncMock, return_value=[]),
+        patch('graphiti_core.search.search.node_similarity_search', new_callable=AsyncMock, return_value=[]),
+        patch('graphiti_core.search.search.edge_similarity_search', new_callable=AsyncMock, return_value=[]),
+        patch('graphiti_core.search.search.episode_fulltext_search', new_callable=AsyncMock, return_value=[]),
+        patch('graphiti_core.search.search.community_fulltext_search', new_callable=AsyncMock, return_value=[]),
+        patch('graphiti_core.search.search.community_similarity_search', new_callable=AsyncMock, return_value=[]),
+    ):
+        await search(
+            clients,
+            '',  # empty query
+            None,
+            _bfs_only_config(),
+            SearchFilters(),
+            bfs_origin_node_uuids=['node-1'],
+        )
+
+        # Embedder must NOT be called — zero vector should be used
+        clients.embedder.create.assert_not_called()


### PR DESCRIPTION
## Summary

- `search()` bails on empty query strings before reaching BFS traversal. This breaks `explore_node` when called with `node_uuid` only (no `node_name`), because the MCP tool passes `query=''` in that case.

## Problem

`explore_node` passes `query=node_name or ''` to `search_()`. When only `node_uuid` is provided, query becomes `''`. The guard at line 85-86 of `search.py`:

```python
if query.strip() == '':
    return SearchResults()
```

...kills the entire search including BFS, even though BFS doesn't need a text query — it only needs `bfs_origin_node_uuids`.

**Result:** `explore_node(node_uuid="...")` always returns 0 nodes and 0 edges. `explore_node(node_name="...")` works fine because the name is a non-empty query string.

## Fix

Two changes in `search()`:

1. **Conditional bail:** Only return empty when BOTH query is empty AND no BFS origins are provided:
   ```python
   if query.strip() == '' and not bfs_origin_node_uuids:
       return SearchResults()
   ```

2. **Skip embedding on empty query:** When query is empty but BFS will run, use a zero vector instead of calling the embedder API with an empty string:
   ```python
   if query.strip() == '':
       search_vector = [0.0] * EMBEDDING_DIM
   elif (needs_embedding):
       search_vector = await embedder.create(...)
   ```

BFS runs normally. bm25/cosine methods return empty for the empty query (they already handle this gracefully). The rerankers work fine because `node_distance` doesn't need embeddings.

## Test plan

- [x] `test_empty_query_no_bfs_returns_empty` — existing behavior preserved
- [x] `test_empty_query_with_bfs_origins_runs_bfs` — BFS executes and returns results
- [x] `test_empty_query_with_bfs_skips_embedding_call` — no wasted API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)