### PR TITLE
fix: resilient async worker and phantom UUID edge filter

### DIFF
--- a/server/graph_service/routers/ingest.py
+++ b/server/graph_service/routers/ingest.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from contextlib import asynccontextmanager
 from functools import partial
 
@@ -9,18 +10,82 @@ from graphiti_core.utils.maintenance.graph_data_operations import clear_data  # 
 from graph_service.dto import AddEntityNodeRequest, AddMessagesRequest, Message, Result
 from graph_service.zep_graphiti import ZepGraphitiDep
 
+logger = logging.getLogger(__name__)
+
+# Retry policy for transient ingestion failures (rate limits, transient
+# network/DB errors). Permanent failures are skipped without retry.
+MAX_RETRIES = 5
+BASE_BACKOFF_SECONDS = 5  # exponential backoff: 5, 10, 20, 40s
+
+# Built-in exceptions that indicate bad input/data — retrying the same job will
+# never succeed, so skip immediately rather than burn the backoff schedule.
+PERMANENT_ERROR_TYPES = (IndexError, KeyError, ValueError)
+# Provider HTTP errors (e.g. OpenAI) aren't imported here; match them by class
+# name and by client-error status codes that won't change on retry. Note that
+# rate limits (429) and timeouts (408) are deliberately excluded — those are
+# transient and should be retried.
+PERMANENT_ERROR_NAMES = {'BadRequestError', 'NotFoundError', 'UnprocessableEntityError'}
+PERMANENT_STATUS_CODES = {400, 404, 422}
+
+
+def _is_permanent_error(exc: Exception) -> bool:
+    """Whether ``exc`` is a permanent (non-retryable) failure."""
+    if isinstance(exc, PERMANENT_ERROR_TYPES):
+        return True
+    if type(exc).__name__ in PERMANENT_ERROR_NAMES:
+        return True
+    return getattr(exc, 'status_code', None) in PERMANENT_STATUS_CODES
+
 
 class AsyncWorker:
     def __init__(self):
         self.queue = asyncio.Queue()
         self.task = None
 
+    async def _process_job(self, job) -> None:
+        """Run a single job, retrying transient failures with exponential backoff.
+
+        Previously ``worker()`` ran ``await job()`` directly, so any exception
+        other than cancellation propagated out of the loop and killed the worker
+        coroutine — leaving every queued job permanently unprocessed while the
+        endpoint had already returned ``202 Accepted``. Catch and classify
+        failures here so a single bad job can never take down the worker.
+        """
+        for attempt in range(MAX_RETRIES):
+            try:
+                await job()
+                return
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                err_name = type(exc).__name__
+                if _is_permanent_error(exc):
+                    logger.error('Job skipped (permanent error: %s)', err_name, exc_info=True)
+                    return
+                if attempt >= MAX_RETRIES - 1:
+                    logger.error(
+                        'Job failed after %d attempts, skipping (%s)',
+                        MAX_RETRIES,
+                        err_name,
+                        exc_info=True,
+                    )
+                    return
+                wait = BASE_BACKOFF_SECONDS * (2**attempt)
+                logger.warning(
+                    'Job attempt %d/%d failed (%s); retrying in %ds',
+                    attempt + 1,
+                    MAX_RETRIES,
+                    err_name,
+                    wait,
+                )
+                await asyncio.sleep(wait)
+
     async def worker(self):
         while True:
             try:
                 print(f'Got a job: (size of remaining queue: {self.queue.qsize()})')
                 job = await self.queue.get()
-                await job()
+                await self._process_job(job)
             except asyncio.CancelledError:
                 break
 

