### PR TITLE
chore: update Docker images to graphiti-core 0.28.1

### DIFF
--- a/mcp_server/docker/Dockerfile
+++ b/mcp_server/docker/Dockerfile
@@ -33,7 +33,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 WORKDIR /app/mcp
 
 # Accept graphiti-core version as build argument
-ARG GRAPHITI_CORE_VERSION=0.23.1
+ARG GRAPHITI_CORE_VERSION=0.28.1
 
 # Copy project files for dependency installation
 COPY pyproject.toml uv.lock ./
@@ -42,7 +42,7 @@ COPY pyproject.toml uv.lock ./
 # and regenerate lock file to match the PyPI version
 RUN sed -i '/\[tool\.uv\.sources\]/,/graphiti-core/d' pyproject.toml && \
     if [ -n "${GRAPHITI_CORE_VERSION}" ]; then \
-      sed -i "s/graphiti-core\[falkordb\]>=[0-9]\+\.[0-9]\+\.[0-9]\+$/graphiti-core[falkordb]==${GRAPHITI_CORE_VERSION}/" pyproject.toml; \
+      sed -i "s/graphiti-core\[falkordb\][>=]\+[0-9]\+\.[0-9]\+\.[0-9]\+/graphiti-core[falkordb]==${GRAPHITI_CORE_VERSION}/" pyproject.toml; \
     fi && \
     echo "Regenerating lock file for PyPI graphiti-core..." && \
     rm -f uv.lock && \

--- a/mcp_server/docker/Dockerfile.standalone
+++ b/mcp_server/docker/Dockerfile.standalone
@@ -28,7 +28,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 WORKDIR /app/mcp
 
 # Accept graphiti-core version as build argument
-ARG GRAPHITI_CORE_VERSION=0.23.1
+ARG GRAPHITI_CORE_VERSION=0.28.1
 
 # Copy project files for dependency installation
 COPY pyproject.toml uv.lock ./
@@ -37,7 +37,7 @@ COPY pyproject.toml uv.lock ./
 # Install with BOTH neo4j and falkordb extras for maximum flexibility
 # and regenerate lock file to match the PyPI version
 RUN sed -i '/\[tool\.uv\.sources\]/,/graphiti-core/d' pyproject.toml && \
-    sed -i "s/graphiti-core\[falkordb\]>=[0-9]\+\.[0-9]\+\.[0-9]\+$/graphiti-core[neo4j,falkordb]==${GRAPHITI_CORE_VERSION}/" pyproject.toml && \
+    sed -i "s/graphiti-core\[falkordb\][>=]\+[0-9]\+\.[0-9]\+\.[0-9]\+/graphiti-core[neo4j,falkordb]==${GRAPHITI_CORE_VERSION}/" pyproject.toml && \
     echo "Regenerating lock file for PyPI graphiti-core..." && \
     rm -f uv.lock && \
     uv lock

--- a/mcp_server/docker/docker-compose-falkordb.yml
+++ b/mcp_server/docker/docker-compose-falkordb.yml
@@ -17,10 +17,10 @@ services:
       start_period: 10s
 
   graphiti-mcp:
+    # To use the latest graphiti-core, build locally with:
+    #   docker compose -f docker-compose-falkordb.yml build
+    # The Docker Hub image may lag behind the latest release.
     image: zepai/knowledge-graph-mcp:standalone
-    # For specific versions, replace 'standalone' with a version tag:
-    #   image: zepai/knowledge-graph-mcp:1.0.0-standalone
-    # When building locally, the build section below will be used.
     build:
       context: ..
       dockerfile: docker/Dockerfile.standalone

--- a/mcp_server/docker/docker-compose-neo4j.yml
+++ b/mcp_server/docker/docker-compose-neo4j.yml
@@ -20,10 +20,10 @@ services:
       start_period: 30s
 
   graphiti-mcp:
+    # To use the latest graphiti-core, build locally with:
+    #   docker compose -f docker-compose-neo4j.yml build
+    # The Docker Hub image may lag behind the latest release.
     image: zepai/knowledge-graph-mcp:standalone
-    # For specific versions, replace 'standalone' with a version tag:
-    #   image: zepai/knowledge-graph-mcp:1.0.0-standalone
-    # When building locally, the build section below will be used.
     build:
       context: ..
       dockerfile: docker/Dockerfile.standalone

--- a/mcp_server/docker/docker-compose.yml
+++ b/mcp_server/docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
       args:
-        GRAPHITI_CORE_VERSION: ${GRAPHITI_CORE_VERSION:-0.23.0}
+        GRAPHITI_CORE_VERSION: ${GRAPHITI_CORE_VERSION:-0.28.1}
         MCP_SERVER_VERSION: ${MCP_SERVER_VERSION:-1.0.0}
         BUILD_DATE: ${BUILD_DATE:-}
         VCS_REF: ${VCS_REF:-}


### PR DESCRIPTION
## Summary
- Update default `GRAPHITI_CORE_VERSION` from `0.23.1` to `0.28.1` in both `Dockerfile` and `Dockerfile.standalone`
- Update default in `docker-compose.yml` from `0.23.0` to `0.28.1`
- Fix sed version-replacement patterns in both Dockerfiles — they only matched `>=` but `pyproject.toml` uses `==`, so the `GRAPHITI_CORE_VERSION` build-arg override was silently failing
- Update comments in `docker-compose-falkordb.yml` and `docker-compose-neo4j.yml` to guide users on building locally when the Docker Hub image is stale

## Test plan
- [ ] Start Docker Desktop
- [ ] `cd mcp_server/docker && docker compose -f docker-compose-falkordb.yml up --build`
- [ ] Verify `graphiti-core==0.28.1` is installed in the container: `docker exec <container> pip show graphiti-core`
- [ ] Verify the build-arg override works: `docker compose -f docker-compose-falkordb.yml build --build-arg GRAPHITI_CORE_VERSION=0.27.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)