### PR TITLE
fix: strip markdown code blocks from Gemini JSON responses

### DIFF
--- a/graphiti_core/llm_client/gemini_client.py
+++ b/graphiti_core/llm_client/gemini_client.py
@@ -316,6 +316,11 @@ class GeminiClient(LLMClient):
             # Always capture the raw output for debugging
             raw_output = getattr(response, 'text', None)
 
+            # Strip markdown code block wrappers if Gemini wraps JSON despite application/json mime type
+            if raw_output:
+                raw_output = re.sub(r'^```(?:json)?\s*', '', raw_output.strip())
+                raw_output = re.sub(r'\s*```$', '', raw_output)
+
             # Check for safety and prompt blocks
             self._check_safety_blocks(response)
             self._check_prompt_blocks(response)

--- a/tests/llm_client/test_gemini_client.py
+++ b/tests/llm_client/test_gemini_client.py
@@ -478,5 +478,59 @@ class TestGeminiClientGenerateResponse:
             )
 
 
+class TestGeminiClientMarkdownStripping:
+    """Tests for stripping markdown code blocks from Gemini responses."""
+
+    @pytest.mark.asyncio
+    async def test_structured_output_with_json_markdown_block(
+        self, gemini_client, mock_gemini_client
+    ):
+        """Test that JSON wrapped in ```json ... ``` is parsed correctly."""
+        mock_response = MagicMock()
+        mock_response.text = '```json\n{"test_field": "hello", "optional_field": 1}\n```'
+        mock_response.candidates = []
+        mock_response.prompt_feedback = None
+        mock_gemini_client.aio.models.generate_content.return_value = mock_response
+
+        messages = [Message(role='user', content='Test message')]
+        result = await gemini_client.generate_response(messages, response_model=ResponseModel)
+
+        assert result['test_field'] == 'hello'
+        assert result['optional_field'] == 1
+
+    @pytest.mark.asyncio
+    async def test_structured_output_with_plain_markdown_block(
+        self, gemini_client, mock_gemini_client
+    ):
+        """Test that JSON wrapped in plain ``` ... ``` is parsed correctly."""
+        mock_response = MagicMock()
+        mock_response.text = '```\n{"test_field": "world"}\n```'
+        mock_response.candidates = []
+        mock_response.prompt_feedback = None
+        mock_gemini_client.aio.models.generate_content.return_value = mock_response
+
+        messages = [Message(role='user', content='Test message')]
+        result = await gemini_client.generate_response(messages, response_model=ResponseModel)
+
+        assert result['test_field'] == 'world'
+
+    @pytest.mark.asyncio
+    async def test_structured_output_without_markdown_block_unchanged(
+        self, gemini_client, mock_gemini_client
+    ):
+        """Test that plain JSON (no markdown wrapper) still parses correctly."""
+        mock_response = MagicMock()
+        mock_response.text = '{"test_field": "plain", "optional_field": 99}'
+        mock_response.candidates = []
+        mock_response.prompt_feedback = None
+        mock_gemini_client.aio.models.generate_content.return_value = mock_response
+
+        messages = [Message(role='user', content='Test message')]
+        result = await gemini_client.generate_response(messages, response_model=ResponseModel)
+
+        assert result['test_field'] == 'plain'
+        assert result['optional_field'] == 99
+
+
 if __name__ == '__main__':
     pytest.main(['-v', 'test_gemini_client.py'])


### PR DESCRIPTION
## Summary
Strip markdown code block wrappers (` ```json ` / ` ``` `) from Gemini responses before JSON parsing, fixing a crash when Gemini wraps JSON in markdown despite `response_mime_type=application/json` being set.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation/Tests

## Objective
N/A (bug fix)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

Tests added in `tests/llm_client/test_gemini_client.py` covering:
- JSON wrapped in ` ```json ` block → parsed correctly
- JSON wrapped in plain ` ``` ` block → parsed correctly
- Plain JSON with no wrapper → unchanged, still works

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Closes #790