### PR TITLE
fix: escape RediSearch special characters in group_id fulltext queries

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -93,6 +93,17 @@ def _sanitize(query: str) -> str:
     return ' '.join(sanitized.split())
 
 
+def _escape_redisearch_value(value: str) -> str:
+    """Escape RediSearch special characters in a field value."""
+    special_chars = r',.<>{}[]"' + r"':;!@#$%^&*()-+=~?|/\\"
+    escaped = []
+    for ch in value:
+        if ch in special_chars:
+            escaped.append('\\')
+        escaped.append(ch)
+    return ''.join(escaped)
+
+
 def _build_falkor_fulltext_query(
     query: str,
     group_ids: list[str] | None = None,
@@ -102,7 +113,7 @@ def _build_falkor_fulltext_query(
     if group_ids is None or len(group_ids) == 0:
         group_filter = ''
     else:
-        escaped_group_ids = [f'"{gid}"' for gid in group_ids]
+        escaped_group_ids = [_escape_redisearch_value(gid) for gid in group_ids]
         group_values = '|'.join(escaped_group_ids)
         group_filter = f'(@group_id:{group_values})'
 

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -400,9 +400,12 @@ class FalkorDriver(GraphDriver):
         if group_ids is None or len(group_ids) == 0:
             group_filter = ''
         else:
-            # Escape group_ids with quotes to prevent RediSearch syntax errors
-            # with reserved words like "main" or special characters like hyphens
-            escaped_group_ids = [f'"{gid}"' for gid in group_ids]
+            # Escape RediSearch special characters (hyphens, etc.) in group_ids
+            from graphiti_core.driver.falkordb.operations.search_ops import (
+                _escape_redisearch_value,
+            )
+
+            escaped_group_ids = [_escape_redisearch_value(gid) for gid in group_ids]
             group_values = '|'.join(escaped_group_ids)
             group_filter = f'(@group_id:{group_values})'
 


### PR DESCRIPTION
## Summary

- Group IDs containing hyphens or other RediSearch special characters (e.g. `"my-group"`, `"ap-erp"`) cause `RediSearch: Syntax error` in FalkorDB fulltext search queries
- The hyphen `-` is interpreted as the RediSearch NOT operator rather than a literal character, even when the value is double-quoted
- Error manifests as: `RediSearch: Syntax error at offset 14 near ap`

## Fix

- Added `_escape_redisearch_value()` helper that backslash-escapes RediSearch special characters (`,.<>{}[]"':;!@#$%^&*()-+=~?|/\`) before interpolating group_ids into fulltext query strings
- Applied the fix to **both** query builder locations:
  - `_build_falkor_fulltext_query()` in `search_ops.py` (used by `FalkorSearchOperations`)
  - `FalkorDriver.build_fulltext_query()` in `falkordb_driver.py` (used by `search_utils.fulltext_query()` fallback path)

## Before/After

```
# Before: RediSearch syntax error
(@group_id:"ap-erp") (search terms)

# After: properly escaped
(@group_id:ap\-erp) (search terms)
```

## Reproduction

1. Create a Graphiti instance with FalkorDB
2. Ingest data with `group_id="my-group"` (any group_id containing a hyphen)
3. Call `search_()` or `search()` with `group_ids=["my-group"]`
4. Observe `RediSearch: Syntax error`