### PR TITLE
fix: correctly merge update_community results from semaphore_gather

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -989,13 +989,16 @@ class Graphiti:
                 communities = []
                 community_edges = []
                 if update_communities:
-                    communities, community_edges = await semaphore_gather(
+                    community_results = await semaphore_gather(
                         *[
                             update_community(self.driver, self.llm_client, self.embedder, node)
                             for node in nodes
                         ],
                         max_coroutines=self.max_coroutines,
                     )
+                    for comm_nodes, comm_edges in community_results:
+                        communities.extend(comm_nodes)
+                        community_edges.extend(comm_edges)
 
                 end = time()
 


### PR DESCRIPTION
## Summary

- Fixes tuple unpacking crash in `add_episode()` when `update_communities=True`
- `semaphore_gather` returns a list of N tuples (one per node), not a single tuple — the results must be merged via iteration

## Problem

`update_community()` returns `tuple[list[CommunityNode], list[CommunityEdge]]` per node. `semaphore_gather()` collects these into a list:

```python
# semaphore_gather returns: [(nodes_A, edges_A), (nodes_B, edges_B), (nodes_C, edges_C)]
# Old code tried:
communities, community_edges = await semaphore_gather(...)
# This only works when exactly 2 nodes are in the episode — crashes otherwise
```

This bug was introduced in v0.19.0 (commit dcc9da3) when community results were added to `AddEpisodeResults`. Every version since v0.19.0 crashes with `ValueError: too many values to unpack (expected 2)` when `update_communities=True` and the episode has != 2 nodes.

## Fix

```python
community_results = await semaphore_gather(...)
for comm_nodes, comm_edges in community_results:
    communities.extend(comm_nodes)
    community_edges.extend(comm_edges)
```

## Test plan

- [x] Verified with episodes producing 3-7 nodes — no crash
- [x] Communities are correctly updated and persisted to Neo4j
- [x] `AddEpisodeResults` correctly contains merged community data

Fixes #836