### PR TITLE
docs: add missing README files for four example directories

### DIFF
--- a/examples/ecommerce/README.md
+++ b/examples/ecommerce/README.md
@@ -1,0 +1,73 @@
+# E-commerce Conversation Example
+
+This example demonstrates how to use Graphiti to build a knowledge graph from an e-commerce sales conversation. It showcases how Graphiti can extract product information, customer preferences, and conversational context from a chat between a customer and a sales assistant.
+
+## Overview
+
+The runner script (`runner.py`) simulates a conversation between a customer (John) and an Allbirds shoe sales assistant. The conversation covers product inquiries, preferences, and purchasing decisions, all of which are captured in the knowledge graph.
+
+An interactive Jupyter notebook (`runner.ipynb`) is also available for step-by-step exploration.
+
+## Prerequisites
+
+- Python 3.10+
+- OpenAI API key (set as `OPENAI_API_KEY` environment variable)
+- Neo4j database running locally or remotely
+
+## Setup
+
+1. Install the required dependencies:
+
+```bash
+pip install graphiti-core python-dotenv
+```
+
+2. Set up environment variables:
+
+```bash
+export OPENAI_API_KEY=your_openai_api_key
+export NEO4J_URI=bolt://localhost:7687
+export NEO4J_USER=neo4j
+export NEO4J_PASSWORD=password
+```
+
+## Running the Example
+
+```bash
+# Using the Python script
+python runner.py
+
+# Or using the Jupyter notebook
+jupyter notebook runner.ipynb
+```
+
+## How It Works
+
+1. **Conversation Ingestion**: Each message in the sales conversation is added to Graphiti as an episode of type `message`.
+
+2. **Knowledge Extraction**: Graphiti automatically extracts:
+   - **Customer entities**: The customer (John) and their attributes
+   - **Product entities**: Shoes, materials (wool, tree fiber), styles
+   - **Preferences**: Customer preferences for materials, colors, and styles
+   - **Relationships**: Links between customers, products, and preferences
+
+3. **Search**: After ingestion, the example performs searches to retrieve relevant facts from the knowledge graph.
+
+## Key Concepts
+
+- **Message-type Episodes**: Each chat message is ingested as an individual episode, preserving conversational flow.
+- **Product Knowledge Graphs**: Demonstrates how Graphiti can build structured product knowledge from unstructured conversations.
+- **Customer Preference Tracking**: Shows how Graphiti captures and links customer preferences to products over the course of a conversation.
+
+## Use Cases
+
+This pattern is applicable to:
+- **Customer support bots** that need to remember user preferences across sessions
+- **Sales assistants** that personalize recommendations based on conversation history
+- **Product recommendation engines** built on conversational data
+
+## Related Examples
+
+- `examples/quickstart/` — Basic Graphiti usage
+- `examples/langgraph-agent/` — Building an interactive sales agent with LangGraph and Graphiti
+- `examples/podcast/` — Processing multi-speaker conversations

