### PR TITLE
chore: bump version to 0.28.1

### DIFF
--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "mcp>=1.9.4",
     "openai>=1.91.0",
-    "graphiti-core[falkordb]==0.28.0",
+    "graphiti-core[falkordb]==0.28.1",
     "pydantic-settings>=2.0.0",
     "pyyaml>=6.0",
     "typing-extensions>=4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "graphiti-core"
 description = "A temporal graph building library"
-version = "0.28.0"
+version = "0.28.1"
 authors = [
     { name = "Paul Paliychuk", email = "paul@getzep.com" },
     { name = "Preston Rasmussen", email = "preston@getzep.com" },


### PR DESCRIPTION
## Summary

- Bump `graphiti-core` version from `0.28.0` to `0.28.1`
- Update MCP server pinned dependency to match

## Motivation

The `0.28.0` release on PyPI still lists `diskcache` as a dependency. The diskcache removal (replaced with SQLite+JSON `LLMCache`) was merged to main after `0.28.0` was published, so `mcp_server/uv.lock` and `server/uv.lock` still resolve `diskcache` as a transitive dependency, keeping dependabot alerts #69 and #70 open.

Publishing `0.28.1` without `diskcache` will allow the downstream lockfiles to drop it, resolving the unsafe pickle deserialization alerts.

## Test plan

- [ ] CI passes (no code changes, version bump only)
- [ ] After publishing to PyPI, regenerate `mcp_server/uv.lock` and `server/uv.lock` to confirm `diskcache` is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)