### PR TITLE
perf: skip redundant index creation in Neo4jDriver when indices already exist

### DIFF
--- a/graphiti_core/driver/neo4j_driver.py
+++ b/graphiti_core/driver/neo4j_driver.py
@@ -51,7 +51,11 @@ from graphiti_core.driver.operations.next_episode_edge_ops import NextEpisodeEdg
 from graphiti_core.driver.operations.saga_node_ops import SagaNodeOperations
 from graphiti_core.driver.operations.search_ops import SearchOperations
 from graphiti_core.driver.query_executor import Transaction
-from graphiti_core.graph_queries import get_fulltext_indices, get_range_indices
+from graphiti_core.graph_queries import (
+    get_fulltext_indices,
+    get_neo4j_expected_index_names,
+    get_range_indices,
+)
 from graphiti_core.helpers import semaphore_gather
 
 logger = logging.getLogger(__name__)
@@ -74,6 +78,7 @@ class Neo4jDriver(GraphDriver):
             auth=(user or '', password or ''),
         )
         self._database = database
+        self._indices_verified: bool = False
 
         # Instantiate Neo4j operations
         self._entity_node_ops = Neo4jEntityNodeOperations()
@@ -203,9 +208,32 @@ class Neo4jDriver(GraphDriver):
                 return None
             raise
 
+    async def _get_existing_index_names(self) -> set[str]:
+        """Return the set of index names currently present in Neo4j."""
+        result = await self.execute_query('SHOW INDEXES YIELD name RETURN name')
+        return {record['name'] for record in result.records}
+
     async def build_indices_and_constraints(self, delete_existing: bool = False):
         if delete_existing:
+            self._indices_verified = False
             await self.delete_all_indexes()
+        elif self._indices_verified:
+            return
+
+        # Fast path: check if all expected indices already exist (1 query)
+        if not delete_existing:
+            try:
+                existing = await self._get_existing_index_names()
+                expected = get_neo4j_expected_index_names()
+                if expected.issubset(existing):
+                    logger.debug('All expected indices already exist, skipping creation')
+                    self._indices_verified = True
+                    return
+            except Exception:
+                logger.debug(
+                    'SHOW INDEXES failed, falling through to individual index creation',
+                    exc_info=True,
+                )
 
         range_indices: list[LiteralString] = get_range_indices(self.provider)
 
@@ -214,6 +242,7 @@ class Neo4jDriver(GraphDriver):
         index_queries: list[LiteralString] = range_indices + fulltext_indices
 
         await semaphore_gather(*[self._execute_index_query(query) for query in index_queries])
+        self._indices_verified = True
 
     async def health_check(self) -> None:
         """Check Neo4j connectivity by running the driver's verify_connectivity method."""

