### PR TITLE
fix: prevent shared driver state mutation in multi-group FalkorDB usage

### DIFF
--- a/graphiti_core/decorators.py
+++ b/graphiti_core/decorators.py
@@ -28,8 +28,10 @@ F = TypeVar('F', bound=Callable[..., Awaitable[Any]])
 
 def handle_multiple_group_ids(func: F) -> F:
     """
-    Decorator for FalkorDB methods that need to handle multiple group_ids.
-    Runs the function for each group_id separately and merges results.
+    Decorator for FalkorDB methods that need to handle group_ids.
+    Each group_id maps to a separate FalkorDB graph database, so this
+    decorator clones the driver to point at the correct graph for each
+    group_id and runs the function per-group, merging results.
     """
 
     @functools.wraps(func)
@@ -44,13 +46,16 @@ def handle_multiple_group_ids(func: F) -> F:
         if group_ids is None and group_ids_pos is not None and len(args) > group_ids_pos:
             group_ids = args[group_ids_pos]
 
-        # Only handle FalkorDB with multiple group_ids
+        # Handle FalkorDB group_ids — each group_id is a separate graph database,
+        # so we must clone the driver to target the correct one.  Previously this
+        # only handled len > 1, which meant single-group queries used whatever
+        # driver state was left over from the last add_episode call.
         if (
             hasattr(self, 'clients')
             and hasattr(self.clients, 'driver')
             and self.clients.driver.provider == GraphProvider.FALKORDB
             and group_ids
-            and len(group_ids) > 1
+            and len(group_ids) >= 1
         ):
             # Execute for each group_id concurrently
             driver = self.clients.driver

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -340,7 +340,13 @@ class Graphiti:
         """
         await self.driver.close()
 
-    async def _get_or_create_saga(self, saga_name: str, group_id: str, now: datetime) -> SagaNode:
+    async def _get_or_create_saga(
+        self,
+        saga_name: str,
+        group_id: str,
+        now: datetime,
+        driver: GraphDriver | None = None,
+    ) -> SagaNode:
         """
         Get an existing saga by name or create a new one.
 
@@ -352,14 +358,18 @@ class Graphiti:
             The group id for the saga.
         now : datetime
             The current timestamp for creation.
+        driver : GraphDriver | None
+            Optional. The graph driver to use. If not provided, uses self.driver.
 
         Returns
         -------
         SagaNode
             The existing or newly created saga node.
         """
+        driver = driver or self.driver
+
         # Query for existing saga with this name in the group
-        records, _, _ = await self.driver.execute_query(
+        records, _, _ = await driver.execute_query(
             """
             MATCH (s:Saga {name: $name, group_id: $group_id})
             RETURN s.uuid AS uuid, s.name AS name, s.group_id AS group_id, s.created_at AS created_at
@@ -387,7 +397,7 @@ class Graphiti:
             group_id=group_id,
             created_at=now,
         )
-        await saga.save(self.driver)
+        await saga.save(driver)
         return saga
 
     async def build_indices_and_constraints(self, delete_existing: bool = False):
@@ -457,6 +467,7 @@ class Graphiti:
         nodes: list[EntityNode],
         uuid_map: dict[str, str],
         custom_extraction_instructions: str | None = None,
+        clients: GraphitiClients | None = None,
     ) -> tuple[list[EntityEdge], list[EntityEdge], list[EntityEdge]]:
         """Extract edges from episode and resolve against existing graph.
 
@@ -468,8 +479,10 @@ class Graphiti:
             - invalidated_edges: Edges invalidated by new information
             - new_edges: Only edges that are new to the graph (not duplicates)
         """
