### PR TITLE
fix(falkordb): remove group_id from fulltext query to fix UUID syntax error

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -115,7 +115,7 @@ def _build_falkor_fulltext_query(
     filtered_words = [word for word in query_words if word and word.lower() not in STOPWORDS]
     sanitized_query = ' | '.join(filtered_words)
 
-    if len(sanitized_query.split(' ')) + len(group_ids or '') >= max_query_length:
+    if len(sanitized_query.split(' ')) >= max_query_length:
         return ''
 
     full_query = '(' + sanitized_query + ')'

--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -98,14 +98,16 @@ def _build_falkor_fulltext_query(
     group_ids: list[str] | None = None,
     max_query_length: int = MAX_QUERY_LENGTH,
 ) -> str:
-    """Build a fulltext query string for FalkorDB using RedisSearch syntax."""
-    if group_ids is None or len(group_ids) == 0:
-        group_filter = ''
-    else:
-        escaped_group_ids = [f'"{gid}"' for gid in group_ids]
-        group_values = '|'.join(escaped_group_ids)
-        group_filter = f'(@group_id:{group_values})'
+    """Build a fulltext query string for FalkorDB using RedisSearch syntax.
 
+    NOTE: group_id filtering is intentionally NOT included in the fulltext
+    query. RediSearch treats hyphens as NOT operators even inside double
+    quotes, which breaks UUID-formatted group_ids (e.g.,
+    "f2c59d63-a7a7-b5e6-8000-000000000000"). This is safe because all
+    callers already apply a Cypher-level ``WHERE n.group_id IN $group_ids``
+    filter that guarantees multi-tenant isolation.
+    See: https://github.com/getzep/graphiti/issues/1269
+    """
     sanitized_query = _sanitize(query)
 
     # Remove stopwords and empty tokens
@@ -116,7 +118,7 @@ def _build_falkor_fulltext_query(
     if len(sanitized_query.split(' ')) + len(group_ids or '') >= max_query_length:
         return ''
 
-    full_query = group_filter + ' (' + sanitized_query + ')'
+    full_query = '(' + sanitized_query + ')'
     return full_query
 
 

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -413,7 +413,7 @@ class FalkorDriver(GraphDriver):
         sanitized_query = ' | '.join(filtered_words)
 
         # If the query is too long return no query
-        if len(sanitized_query.split(' ')) + len(group_ids or '') >= max_query_length:
+        if len(sanitized_query.split(' ')) >= max_query_length:
             return ''
 
         full_query = '(' + sanitized_query + ')'

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -397,14 +397,13 @@ class FalkorDriver(GraphDriver):
         - AND is implicit with space: (@group_id:value) (text)
         - OR uses pipe within parentheses: (@group_id:value1|value2)
         """
-        if group_ids is None or len(group_ids) == 0:
-            group_filter = ''
-        else:
-            # Escape group_ids with quotes to prevent RediSearch syntax errors
-            # with reserved words like "main" or special characters like hyphens
-            escaped_group_ids = [f'"{gid}"' for gid in group_ids]
-            group_values = '|'.join(escaped_group_ids)
-            group_filter = f'(@group_id:{group_values})'
+        # NOTE: group_id filtering is intentionally NOT included in the fulltext
+        # query. RediSearch treats hyphens as NOT operators even inside double
+        # quotes, which breaks UUID-formatted group_ids (e.g.,
+        # "f2c59d63-a7a7-b5e6-8000-000000000000"). This is safe because all
+        # callers already apply a Cypher-level `WHERE n.group_id IN $group_ids`
+        # filter that guarantees multi-tenant isolation.
+        # See: https://github.com/getzep/graphiti/issues/1269
 
         sanitized_query = self.sanitize(query)
 
@@ -417,6 +416,6 @@ class FalkorDriver(GraphDriver):
         if len(sanitized_query.split(' ')) + len(group_ids or '') >= max_query_length:
             return ''
 
-        full_query = group_filter + ' (' + sanitized_query + ')'
+        full_query = '(' + sanitized_query + ')'
 
         return full_query


### PR DESCRIPTION
## Summary

- RediSearch treats hyphens (`-`) as NOT operators even inside double quotes, causing `Syntax error` for UUID-formatted `group_ids` (e.g., `f2c59d63-a7a7-b5e6-8000-000000000000`)
- PR #1175 attempted to fix this by wrapping group_ids in double quotes, but **double quotes do not prevent RediSearch from interpreting hyphens as operators**
- This is a **complete blocker** for any application using UUIDs as `group_id` (the standard pattern for multi-tenant isolation)

## Root cause

`build_fulltext_query` generates:
```
(@group_id:"f2c59d63-a7a7-b5e6-8000-000000000000") (search terms)
```

RediSearch parses the UUID as:
```
f2c59d63 NOT a7a7 NOT b5e6 NOT 8000 NOT 000000000000
```

This is a [known RediSearch limitation](https://github.com/RediSearch/RediSearch/issues/2628) — hyphens cannot be reliably escaped in TEXT field queries.

## Fix

Remove `@group_id` filtering from the fulltext query entirely. This is safe because **all callers already apply a Cypher-level filter**:

```cypher
WHERE n.group_id IN $group_ids
```

This guarantees multi-tenant isolation regardless of the fulltext query content.

### Performance impact

Negligible — fulltext returns a small candidate set (default top 20), and the Cypher `WHERE` filter on those 20 rows is essentially free.

## Error before fix

```
RediSearch: Syntax error at offset 20 near f2c59d63
```

## Test plan

- [x] Verified UUID group_ids no longer cause syntax errors
- [x] Verified multi-tenant isolation is maintained via Cypher WHERE clause
- [x] Confirmed both code paths updated (legacy `FalkorDriver.build_fulltext_query` and new `_build_falkor_fulltext_query`)

Fixes #1269
Related: #841, #757, #1175

🤖 Generated with [Claude Code](https://claude.ai/code)