--- a/server/tests/test_ingest_worker.py
+++ b/server/tests/test_ingest_worker.py
@@ -1,0 +1,119 @@
+"""Unit tests for the ingestion ``AsyncWorker`` failure-resilience behavior.
+
+A job that raises a non-cancellation exception must not kill the worker:
+transient errors are retried with exponential backoff, permanent (bad-data)
+errors are skipped immediately, and in every case the worker stays alive to
+process the next job. The backoff delay is patched to zero so the retry tests
+run instantly while still exercising the real ``asyncio.sleep`` yield.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from graph_service.routers.ingest import (
+    MAX_RETRIES,
+    AsyncWorker,
+    _is_permanent_error,
+)
+
+
+@pytest.fixture(autouse=True)
+def _instant_backoff():
+    # Collapse the 5/10/20/40s backoff to 0s so retry tests don't actually sleep.
+    with patch('graph_service.routers.ingest.BASE_BACKOFF_SECONDS', 0):
+        yield
+
+
+class TestIsPermanentError:
+    def test_builtin_data_errors_are_permanent(self):
+        assert _is_permanent_error(ValueError('bad'))
+        assert _is_permanent_error(KeyError('missing'))
+        assert _is_permanent_error(IndexError('range'))
+
+    def test_provider_client_error_status_codes_are_permanent(self):
+        class BadRequestError(Exception):
+            status_code = 400
+
+        assert _is_permanent_error(BadRequestError())
+
+    def test_matched_by_class_name(self):
+        class NotFoundError(Exception):  # no status_code attribute
+            pass
+
+        assert _is_permanent_error(NotFoundError())
+
+    def test_rate_limit_and_network_errors_are_transient(self):
+        # 429 (rate limit) and 408 (timeout) are retryable — must NOT be permanent.
+        class RateLimitError(Exception):
+            status_code = 429
+
+        assert not _is_permanent_error(RateLimitError())
+        assert not _is_permanent_error(ConnectionError('reset'))
+        assert not _is_permanent_error(TimeoutError())
+
+
+@pytest.mark.asyncio
+async def test_transient_failure_is_retried_then_succeeds():
+    worker = AsyncWorker()
+    job = AsyncMock(side_effect=[ConnectionError('transient'), None])
+
+    await worker._process_job(job)
+
+    assert job.await_count == 2  # failed once, retried, then succeeded
+
+
+@pytest.mark.asyncio
+async def test_permanent_failure_is_not_retried():
+    worker = AsyncWorker()
+    job = AsyncMock(side_effect=ValueError('bad data'))
+
+    await worker._process_job(job)
+
+    assert job.await_count == 1  # permanent → skipped immediately, no retry
+
+
+@pytest.mark.asyncio
+async def test_persistent_transient_failure_gives_up_after_max_retries():
+    worker = AsyncWorker()
+    job = AsyncMock(side_effect=ConnectionError('always down'))
+
+    await worker._process_job(job)
+
+    assert job.await_count == MAX_RETRIES  # tried MAX_RETRIES times, then skipped
+
+
+@pytest.mark.asyncio
+async def test_cancellation_propagates():
+    worker = AsyncWorker()
+    job = AsyncMock(side_effect=asyncio.CancelledError())
+
+    with pytest.raises(asyncio.CancelledError):
+        await worker._process_job(job)
+
+
+@pytest.mark.asyncio
+async def test_worker_survives_failing_job_and_processes_next():
+    """End-to-end: a failing job must not stop the worker loop."""
+    worker = AsyncWorker()
+    bad_job = AsyncMock(side_effect=ValueError('bad'))
+    good_job = AsyncMock()
+
+    task = asyncio.create_task(worker.worker())
+    await worker.queue.put(bad_job)
+    await worker.queue.put(good_job)
+
+    # Let the worker drain both jobs (real asyncio.sleep(0) yields the loop).
+    for _ in range(100):
+        if good_job.await_count and worker.queue.empty():
+            break
+        await asyncio.sleep(0)
+
+    # worker() catches CancelledError internally and exits cleanly, so just
+    # cancel and drain the task without expecting the exception to propagate.
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    bad_job.assert_awaited_once()
+    good_job.assert_awaited_once()


### PR DESCRIPTION
## Summary

Two bug fixes developed and validated in a self-hosted Docker deployment. Each fix addresses a distinct failure mode observed in production with `gpt-4.1-mini`/`gpt-4.1-nano` models.

> **Note:** A third planned fix (`DEFAULT_MAX_TOKENS` 8192 → 16384) turned out to be already present in `upstream/main` — so it is not included here.

---

## Fix 1: Resilient async worker with retry and error classification (`server/graph_service/routers/ingest.py`)

**Problem:** `AsyncWorker.worker()` only caught `asyncio.CancelledError`. Any other exception (e.g., `RateLimitError`, Neo4j `SocketDeadlineExceededError`) would silently kill the coroutine, leaving jobs permanently stuck in the `asyncio.Queue`. The endpoint returned `202 Accepted` but jobs were never processed.

**Fix:** Added a retry loop with exponential backoff (up to 5 attempts: 5/10/20/40 s) and error classification:
- **Permanent errors** (`IndexError`, `KeyError`, `ValueError`, `BadRequestError`, HTTP 400): skipped immediately with a clear log message — no point retrying the same data.
- **Transient errors** (rate limits, network/connection issues): retried up to `MAX_RETRIES` times with exponential backoff.
- All outcomes are logged at appropriate levels (`logger.warning` for retries, `logger.error` for final failures) for observability.

Related: #1177

---

## Fix 2: Filter phantom UUID references in `resolve_extracted_edges` (`graphiti_core/utils/maintenance/edge_operations.py`)

**Problem:** When the LLM is inconsistent between the node-extraction and edge-extraction steps (a known LLM non-determinism issue), edges may reference UUIDs of nodes that were never created in the same batch. The upstream code already attempts to fetch those missing nodes from the database via `EntityNode.get_by_uuids`, but if the UUID is truly phantom (hallucinated — never persisted anywhere), the node is still absent from `uuid_entity_map` and downstream code raises a `KeyError`, aborting the entire episode.

**Fix:** Immediately after the DB lookup, filter out any `extracted_edges` whose `source_node_uuid` or `target_node_uuid` is still not present in `uuid_entity_map`. A warning is logged when edges are dropped. The `related_edges_lists` and `edge_invalidation_candidates` parallel lists are filtered in lockstep to keep all indices consistent. No valid data is lost — these edges cannot be persisted regardless since their referenced nodes do not exist anywhere in the graph.

Related: #1171

---

## Testing

Both fixes were deployed and validated in a self-hosted Docker environment processing ~300 episodes across multiple knowledge groups.

Before the fixes:
- Worker coroutines died silently on `RateLimitError` (confirmed via queue monitoring) — `202 Accepted` returned but no processing occurred
- ~50% of episode batches failed with `KeyError` in `resolve_extracted_edges` due to phantom UUIDs from LLM inconsistency

After the fixes: zero silent failures observed, episode processing completed successfully across all batches.