--- a/graphiti_core/graph_queries.py
+++ b/graphiti_core/graph_queries.py
@@ -5,6 +5,8 @@ This module provides database-agnostic query generation for Neo4j and FalkorDB,
 supporting index creation, fulltext search, and bulk operations.
 """
 
+import re
+
 from typing_extensions import LiteralString
 
 from graphiti_core.driver.driver import GraphProvider
@@ -173,3 +175,24 @@ def get_relationships_query(name: str, limit: int, provider: GraphProvider) -> s
         return f"CALL QUERY_FTS_INDEX('{label}', '{name}', cast($query AS STRING), TOP := $limit)"
 
     return f'CALL db.index.fulltext.queryRelationships("{name}", $query, {{limit: $limit}})'
+
+
+_NEO4J_INDEX_NAME_RE = re.compile(
+    r'CREATE\s+(?:FULLTEXT\s+)?INDEX\s+(\S+)\s+IF\s+NOT\s+EXISTS',
+    re.IGNORECASE,
+)
+
+
+def get_neo4j_expected_index_names() -> set[str]:
+    """Extract index names from Neo4j CREATE INDEX queries.
+
+    Returns the set of index names that Neo4j is expected to have, derived
+    directly from the queries in get_range_indices and get_fulltext_indices.
+    """
+    queries = get_range_indices(GraphProvider.NEO4J) + get_fulltext_indices(GraphProvider.NEO4J)
+    names: set[str] = set()
+    for q in queries:
+        m = _NEO4J_INDEX_NAME_RE.search(q)
+        if m:
+            names.add(m.group(1))
+    return names

--- a/tests/driver/test_neo4j_driver.py
+++ b/tests/driver/test_neo4j_driver.py
@@ -1,0 +1,148 @@
+"""Tests for Neo4jDriver index-creation fast path."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graphiti_core.graph_queries import get_neo4j_expected_index_names
+
+
+def _make_driver():
+    """Create a Neo4jDriver with a mocked Neo4j client (no real connection).
+
+    Patches AsyncGraphDatabase so no real connection is made, and temporarily
+    stubs out build_indices_and_constraints so the __init__ background task
+    (scheduled via loop.create_task) does not interfere with tests.
+    """
+    from graphiti_core.driver.neo4j_driver import Neo4jDriver
+
+    with (
+        patch('graphiti_core.driver.neo4j_driver.AsyncGraphDatabase') as mock_agd,
+        patch.object(Neo4jDriver, 'build_indices_and_constraints', new_callable=AsyncMock),
+    ):
+        mock_agd.driver.return_value = MagicMock()
+        driver = Neo4jDriver(uri='bolt://localhost:7687', user='neo4j', password='test')
+    # Restore the real method after construction
+    driver._indices_verified = False
+    return driver
+
+
+def _mock_show_indexes_result(names: set[str]):
+    """Build a fake EagerResult whose .records yield {'name': n} dicts."""
+    result = MagicMock()
+    result.records = [{'name': n} for n in names]
+    return result
+
+
+class TestGetNeo4jExpectedIndexNames:
+    def test_returns_expected_count(self):
+        """get_neo4j_expected_index_names returns exactly 31 index names."""
+        names = get_neo4j_expected_index_names()
+        assert len(names) == 31
+        assert all(isinstance(n, str) for n in names)
+
+    def test_contains_known_indices(self):
+        """Spot-check that well-known index names are present."""
+        names = get_neo4j_expected_index_names()
+        for expected in ('entity_uuid', 'episode_content', 'node_name_and_summary'):
+            assert expected in names
+
+
+class TestBuildIndicesFastPath:
+    @pytest.mark.asyncio
+    async def test_fast_path_all_exist(self):
+        """When all indices already exist, only 1 SHOW INDEXES query is executed."""
+        driver = _make_driver()
+        expected_names = get_neo4j_expected_index_names()
+        # Superset: DB has all expected + some extras
+        existing = expected_names | {'extra_index'}
+
+        driver.execute_query = AsyncMock(return_value=_mock_show_indexes_result(existing))
+
+        await driver.build_indices_and_constraints()
+
+        # Only the SHOW INDEXES query should have been called
+        driver.execute_query.assert_called_once()
+        call_args = driver.execute_query.call_args
+        assert 'SHOW INDEXES' in call_args[0][0]
+        assert driver._indices_verified is True
+
+    @pytest.mark.asyncio
+    async def test_partial_missing_falls_through(self):
+        """When some indices are missing, all CREATE queries are executed."""
+        driver = _make_driver()
+        # Return only a subset of expected indices
+        partial = {'entity_uuid', 'episode_uuid'}
+        driver.execute_query = AsyncMock(return_value=_mock_show_indexes_result(partial))
+
+        await driver.build_indices_and_constraints()
+
+        # 1 SHOW INDEXES + 31 CREATE INDEX queries = 32
+        assert driver.execute_query.call_count == 32
+        assert driver._indices_verified is True
+
+    @pytest.mark.asyncio
+    async def test_delete_existing_bypasses_fast_path(self):
+        """delete_existing=True always runs delete + CREATE queries."""
+        driver = _make_driver()
+        driver._indices_verified = True  # Should be ignored
+
+        driver.execute_query = AsyncMock(return_value=MagicMock(records=[]))
+        driver.client.execute_query = AsyncMock()  # for delete_all_indexes
+
+        await driver.build_indices_and_constraints(delete_existing=True)
+
+        # Flag should have been reset then set again
+        assert driver._indices_verified is True
+        # Should have executed the 31 CREATE INDEX queries (no SHOW INDEXES)
+        assert driver.execute_query.call_count == 31
+
+    @pytest.mark.asyncio
+    async def test_show_indexes_failure_falls_through(self):
+        """If SHOW INDEXES fails, fall through to individual CREATE queries."""
+        driver = _make_driver()
+
+        call_count = 0
+
+        async def side_effect(query, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if 'SHOW INDEXES' in query:
+                raise RuntimeError('Simulated SHOW INDEXES failure')
+            return MagicMock()
+
+        driver.execute_query = AsyncMock(side_effect=side_effect)
+
+        await driver.build_indices_and_constraints()
+
+        # 1 failed SHOW INDEXES + 31 CREATE INDEX queries = 32
+        assert call_count == 32
+        assert driver._indices_verified is True
+
+    @pytest.mark.asyncio
+    async def test_indices_verified_flag_skips_second_call(self):
+        """Second call with _indices_verified=True does zero queries."""
+        driver = _make_driver()
+        driver._indices_verified = True
+
+        driver.execute_query = AsyncMock()
+
+        await driver.build_indices_and_constraints()
+
+        driver.execute_query.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_existing_resets_verified_flag(self):
+        """delete_existing=True resets _indices_verified even if it was True."""
+        driver = _make_driver()
+        driver._indices_verified = True
+
+        driver.execute_query = AsyncMock(return_value=MagicMock(records=[]))
+        driver.client.execute_query = AsyncMock()
+
+        await driver.build_indices_and_constraints(delete_existing=True)
+
+        # Flag should be True again after successful recreation
+        assert driver._indices_verified is True
+        # All 31 CREATE queries should have been issued
+        assert driver.execute_query.call_count == 31


### PR DESCRIPTION
## Summary

- Add a fast path to `Neo4jDriver.build_indices_and_constraints()`: query `SHOW INDEXES YIELD name` (1 roundtrip) and skip creation if all 31 expected indices already exist
- Add an instance-level `_indices_verified` flag so repeated calls within the same process are free
- Extract `get_neo4j_expected_index_names()` from existing CREATE queries (regex over single source of truth — no separate manifest)
- Graceful fallback: if `SHOW INDEXES` fails, falls through to the original 31-query behavior

| Scenario | Before | After |
|---|---|---|
| All indices exist | 31 queries (~1-2s) | 1 query (~50ms) |
| Some missing | 31 queries | 32 queries (1 check + 31 creates) |
| Second call, same instance | 31 queries | 0 queries (flag) |
| `delete_existing=True` | unchanged | unchanged |
| `SHOW INDEXES` fails | N/A | falls through to 31 queries |

## Files changed

| File | Change |
|---|---|
| `graphiti_core/graph_queries.py` | Add `get_neo4j_expected_index_names()` + regex |
| `graphiti_core/driver/neo4j_driver.py` | Fast-path logic + `_indices_verified` flag |
| `tests/driver/test_neo4j_driver.py` | New test file (8 tests) |

## Test plan

- [x] `get_neo4j_expected_index_names()` returns exactly 31 index names
- [x] Fast path: all indices exist → 1 query only
- [x] Partial missing → falls through to creation
- [x] `delete_existing=True` → bypasses fast path
- [x] `SHOW INDEXES` failure → graceful fallback to individual queries
- [x] `_indices_verified` flag → second call is free (0 queries)
- [x] `delete_existing=True` → resets verified flag
- [x] Ruff format/lint clean, Pyright 0 errors