### PR TITLE
fix(falkordb): use startNode/endNode instead of re-MATCH for edge search

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -302,8 +302,8 @@ class FalkorSearchOperations(SearchOperations):
                 'edge_name_and_fact', limit=limit, provider=GraphProvider.FALKORDB
             )
             + """
-            YIELD relationship AS rel, score
-            MATCH (n:Entity)-[e:RELATES_TO {uuid: rel.uuid}]->(m:Entity)
+            YIELD relationship AS e, score
+            WITH e, score, startNode(e) AS n, endNode(e) AS m
             """
             + filter_query
             + """
@@ -414,8 +414,8 @@ class FalkorSearchOperations(SearchOperations):
             f"""
             UNWIND $bfs_origin_node_uuids AS origin_uuid
             MATCH path = (origin {{uuid: origin_uuid}})-[:RELATES_TO|MENTIONS*1..{max_depth}]->(:Entity)
-            UNWIND relationships(path) AS rel
-            MATCH (n:Entity)-[e:RELATES_TO {{uuid: rel.uuid}}]-(m:Entity)
+            UNWIND relationships(path) AS e
+            WITH e, startNode(e) AS n, endNode(e) AS m
             """
             + filter_query
             + """


### PR DESCRIPTION
## Summary

`edge_fulltext_search` and `edge_bfs_search` in `FalkorSearchOperations` use a `MATCH (n:Entity)-[e:RELATES_TO {uuid: rel.uuid}]->(m:Entity)` pattern to retrieve source/target nodes after a fulltext search. This causes FalkorDB to perform a **full graph scan** of all RELATES_TO edges for each fulltext result, leading to O(n×m) complexity and query timeouts.

## Root Cause

The fulltext procedure already returns the relationship object, but the code re-MATCHes it by UUID — which FalkorDB cannot optimize with an index lookup for this join pattern.

## Fix

Replace the re-MATCH pattern with direct `startNode(e)` / `endNode(e)` calls:

```diff
- YIELD relationship AS rel, score
- MATCH (n:Entity)-[e:RELATES_TO {uuid: rel.uuid}]->(m:Entity)
+ YIELD relationship AS e, score
+ WITH e, score, startNode(e) AS n, endNode(e) AS m
```

Applied to both `edge_fulltext_search` (line 305) and `edge_bfs_search` (line 417).

## Impact

From the issue's benchmarks on a ~5,169-edge graph:
- **Before**: 118.4s for 1,492 fulltext results + MATCH + WHERE + ORDER
- **After**: ~2ms for fulltext + direct endpoint access (O(n) instead of O(n×m))

Fixes #1272