### PR TITLE
fix(server): fix Neo4j client lifecycle bugs causing "Driver closed" errors

### DIFF
--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -96,7 +96,10 @@ async def initialize_graphiti(settings: ZepEnvDep):
         user=settings.neo4j_user,
         password=settings.neo4j_password,
     )
-    await client.build_indices_and_constraints()
+    try:
+        await client.build_indices_and_constraints()
+    finally:
+        await client.close()
 
 
 def get_fact_result_from_edge(edge: EntityEdge):


### PR DESCRIPTION
## Problem

The `graph_service` server has two client lifecycle bugs that cause `neo4j.exceptions.DriverError: Driver closed` errors, resulting in silently dropped messages and failed index creation.

### Bug 1: AsyncWorker uses a closed client (`ingest.py`)

The `POST /messages` endpoint injects a request-scoped `ZepGraphiti` client via `ZepGraphitiDep` and captures it in a closure queued for `AsyncWorker`:

```python
@router.post('/messages', status_code=status.HTTP_202_ACCEPTED)
async def add_messages(request, graphiti: ZepGraphitiDep):
    async def add_messages_task(m):
        await graphiti.add_episode(...)  # uses captured client

    for m in request.messages:
        await async_worker.queue.put(partial(add_messages_task, m))
    return Result(message='Messages added to processing queue')
```

The request handler returns immediately (HTTP 202), which triggers FastAPI's dependency cleanup — `get_graphiti`'s `finally: await client.close()` runs. By the time `AsyncWorker` picks up the job, the Neo4j driver is already closed.

**Result:** Every message logged via `/messages` silently fails with `DriverError: Driver closed`.

### Bug 2: `initialize_graphiti` never closes its client (`zep_graphiti.py`)

```python
async def initialize_graphiti(settings):
    client = ZepGraphiti(uri=..., user=..., password=...)
    await client.build_indices_and_constraints()
    # client is never closed — gets garbage collected with open async tasks
```

The Neo4j async driver is garbage collected while `build_indices_and_constraints()` background tasks are still running.

**Result:** `Driver closed` errors on every startup, indices may not be created.

## Fix

1. **`ingest.py`**: Remove `AsyncWorker`. Process messages inline within the request handler so the `graphiti` client remains open for the duration. Changes status from `202 Accepted` to `200 OK`.

2. **`zep_graphiti.py`**: Add `try/finally` to `initialize_graphiti` to ensure `await client.close()` is always called.

## Test plan

- [x] Deploy server, send `POST /messages` with a fact, verify it appears in `POST /search`
- [x] Restart server, confirm no `Driver closed` errors in logs
- [x] Verify `SHOW INDEXES` returns all expected indices after clean startup