--- a/examples/langgraph-agent/README.md
+++ b/examples/langgraph-agent/README.md
@@ -1,0 +1,71 @@
+# LangGraph Agent Example
+
+This example demonstrates how to build an interactive sales agent using [LangGraph](https://github.com/langchain-ai/langgraph) and Graphiti. The agent uses Graphiti as its memory and knowledge layer to personalize responses based on prior conversations and product information.
+
+## Overview
+
+The Jupyter notebook (`agent.ipynb`) walks through building a **ShoeBot Sales Agent** that:
+
+- Persists new chat turns to Graphiti and recalls relevant facts
+- Uses a tool to query the Graphiti knowledge graph for shoe information
+- Maintains agent state with an in-memory `MemorySaver`
+
+## Prerequisites
+
+- Python 3.10+
+- OpenAI API key (set as `OPENAI_API_KEY` environment variable)
+- Neo4j database running locally or remotely
+- Jupyter Notebook or JupyterLab
+
+## Setup
+
+1. Install the required dependencies:
+
+```bash
+pip install graphiti-core langchain-openai langgraph ipywidgets python-dotenv
+```
+
+2. Set up environment variables (or use a `.env` file):
+
+```bash
+export OPENAI_API_KEY=your_openai_api_key
+export NEO4J_URI=bolt://localhost:7687
+export NEO4J_USER=neo4j
+export NEO4J_PASSWORD=password
+```
+
+3. _(Optional)_ To enable LangSmith tracing, set:
+
+```bash
+export LANGCHAIN_TRACING_V2=true
+export LANGSMITH_API_KEY=your_langsmith_api_key
+export LANGCHAIN_PROJECT="Graphiti LangGraph Tutorial"
+```
+
+## Running the Example
+
+```bash
+jupyter notebook agent.ipynb
+```
+
+## How It Works
+
+1. **Graphiti Initialization**: Connects to Neo4j and sets up Graphiti with indices and constraints.
+2. **Product Data Loading**: Loads shoe product data into the Graphiti knowledge graph.
+3. **Agent Construction**: Builds a LangGraph agent with:
+   - A **search tool** that queries Graphiti for product information
+   - **Memory persistence** that saves each conversation turn to Graphiti
+   - **Fact recall** that retrieves relevant facts based on the latest user message
+4. **Interactive Chat**: The agent responds to user queries using both its LLM capabilities and the knowledge stored in Graphiti.
+
+## Key Concepts
+
+- **Agent Memory with Knowledge Graphs**: Instead of simple chat history, the agent builds a rich knowledge graph that captures entities and relationships from conversations.
+- **Tool-augmented Agents**: The agent uses a Graphiti search tool to retrieve product information on demand.
+- **Framework Integration**: Shows how Graphiti integrates with the LangChain/LangGraph ecosystem.
+
+## Related Examples
+
+- `examples/ecommerce/` — E-commerce conversation without an agent framework
+- `examples/quickstart/` — Basic Graphiti usage
+- `examples/podcast/` — Processing conversational data

--- a/examples/podcast/README.md
+++ b/examples/podcast/README.md
@@ -1,0 +1,64 @@
+# Podcast Transcript Example
+
+This example demonstrates how to use Graphiti to build a knowledge graph from a podcast transcript. It showcases Graphiti's ability to process conversational data with multiple speakers and temporal information.
+
+## Overview
+
+The example includes:
+
+- **Transcript Parser** (`transcript_parser.py`): Parses a podcast transcript into structured messages with speaker information, timestamps, and roles.
+- **Podcast Runner** (`podcast_runner.py`): Ingests the parsed transcript into Graphiti as a series of episodes and performs searches on the resulting knowledge graph.
+
+## Prerequisites
+
+- Python 3.10+
+- OpenAI API key (set as `OPENAI_API_KEY` environment variable)
+- Neo4j database running locally or remotely
+
+## Setup
+
+1. Install the required dependencies:
+
+```bash
+pip install graphiti-core python-dotenv
+```
+
+2. Set up environment variables:
+
+```bash
+export OPENAI_API_KEY=your_openai_api_key
+export NEO4J_URI=bolt://localhost:7687
+export NEO4J_USER=neo4j
+export NEO4J_PASSWORD=password
+```
+
+3. Ensure the transcript file (`podcast_transcript.txt`) is in the same directory.
+
+## Running the Example
+
+```bash
+python podcast_runner.py
+```
+
+## How It Works
+
+1. **Transcript Parsing**: The `transcript_parser.py` module reads the raw transcript and extracts individual messages with:
+   - Speaker name and role
+   - Relative and absolute timestamps
+   - Message content
+
+2. **Graph Construction**: Each message is added to Graphiti as an episode, preserving the temporal ordering and speaker attribution.
+
+3. **Knowledge Extraction**: Graphiti automatically extracts entities and relationships from the conversation, building a queryable knowledge graph.
+
+## Key Concepts
+
+- **Multi-speaker Episodes**: Demonstrates handling conversations with multiple participants, each with distinct roles.
+- **Temporal Ordering**: Messages are ingested with accurate timestamps, enabling temporal queries on the knowledge graph.
+- **Bulk Ingestion**: Uses `RawEpisode` for efficient batch processing of transcript data.
+
+## Related Examples
+
+- `examples/quickstart/` — Basic Graphiti usage
+- `examples/wizard_of_oz/` — Processing literary text
+- `examples/langgraph-agent/` — Building an interactive agent with Graphiti

--- a/examples/wizard_of_oz/README.md
+++ b/examples/wizard_of_oz/README.md
@@ -1,0 +1,64 @@
+# Wizard of Oz Example
+
+This example demonstrates how to use Graphiti to build a knowledge graph from a literary text — _The Wonderful Wizard of Oz_ by L. Frank Baum. It showcases processing long-form narrative content and extracting entities and relationships across chapters.
+
+## Overview
+
+The example includes:
+
+- **Text Parser** (`parser.py`): Splits the full text of _The Wizard of Oz_ into chapter-based episodes.
+- **Runner** (`runner.py`): Ingests the parsed chapters into Graphiti and builds a knowledge graph of characters, locations, and events.
+
+## Prerequisites
+
+- Python 3.10+
+- Anthropic API key (set as `ANTHROPIC_API_KEY` environment variable) — this example uses the Anthropic LLM client
+- Neo4j database running locally or remotely
+
+## Setup
+
+1. Install the required dependencies:
+
+```bash
+pip install graphiti-core python-dotenv
+```
+
+2. Set up environment variables:
+
+```bash
+export ANTHROPIC_API_KEY=your_anthropic_api_key
+export NEO4J_URI=bolt://localhost:7687
+export NEO4J_USER=neo4j
+export NEO4J_PASSWORD=password
+```
+
+3. Ensure the text file (`woo.txt`) is in the same directory.
+
+## Running the Example
+
+```bash
+python runner.py
+```
+
+## How It Works
+
+1. **Text Parsing**: The parser splits the full text into chapters using regex-based chapter detection, extracting:
+   - Chapter number
+   - Chapter title
+   - Chapter content
+
+2. **Graph Construction**: Each chapter is added to Graphiti as an episode with simulated temporal spacing (one day per chapter).
+
+3. **Knowledge Extraction**: Graphiti extracts characters (Dorothy, Toto, the Scarecrow, etc.), locations (Kansas, Oz, Emerald City), and the relationships between them.
+
+## Key Concepts
+
+- **Long-form Text Processing**: Demonstrates handling book-length content by splitting into logical episodes (chapters).
+- **Anthropic LLM Client**: Shows how to use Graphiti with Anthropic's Claude instead of OpenAI.
+- **Narrative Knowledge Graphs**: Builds a graph that captures story elements — characters, locations, events, and their evolving relationships.
+
+## Related Examples
+
+- `examples/podcast/` — Processing conversational transcripts
+- `examples/quickstart/` — Basic Graphiti usage with OpenAI
+- `examples/ecommerce/` — Domain-specific knowledge graphs


### PR DESCRIPTION
## Summary

This PR adds README documentation to four example directories that were previously missing them:

- **`examples/podcast/`** — Documents the podcast transcript processing example, including transcript parsing, multi-speaker episode ingestion, and temporal ordering.
- **`examples/wizard_of_oz/`** — Documents the literary text processing example using *The Wizard of Oz*, including the Anthropic LLM client usage and chapter-based episode splitting.
- **`examples/ecommerce/`** — Documents the e-commerce sales conversation example, covering product knowledge extraction and customer preference tracking.
- **`examples/langgraph-agent/`** — Documents the LangGraph integration example for building an interactive ShoeBot sales agent with Graphiti-powered memory.

## Motivation

The `examples/quickstart/`, `examples/azure-openai/`, `examples/opentelemetry/`, and `examples/gliner2/` directories all have README files, but the other four examples did not. This makes it harder for new users to discover and understand these examples.

Each README follows the same structure as the existing example READMEs:
- Overview of what the example does
- Prerequisites and setup instructions
- How to run the example
- Key concepts demonstrated
- Cross-references to related examples

## Changes

- Added `examples/podcast/README.md`
- Added `examples/wizard_of_oz/README.md`
- Added `examples/ecommerce/README.md`
- Added `examples/langgraph-agent/README.md`

No code changes.