### PR TITLE
fix: limit resolve_extracted_nodes context to prevent max_tokens overflow

### DIFF
--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -57,6 +57,11 @@ logger = logging.getLogger(__name__)
 # Maximum number of nodes to summarize in a single LLM call
 MAX_NODES = 30
 
+# Maximum number of existing-node candidates passed to the resolution LLM context.
+# Prevents token overflow when many nodes match (e.g. 15 extracted × 10 candidates = 150 nodes
+# with verbose attributes each, pushing the prompt past max_tokens).
+MAX_RESOLVE_CANDIDATES = 50
+
 NodeSummaryFilter = Callable[[EntityNode], Awaitable[bool]]
 
 
@@ -298,13 +303,12 @@ async def _resolve_with_llm(
 
     existing_nodes_context = [
         {
-            **{
-                'name': candidate.name,
-                'entity_types': candidate.labels,
-            },
-            **candidate.attributes,
+            'name': candidate.name,
+            'entity_types': candidate.labels,
+            # candidate.attributes omitted: summaries and descriptions are too verbose and
+            # can push the resolution prompt past max_tokens when many candidates are present.
         }
-        for candidate in indexes.existing_nodes
+        for candidate in indexes.existing_nodes[:MAX_RESOLVE_CANDIDATES]
     ]
 
     # Build name -> node mapping for resolving duplicates by name


### PR DESCRIPTION
## Problem

When deduplicating extracted nodes in `resolve_extracted_nodes`, the LLM prompt includes the full `candidate.attributes` dict for every candidate returned by the similarity search. In production workloads with:

- 10–15 extracted nodes per episode
- Up to 10 candidates per node from vector/BM25 search

This produces **~100–150 candidates**, each carrying verbose attributes (summaries, descriptions, relationship lists, etc.). The resulting prompt regularly exceeds **17k tokens**, pushing the JSON output past the `max_tokens=16384` limit and causing truncated/invalid responses.

Reported in issue #1275.

## Fix

Two surgical changes to `graphiti_core/utils/maintenance/node_operations.py`:

### 1. Remove `candidate.attributes` from the resolution context

Only `name` and `entity_types` are needed for identity-level deduplication. The full attribute payload adds thousands of tokens without improving match quality.

```python
# Before
existing_nodes_context = [
    {
        **{'name': candidate.name, 'entity_types': candidate.labels},
        **candidate.attributes,   # ← verbose, causes overflow
    }
    for candidate in indexes.existing_nodes
]

# After
existing_nodes_context = [
    {
        'name': candidate.name,
        'entity_types': candidate.labels,
        # attributes omitted to prevent token overflow
    }
    for candidate in indexes.existing_nodes[:MAX_RESOLVE_CANDIDATES]
]
```

### 2. Add `MAX_RESOLVE_CANDIDATES = 50` constant

Caps the candidate list to bound worst-case context size regardless of search result count. Placed alongside the existing `MAX_NODES` constant.

## Impact

- No change to resolution logic or search behavior
- Eliminates context overflow for typical workloads (10–15 nodes × 10 candidates)
- `MAX_RESOLVE_CANDIDATES = 50` provides a safety ceiling for extreme cases
- The name + entity_types fields are sufficient for the deduplication LLM to make correct identity judgments