+        clients = clients or self.clients
+
         extracted_edges = await extract_edges(
-            self.clients,
+            clients,
             episode,
             extracted_nodes,
             previous_episodes,
@@ -482,7 +495,7 @@ class Graphiti:
         edges = resolve_edge_pointers(extracted_edges, uuid_map)
 
         resolved_edges, invalidated_edges, new_edges = await resolve_extracted_edges(
-            self.clients,
+            clients,
             edges,
             episode,
             nodes,
@@ -501,6 +514,7 @@ class Graphiti:
         group_id: str,
         saga: str | SagaNode | None = None,
         saga_previous_episode_uuid: str | None = None,
+        driver: GraphDriver | None = None,
     ) -> tuple[list[EpisodicEdge], EpisodicNode]:
         """Process and save episode data to the graph.
 
@@ -524,7 +538,11 @@ class Graphiti:
             Optional. UUID of the previous episode in the saga. If provided, skips
             the database query to find the most recent episode. Useful for efficiently
             adding multiple episodes to the same saga in sequence.
+        driver : GraphDriver | None
+            Optional. The graph driver to use. If not provided, uses self.driver.
         """
+        driver = driver or self.driver
+
         episodic_edges = build_episodic_edges(nodes, episode.uuid, now)
         episode.entity_edges = [edge.uuid for edge in entity_edges]
 
@@ -532,7 +550,7 @@ class Graphiti:
             episode.content = ''
 
         await add_nodes_and_edges_bulk(
-            self.driver,
+            driver,
             [episode],
             episodic_edges,
             nodes,
@@ -544,7 +562,7 @@ class Graphiti:
         if saga is not None:
             # Get or create saga node based on input type
             if isinstance(saga, str):
-                saga_node = await self._get_or_create_saga(saga, group_id, now)
+                saga_node = await self._get_or_create_saga(saga, group_id, now, driver=driver)
             else:
                 saga_node = saga
 
@@ -552,7 +570,7 @@ class Graphiti:
             previous_episode_uuid: str | None = saga_previous_episode_uuid
             if previous_episode_uuid is None:
                 # Find the most recent episode in the saga (excluding the current one)
-                previous_episode_records, _, _ = await self.driver.execute_query(
+                previous_episode_records, _, _ = await driver.execute_query(
                     """
                     MATCH (s:Saga {uuid: $saga_uuid})-[:HAS_EPISODE]->(e:Episodic)
                     WHERE e.uuid <> $current_episode_uuid
@@ -575,7 +593,7 @@ class Graphiti:
                     group_id=group_id,
                     created_at=now,
                 )
-                await next_episode_edge.save(self.driver)
+                await next_episode_edge.save(driver)
 
             # Create HAS_EPISODE edge from saga to the new episode
             has_episode_edge = HasEpisodeEdge(
@@ -584,7 +602,7 @@ class Graphiti:
                 group_id=group_id,
                 created_at=now,
             )
-            await has_episode_edge.save(self.driver)
+            await has_episode_edge.save(driver)
 
         return episodic_edges, episode
 
@@ -596,15 +614,18 @@ class Graphiti:
         entity_types: dict[str, type[BaseModel]] | None,
         excluded_entity_types: list[str] | None,
         custom_extraction_instructions: str | None = None,
+        clients: GraphitiClients | None = None,
     ) -> tuple[
         dict[str, list[EntityNode]],
         dict[str, str],
         list[list[EntityEdge]],
     ]:
         """Extract nodes and edges from all episodes and deduplicate."""
+        clients = clients or self.clients
+
         # Extract all nodes and edges for each episode
         extracted_nodes_bulk, extracted_edges_bulk = await extract_nodes_and_edges_bulk(
-            self.clients,
+            clients,
             episode_context,
             edge_type_map=edge_type_map,
             edge_types=edge_types,
@@ -615,7 +636,7 @@ class Graphiti:
 
         # Dedupe extracted nodes in memory
         nodes_by_episode, uuid_map = await dedupe_nodes_bulk(
-            self.clients, extracted_nodes_bulk, episode_context, entity_types
+            clients, extracted_nodes_bulk, episode_context, entity_types
         )
 
         return nodes_by_episode, uuid_map, extracted_edges_bulk
@@ -629,8 +650,11 @@ class Graphiti:
         edge_types: dict[str, type[BaseModel]] | None,
         edge_type_map: dict[tuple[str, str], list[str]],
         episodes: list[EpisodicNode],
+        clients: GraphitiClients | None = None,
     ) -> tuple[list[EntityNode], list[EntityEdge], list[EntityEdge], dict[str, str]]:
         """Resolve nodes and edges against the existing graph."""
+        clients = clients or self.clients
+
         nodes_by_uuid: dict[str, EntityNode] = {
             node.uuid: node for nodes in nodes_by_episode.values() for node in nodes
         }
@@ -650,7 +674,7 @@ class Graphiti:
         node_results = await semaphore_gather(
             *[
                 resolve_extracted_nodes(
-                    self.clients,
+                    clients,
                     nodes_by_episode_unique[episode.uuid],
                     episode,
                     previous_episodes,
@@ -683,7 +707,7 @@ class Graphiti:
         hydrated_nodes_results: list[list[EntityNode]] = await semaphore_gather(
             *[
                 extract_attributes_from_nodes(
-                    self.clients,
+                    clients,
                     nodes_by_episode_unique[episode.uuid],
                     episode,
                     previous_episodes,
@@ -710,7 +734,7 @@ class Graphiti:
         edge_results = await semaphore_gather(
             *[
                 resolve_extracted_edges(
-                    self.clients,
+                    clients,
                     edges_by_episode_unique[episode.uuid],
                     episode,
                     final_hydrated_nodes,
@@ -884,10 +908,17 @@ class Graphiti:
             group_id = get_default_group_id(self.driver.provider)
         else:
             validate_group_id(group_id)
-            if group_id != self.driver._database:
-                # if group_id is provided, use it as the database name
-                self.driver = self.driver.clone(database=group_id)
-                self.clients.driver = self.driver
+
+        # Create local driver/clients scoped to this call to avoid mutating shared
+        # instance state.  When using FalkorDB each group_id maps to a separate
+        # graph database, so we clone the driver to point at the right one without
+        # affecting concurrent callers that may target a different group.
+        if group_id != self.driver._database:
+            driver = self.driver.clone(database=group_id)
+            clients = self.clients.model_copy(update={'driver': driver})
+        else:
+            driver = self.driver
+            clients = self.clients
 
         with self.tracer.start_span('add_episode') as span:
             try:
@@ -898,14 +929,15 @@ class Graphiti:
                         last_n=RELEVANT_SCHEMA_LIMIT,
                         group_ids=[group_id],
                         source=source,
+                        driver=driver,
                     )
                     if previous_episode_uuids is None
-                    else await EpisodicNode.get_by_uuids(self.driver, previous_episode_uuids)
+                    else await EpisodicNode.get_by_uuids(driver, previous_episode_uuids)
                 )
 
                 # Get or create episode
                 episode = (
-                    await EpisodicNode.get_by_uuid(self.driver, uuid)
+                    await EpisodicNode.get_by_uuid(driver, uuid)
                     if uuid is not None
                     else EpisodicNode(
                         name=name,
@@ -928,7 +960,7 @@ class Graphiti:
 
                 # Extract and resolve nodes
                 extracted_nodes = await extract_nodes(
-                    self.clients,
+                    clients,
                     episode,
                     previous_episodes,
                     entity_types,
@@ -937,7 +969,7 @@ class Graphiti:
                 )
 
                 nodes, uuid_map, _ = await resolve_extracted_nodes(
-                    self.clients,
+                    clients,
                     extracted_nodes,
                     episode,
                     previous_episodes,
@@ -959,6 +991,7 @@ class Graphiti:
                     nodes,
                     uuid_map,
                     custom_extraction_instructions,
+                    clients=clients,
                 )
 
                 entity_edges = resolved_edges + invalidated_edges
@@ -966,7 +999,7 @@ class Graphiti:
                 # Extract node attributes - only pass new edges for summary generation
                 # to avoid duplicating facts that already exist in the graph
                 hydrated_nodes = await extract_attributes_from_nodes(
-                    self.clients,
+                    clients,
                     nodes,
                     episode,
                     previous_episodes,
@@ -983,6 +1016,7 @@ class Graphiti:
                     group_id,
                     saga,
                     saga_previous_episode_uuid,
+                    driver=driver,
                 )
 
                 # Update communities if requested
@@ -991,7 +1025,7 @@ class Graphiti:
                 if update_communities:
                     communities, community_edges = await semaphore_gather(
                         *[
-                            update_community(self.driver, self.llm_client, self.embedder, node)
+                            update_community(driver, self.llm_client, self.embedder, node)
                             for node in nodes
                         ],
                         max_coroutines=self.max_coroutines,
@@ -1110,10 +1144,14 @@ class Graphiti:
                     group_id = get_default_group_id(self.driver.provider)
                 else:
                     validate_group_id(group_id)
-                    if group_id != self.driver._database:
-                        # if group_id is provided, use it as the database name
-                        self.driver = self.driver.clone(database=group_id)
-                        self.clients.driver = self.driver
+
+                # Create local driver/clients scoped to this call (see add_episode)
+                if group_id != self.driver._database:
+                    driver = self.driver.clone(database=group_id)
+                    clients = self.clients.model_copy(update={'driver': driver})
+                else:
+                    driver = self.driver
+                    clients = self.clients
 
                 # Create default edge type map
                 edge_type_map_default = (
@@ -1123,7 +1161,7 @@ class Graphiti:
                 )
 
                 episodes = [
-                    await EpisodicNode.get_by_uuid(self.driver, episode.uuid)
+                    await EpisodicNode.get_by_uuid(driver, episode.uuid)
                     if episode.uuid is not None
                     else EpisodicNode(
                         name=episode.name,
@@ -1140,7 +1178,7 @@ class Graphiti:
 
                 # Save all episodes
                 await add_nodes_and_edges_bulk(
-                    driver=self.driver,
+                    driver=driver,
                     episodic_nodes=episodes,
                     episodic_edges=[],
                     entity_nodes=[],
@@ -1149,7 +1187,7 @@ class Graphiti:
                 )
 
                 # Get previous episode context for each episode
-                episode_context = await retrieve_previous_episodes_bulk(self.driver, episodes)
+                episode_context = await retrieve_previous_episodes_bulk(driver, episodes)
 
                 # Extract and dedupe nodes and edges
                 (
@@ -1163,6 +1201,7 @@ class Graphiti:
                     entity_types,
                     excluded_entity_types,
                     custom_extraction_instructions,
+                    clients=clients,
                 )
 
                 # Create Episodic Edges
@@ -1176,7 +1215,7 @@ class Graphiti:
                 ]
 
                 edges_by_episode = await dedupe_edges_bulk(
-                    self.clients,
+                    clients,
                     extracted_edges_bulk_updated,
                     episode_context,
                     [],
@@ -1198,6 +1237,7 @@ class Graphiti:
                     edge_types,
                     edge_type_map or edge_type_map_default,
                     episodes,
+                    clients=clients,
                 )
 
                 # Resolved pointers for episodic edges
@@ -1205,7 +1245,7 @@ class Graphiti:
 
                 # save data to KG
                 await add_nodes_and_edges_bulk(
-                    self.driver,
+                    driver,
                     episodes,
                     resolved_episodic_edges,
                     final_hydrated_nodes,
@@ -1217,7 +1257,9 @@ class Graphiti:
                 if saga is not None:
                     # Get or create saga node based on input type
                     if isinstance(saga, str):
-                        saga_node = await self._get_or_create_saga(saga, group_id, now)
+                        saga_node = await self._get_or_create_saga(
+                            saga, group_id, now, driver=driver
+                        )
                     else:
                         saga_node = saga
 
@@ -1225,7 +1267,7 @@ class Graphiti:
                     sorted_episodes = sorted(episodes, key=lambda e: e.valid_at)
 
                     # Find the most recent episode already in the saga
-                    previous_episode_records, _, _ = await self.driver.execute_query(
+                    previous_episode_records, _, _ = await driver.execute_query(
                         """
                         MATCH (s:Saga {uuid: $saga_uuid})-[:HAS_EPISODE]->(e:Episodic)
                         RETURN e.uuid AS uuid
@@ -1249,7 +1291,7 @@ class Graphiti:
                                 group_id=group_id,
                                 created_at=now,
                             )
-                            await next_episode_edge.save(self.driver)
+                            await next_episode_edge.save(driver)
 
                         # Create HAS_EPISODE edge from saga to episode
                         has_episode_edge = HasEpisodeEdge(
@@ -1258,7 +1300,7 @@ class Graphiti:
                             group_id=group_id,
                             created_at=now,
                         )
-                        await has_episode_edge.save(self.driver)
+                        await has_episode_edge.save(driver)
 
                         # Update previous_episode_uuid for the next iteration
                         previous_episode_uuid = episode.uuid


### PR DESCRIPTION
## Summary

- **`add_episode()` and `add_episode_bulk()` mutate `self.driver` and `self.clients.driver`** when switching FalkorDB graphs for different `group_id`s. In a multi-tenant server with one shared `Graphiti` client, writes to one group silently redirect all subsequent reads for other groups to the wrong FalkorDB graph database, returning empty results.
- **Root cause**: FalkorDB uses a separate graph database per `group_id`. `add_episode()` clones the driver to point at the target group's graph but stores the clone back into `self.driver`/`self.clients.driver`, permanently changing which graph the shared instance targets. Concurrent or interleaved operations targeting different groups corrupt each other's queries.
- **`@handle_multiple_group_ids` decorator only cloned drivers for `len(group_ids) > 1`**, so single-group searches used whatever stale driver state the last `add_episode` left behind.

## Fix

- `add_episode()` and `add_episode_bulk()` now create **local** `driver`/`clients` via `clone()` and `model_copy()` instead of mutating shared instance state
- All private methods (`_extract_and_resolve_edges`, `_process_episode_data`, `_get_or_create_saga`, `_extract_and_dedupe_nodes_bulk`, `_resolve_nodes_and_edges_bulk`) accept optional `driver`/`clients` params so the local clone flows through without touching `self`
- `@handle_multiple_group_ids` decorator now clones the driver for single `group_id` queries too (`>= 1` instead of `> 1`)

## Reproduction

1. Create a `Graphiti` instance with a FalkorDB driver
2. Call `add_episode(group_id="group-a", ...)` — driver now points to `group-a` graph
3. Call `add_episode(group_id="group-b", ...)` — driver flips to `group-b` graph
4. Call `search_(group_ids=["group-a"], ...)` — **returns empty results** because driver is querying `group-b` graph