### PR TITLE
fix(falkordb): handle empty query in build_fulltext_query

### DIFF
--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -363,6 +363,12 @@ class FalkorDriver(GraphDriver):
         if len(sanitized_query.split(' ')) + len(group_ids or '') >= max_query_length:
             return ''
 
+        # If the query is empty (e.g., node_uuid-only explore_node), return
+        # just the group filter or empty string — empty parens are invalid
+        # RediSearch syntax.
+        if not sanitized_query:
+            return group_filter
+
         full_query = group_filter + ' (' + sanitized_query + ')'
 
         return full_query


### PR DESCRIPTION
## Summary

- Fix RediSearch syntax error when `build_fulltext_query()` receives an empty query string with group IDs
- When the query is empty (e.g., `explore_node` called with `node_uuid` but no `node_name`), the method was producing `(@group_id:"...") ()` — the empty parentheses are invalid RediSearch syntax
- Now returns just the group filter when the sanitized query is empty

## Reproduction

```python
# MCP server: explore_node with node_uuid triggers search with query=""
await client.search_(query="", group_ids=["my_graph"], ...)

# build_fulltext_query("", ["my_graph"]) was producing:
#   (@group_id:"my_graph") ()     ← invalid RediSearch syntax
#
# Error: "RediSearch: Syntax error at offset 22 near my_graph"
```

The `explore_node` MCP tool calls `client.search_()` with `query=node_name or ''` (line 803 in `graphiti_mcp_server.py`). When only `node_uuid` is provided, `node_name` is `None`, so the query becomes `""`. This empty query flows through `fulltext_query()` → `build_fulltext_query()`, which produces the malformed RediSearch syntax.

## Fix

3-line change in `falkordb_driver.py`: if `sanitized_query` is empty after stopword removal, return just the `group_filter` instead of appending empty parentheses.

## Test plan

- [x] `test_empty_query_with_group_ids_returns_group_filter_only` — regression test for the exact bug
- [x] `test_empty_query_without_group_ids_returns_empty` — empty query, no groups
- [x] `test_stopword_only_query_with_group_ids` — query of only stopwords (also produces empty after filtering)
- [x] `test_basic_query_with_group_ids` — existing behavior preserved
- [x] `test_multiple_group_ids` — multi-group filter preserved
- [x] `test_no_group_ids` — no-group behavior preserved
- [x] All 30 driver tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)