### PR TITLE
Fix/falkordb group id race condition

### DIFF
--- a/graphiti_core/decorators.py
+++ b/graphiti_core/decorators.py
@@ -61,10 +61,12 @@ def handle_multiple_group_ids(func: F) -> F:
             gid = group_ids[0]
             driver = self.clients.driver
             if gid != getattr(driver, '_database', None):
+                cloned = driver.clone(database=gid)
+                await cloned.ensure_database_initialized()
                 return await func(
                     self,
                     *args,
-                    **{**kwargs, 'driver': driver.clone(database=gid)},
+                    **{**kwargs, 'driver': cloned},
                 )
             return await func(self, *args, **kwargs)
 
@@ -79,10 +81,13 @@ def handle_multiple_group_ids(func: F) -> F:
                 if group_ids_pos is not None and len(args) > group_ids_pos:
                     filtered_args.pop(group_ids_pos)
 
+                cloned = driver.clone(database=gid)
+                await cloned.ensure_database_initialized()
+
                 return await func(
                     self,
                     *filtered_args,
-                    **{**kwargs, 'group_ids': [gid], 'driver': driver.clone(database=gid)},
+                    **{**kwargs, 'group_ids': [gid], 'driver': cloned},
                 )
 
             results = await semaphore_gather(
@@ -111,6 +116,34 @@ def handle_multiple_group_ids(func: F) -> F:
                 return results
 
         # Normal execution
+        return await func(self, *args, **kwargs)
+
+    return wrapper  # type: ignore
+
+
+def handle_single_group_id(func: F) -> F:
+    """
+    Decorator for FalkorDB write methods that need to scope to a single group_id.
+    Injects a cloned driver targeted at the group's graph instead of mutating self.driver.
+    """
+
+    @functools.wraps(func)
+    async def wrapper(self, *args, **kwargs):
+        group_id = kwargs.get('group_id')
+        if group_id is None:
+            pos = get_parameter_position(func, 'group_id')
+            if pos is not None and len(args) > pos - 1:
+                group_id = args[pos - 1]  # adjust for self
+        if (
+            group_id
+            and hasattr(self, 'clients')
+            and hasattr(self.clients, 'driver')
+            and self.clients.driver.provider == GraphProvider.FALKORDB
+            and group_id != self.clients.driver._database
+        ):
+            cloned = self.clients.driver.clone(database=group_id)
+            await cloned.ensure_database_initialized()
+            kwargs['driver'] = cloned
         return await func(self, *args, **kwargs)
 
     return wrapper  # type: ignore

--- a/graphiti_core/driver/driver.py
+++ b/graphiti_core/driver/driver.py
@@ -132,6 +132,14 @@ class GraphDriver(QueryExecutor, ABC):
         """Clone the driver with a different database or graph name."""
         return self
 
+    async def ensure_database_initialized(self) -> None:
+        """Ensure indices and constraints exist for the current database.
+
+        FalkorDB overrides this to track per-graph initialization.
+        Other backends are no-ops since they share a single database.
+        """
+        pass
+
     def build_fulltext_query(
         self, query: str, group_ids: list[str] | None = None, max_query_length: int = 128
     ) -> str:

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import asyncio
+import copy
 import datetime
 import logging
 import re
@@ -173,12 +174,16 @@ class FalkorDriver(GraphDriver):
         self._search_ops = FalkorSearchOperations()
         self._graph_ops = FalkorGraphMaintenanceOperations()
 
+        # Track which databases have had indices built (shared across clones via shallow copy)
+        self._initialized_databases: set[str] = set()
+
         # Schedule the indices and constraints to be built
         try:
             # Try to get the current event loop
             loop = asyncio.get_running_loop()
             # Schedule the build_indices_and_constraints to run
             loop.create_task(self.build_indices_and_constraints())
+            self._initialized_databases.add(self._database)
         except RuntimeError:
             # No event loop running, this will be handled later
             pass
@@ -323,17 +328,24 @@ class FalkorDriver(GraphDriver):
     def clone(self, database: str) -> 'GraphDriver':
         """
         Returns a shallow copy of this driver with a different default database.
-        Reuses the same connection (e.g. FalkorDB, Neo4j).
+        Reuses the same connection and all operation objects without running __init__.
+        The _initialized_databases set is shared across all clones via shallow copy.
         """
         if database == self._database:
-            cloned = self
-        elif database == self.default_group_id:
-            cloned = FalkorDriver(falkor_db=self.client)
-        else:
-            # Create a new instance of FalkorDriver with the same connection but a different database
-            cloned = FalkorDriver(falkor_db=self.client, database=database)
-
+            return self
+        cloned = copy.copy(self)
+        cloned._database = database
         return cloned
+
+    async def ensure_database_initialized(self) -> None:
+        """Ensure indices and constraints exist for the current database.
+
+        Uses _initialized_databases (shared across all clones via shallow copy)
+        to ensure each group's graph gets indices built exactly once.
+        """
+        if self._database not in self._initialized_databases:
+            self._initialized_databases.add(self._database)
+            await self.build_indices_and_constraints()
 
     async def health_check(self) -> None:
         """Check FalkorDB connectivity by running a simple query."""

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -25,7 +25,7 @@ from typing_extensions import LiteralString
 
 from graphiti_core.cross_encoder.client import CrossEncoderClient
 from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient
-from graphiti_core.decorators import handle_multiple_group_ids
+from graphiti_core.decorators import handle_multiple_group_ids, handle_single_group_id
 from graphiti_core.driver.driver import GraphDriver
 from graphiti_core.driver.neo4j_driver import Neo4jDriver
 from graphiti_core.edges import (
@@ -344,7 +344,11 @@ class Graphiti:
         await self.driver.close()
 
     async def _get_or_create_saga(
-        self, saga_name: str, group_id: str, created_at: datetime
+        self,
+        saga_name: str,
+        group_id: str,
+        created_at: datetime,
+        driver: GraphDriver | None = None,
     ) -> SagaNode:
         """
         Get an existing saga by name or create a new one.
@@ -360,6 +364,8 @@ class Graphiti:
             originating episode's reference time (``valid_at``) rather than the
             current wall-clock time so the saga's ``created_at`` reflects the
             episode it was minted from.
+        driver : GraphDriver | None
+            Optional. The graph driver to use. If not provided, uses self.clients.driver.
 
         Returns
         -------
@@ -368,7 +374,8 @@ class Graphiti:
         """
         from graphiti_core.helpers import parse_db_date
 
-        records, _, _ = await self.driver.execute_query(
+        driver = driver or self.clients.driver
+        records, _, _ = await driver.execute_query(
             """
             MATCH (s:Saga {name: $name, group_id: $group_id})
             RETURN s.uuid AS uuid, s.name AS name, s.group_id AS group_id, s.created_at AS created_at
@@ -388,22 +395,26 @@ class Graphiti:
             )
 
         saga = SagaNode(name=saga_name, group_id=group_id, created_at=created_at)
-        await saga.save(self.driver)
+        await saga.save(driver)
         return saga
 
     async def _saga_get_previous_episode_uuid(
-        self, saga_uuid: str, current_episode_uuid: str
+        self,
+        saga_uuid: str,
+        current_episode_uuid: str,
+        driver: GraphDriver | None = None,
     ) -> str | None:
         """Find the most recent episode UUID in a saga, excluding the current one."""
-        if self.driver.graph_operations_interface:
+        driver = driver or self.clients.driver
+        if driver.graph_operations_interface:
             try:
-                return await self.driver.graph_operations_interface.saga_get_previous_episode_uuid(
-                    self.driver, saga_uuid, current_episode_uuid
+                return await driver.graph_operations_interface.saga_get_previous_episode_uuid(
+                    driver, saga_uuid, current_episode_uuid
                 )
             except NotImplementedError:
                 pass
 
-        records, _, _ = await self.driver.execute_query(
+        records, _, _ = await driver.execute_query(
             """
             MATCH (s:Saga {uuid: $saga_uuid})-[:HAS_EPISODE]->(e:Episodic)
             WHERE e.uuid <> $current_episode_uuid
@@ -639,6 +650,7 @@ class Graphiti:
         nodes: list[EntityNode],
         uuid_map: dict[str, str],
         custom_extraction_instructions: str | None = None,
+        driver: GraphDriver | None = None,
     ) -> tuple[list[EntityEdge], list[EntityEdge], list[EntityEdge]]:
         """Extract edges from episode(s) and resolve against existing graph.
 
@@ -650,11 +662,17 @@ class Graphiti:
             - invalidated_edges: Edges invalidated by new information
             - new_edges: Only edges that are new to the graph (not duplicates)
         """
+        clients = (
+            self.clients.model_copy(update={'driver': driver})
+            if driver is not None
+            else self.clients
+        )
+
         episodes = episode if isinstance(episode, list) else [episode]
         primary_episode = episodes[0]
 
         extracted_edges = await extract_edges(
-            self.clients,
+            clients,
             episode,
             extracted_nodes,
             previous_episodes,
@@ -667,7 +685,7 @@ class Graphiti:
         edges = resolve_edge_pointers(extracted_edges, uuid_map)
 
         resolved_edges, invalidated_edges, new_edges = await resolve_extracted_edges(
-            self.clients,
+            clients,
             edges,
             primary_episode,
             nodes,
@@ -687,6 +705,7 @@ class Graphiti:
         saga: str | SagaNode | None = None,
         saga_previous_episode_uuid: str | None = None,
         node_episode_index_map: dict[str, list[int]] | None = None,
+        driver: GraphDriver | None = None,
     ) -> tuple[list[EpisodicEdge], EpisodicNode]:
         """Process and save episode data to the graph.
 
@@ -714,6 +733,7 @@ class Graphiti:
             Optional mapping from node UUID to 0-indexed episode positions for
             building episodic edges with correct attribution.
         """
+        driver = driver or self.clients.driver
         episodes = episode if isinstance(episode, list) else [episode]
         episode_uuids = [ep.uuid for ep in episodes]
 
@@ -724,7 +744,7 @@ class Graphiti:
                 ep.content = ''
 
         await add_nodes_and_edges_bulk(
-            self.driver,
+            driver,
             episodes,
             episodic_edges,
             nodes,
@@ -742,7 +762,9 @@ class Graphiti:
                 # newly created saga so its created_at matches the episode that
                 # minted it, not the wall-clock time of this run.
                 saga_created_at = primary_episode.valid_at or now
-                saga_node = await self._get_or_create_saga(saga, group_id, saga_created_at)
+                saga_node = await self._get_or_create_saga(
+                    saga, group_id, saga_created_at, driver=driver
+                )
             else:
                 saga_node = saga
 
@@ -750,7 +772,7 @@ class Graphiti:
             previous_episode_uuid: str | None = saga_previous_episode_uuid
             if previous_episode_uuid is None:
                 previous_episode_uuid = await self._saga_get_previous_episode_uuid(
-                    saga_node.uuid, primary_episode.uuid
+                    saga_node.uuid, primary_episode.uuid, driver=driver
                 )
 
             # Create NEXT_EPISODE edge from the previous episode to the new one
@@ -761,7 +783,7 @@ class Graphiti:
                     group_id=group_id,
                     created_at=now,
                 )
-                await next_episode_edge.save(self.driver)
+                await next_episode_edge.save(driver)
 
             # Create HAS_EPISODE edge from saga to the new episode
             has_episode_edge = HasEpisodeEdge(
@@ -770,13 +792,13 @@ class Graphiti:
                 group_id=group_id,
                 created_at=now,
             )
-            await has_episode_edge.save(self.driver)
+            await has_episode_edge.save(driver)
 
             # Track first and last episode on the saga node
             if saga_node.first_episode_uuid is None:
                 saga_node.first_episode_uuid = primary_episode.uuid
             saga_node.last_episode_uuid = primary_episode.uuid
-            await saga_node.save(self.driver)
+            await saga_node.save(driver)
 
         return episodic_edges, primary_episode
 
@@ -788,15 +810,22 @@ class Graphiti:
         entity_types: dict[str, type[BaseModel]] | None,
         excluded_entity_types: list[str] | None,
         custom_extraction_instructions: str | None = None,
+        driver: GraphDriver | None = None,
     ) -> tuple[
         dict[str, list[EntityNode]],
         dict[str, str],
         list[list[EntityEdge]],
     ]:
         """Extract nodes and edges from all episodes and deduplicate."""
+        clients = (
+            self.clients.model_copy(update={'driver': driver})
+            if driver is not None
+            else self.clients
+        )
+
         # Extract all nodes and edges for each episode
         extracted_nodes_bulk, extracted_edges_bulk = await extract_nodes_and_edges_bulk(
-            self.clients,
+            clients,
             episode_context,
             edge_type_map=edge_type_map,
             edge_types=edge_types,
@@ -807,7 +836,7 @@ class Graphiti:
 
         # Dedupe extracted nodes in memory
         nodes_by_episode, uuid_map = await dedupe_nodes_bulk(
-            self.clients, extracted_nodes_bulk, episode_context, entity_types
+            clients, extracted_nodes_bulk, episode_context, entity_types
         )
 
         return nodes_by_episode, uuid_map, extracted_edges_bulk
@@ -821,8 +850,15 @@ class Graphiti:
         edge_types: dict[str, type[BaseModel]] | None,
         edge_type_map: dict[tuple[str, str], list[str]],
         episodes: list[EpisodicNode],
+        driver: GraphDriver | None = None,
     ) -> tuple[list[EntityNode], list[EntityEdge], list[EntityEdge], dict[str, str]]:
         """Resolve nodes and edges against the existing graph."""
+        clients = (
+            self.clients.model_copy(update={'driver': driver})
+            if driver is not None
+            else self.clients
+        )
+
         nodes_by_uuid: dict[str, EntityNode] = {
             node.uuid: node for nodes in nodes_by_episode.values() for node in nodes
         }
@@ -842,7 +878,7 @@ class Graphiti:
         node_results = await semaphore_gather(
             *[
                 resolve_extracted_nodes(
-                    self.clients,
+                    clients,
                     nodes_by_episode_unique[episode.uuid],
                     episode,
                     previous_episodes,
@@ -875,7 +911,7 @@ class Graphiti:
         hydrated_nodes_results: list[list[EntityNode]] = await semaphore_gather(
             *[
                 extract_attributes_from_nodes(
-                    self.clients,
+                    clients,
                     nodes_by_episode_unique[episode.uuid],
                     episode,
                     previous_episodes,
@@ -902,7 +938,7 @@ class Graphiti:
         edge_results = await semaphore_gather(
             *[
                 resolve_extracted_edges(
-                    self.clients,
+                    clients,
                     edges_by_episode_unique[episode.uuid],
                     episode,
                     final_hydrated_nodes,
@@ -977,6 +1013,7 @@ class Graphiti:
 
         return await retrieve_episodes(driver, reference_time, last_n, group_ids, source, saga)
 
+    @handle_single_group_id
     async def add_episode(
         self,
         name: str,
@@ -995,6 +1032,7 @@ class Graphiti:
         custom_extraction_instructions: str | None = None,
         saga: str | SagaNode | None = None,
         saga_previous_episode_uuid: str | None = None,
+        driver: GraphDriver | None = None,
     ) -> AddEpisodeResults:
         """
         Process an episode and update the graph.
@@ -1066,6 +1104,8 @@ class Graphiti:
         """
         start = time()
         now = utc_now()
+        driver = driver or self.clients.driver
+        clients = self.clients.model_copy(update={'driver': driver})
 
         validate_entity_types(entity_types)
         validate_excluded_entity_types(excluded_entity_types, entity_types)
@@ -1073,13 +1113,9 @@ class Graphiti:
         if group_id is None:
             # if group_id is None, use the default group id by the provider
             # and the preset database name will be used
-            group_id = get_default_group_id(self.driver.provider)
+            group_id = get_default_group_id(driver.provider)
         else:
             validate_group_id(group_id)
-            if group_id != self.driver._database:
-                # if group_id is provided, use it as the database name
-                self.driver = self.driver.clone(database=group_id)
-                self.clients.driver = self.driver
 
         with self.tracer.start_span('add_episode') as span:
             try:
@@ -1092,12 +1128,12 @@ class Graphiti:
                         source=source,
                     )
                     if previous_episode_uuids is None
-                    else await EpisodicNode.get_by_uuids(self.driver, previous_episode_uuids)
+                    else await EpisodicNode.get_by_uuids(driver, previous_episode_uuids)
                 )
 
                 # Get or create episode
                 episode = (
-                    await EpisodicNode.get_by_uuid(self.driver, uuid)
+                    await EpisodicNode.get_by_uuid(driver, uuid)
                     if uuid is not None
                     else EpisodicNode(
                         name=name,
@@ -1120,7 +1156,7 @@ class Graphiti:
 
                 # Extract and resolve nodes
                 extracted_nodes, node_episode_index_map = await extract_nodes(
-                    self.clients,
+                    clients,
                     episode,
                     previous_episodes,
                     entity_types,
@@ -1129,7 +1165,7 @@ class Graphiti:
                 )
 
                 nodes, uuid_map, _ = await resolve_extracted_nodes(
-                    self.clients,
+                    clients,
                     extracted_nodes,
                     episode,
                     previous_episodes,
@@ -1151,6 +1187,7 @@ class Graphiti:
                     nodes,
                     uuid_map,
                     custom_extraction_instructions,
+                    driver=driver,
                 )
 
                 entity_edges = resolved_edges + invalidated_edges
@@ -1158,7 +1195,7 @@ class Graphiti:
                 # Extract node attributes - only pass new edges for summary generation
                 # to avoid duplicating facts that already exist in the graph
                 hydrated_nodes = await extract_attributes_from_nodes(
-                    self.clients,
+                    clients,
                     nodes,
                     episode,
                     previous_episodes,
@@ -1176,6 +1213,7 @@ class Graphiti:
                     saga,
                     saga_previous_episode_uuid,
                     node_episode_index_map,
+                    driver=driver,
                 )
 
                 # Update communities if requested
@@ -1184,7 +1222,7 @@ class Graphiti:
                 if update_communities:
                     communities, community_edges = await semaphore_gather(
                         *[
-                            update_community(self.driver, self.llm_client, self.embedder, node)
+                            update_community(driver, self.llm_client, self.embedder, node)
                             for node in nodes
                         ],
                         max_coroutines=self.max_coroutines,
@@ -1227,6 +1265,7 @@ class Graphiti:
                 span.record_exception(e)
                 raise e
 
+    @handle_single_group_id
     async def add_episode_bulk(
         self,
         bulk_episodes: list[RawEpisode],
@@ -1237,6 +1276,7 @@ class Graphiti:
         edge_type_map: dict[tuple[str, str], list[str]] | None = None,
         custom_extraction_instructions: str | None = None,
         saga: str | SagaNode | None = None,
+        driver: GraphDriver | None = None,
     ) -> AddBulkEpisodeResults:
         """
         Process multiple episodes in bulk and update the graph.
@@ -1298,16 +1338,14 @@ class Graphiti:
             try:
                 start = time()
                 now = utc_now()
+                driver = driver or self.clients.driver
+                clients = self.clients.model_copy(update={'driver': driver})
 
                 # if group_id is None, use the default group id by the provider
                 if group_id is None:
-                    group_id = get_default_group_id(self.driver.provider)
+                    group_id = get_default_group_id(driver.provider)
                 else:
                     validate_group_id(group_id)
-                    if group_id != self.driver._database:
-                        # if group_id is provided, use it as the database name
-                        self.driver = self.driver.clone(database=group_id)
-                        self.clients.driver = self.driver
 
                 # Create default edge type map
                 edge_type_map_default = (
@@ -1317,7 +1355,7 @@ class Graphiti:
                 )
 
                 episodes = [
-                    await EpisodicNode.get_by_uuid(self.driver, episode.uuid)
+                    await EpisodicNode.get_by_uuid(driver, episode.uuid)
                     if episode.uuid is not None
                     else EpisodicNode(
                         name=episode.name,
@@ -1334,7 +1372,7 @@ class Graphiti:
 
                 # Save all episodes
                 await add_nodes_and_edges_bulk(
-                    driver=self.driver,
+                    driver=driver,
                     episodic_nodes=episodes,
                     episodic_edges=[],
                     entity_nodes=[],
@@ -1343,7 +1381,7 @@ class Graphiti:
                 )
 
                 # Get previous episode context for each episode
-                episode_context = await retrieve_previous_episodes_bulk(self.driver, episodes)
+                episode_context = await retrieve_previous_episodes_bulk(driver, episodes)
 
                 # Extract and dedupe nodes and edges
                 (
@@ -1357,6 +1395,7 @@ class Graphiti:
                     entity_types,
                     excluded_entity_types,
                     custom_extraction_instructions,
+                    driver=driver,
                 )
 
                 # Create Episodic Edges
@@ -1370,7 +1409,7 @@ class Graphiti:
                 ]
 
                 edges_by_episode = await dedupe_edges_bulk(
-                    self.clients,
+                    clients,
                     extracted_edges_bulk_updated,
                     episode_context,
                     [],
@@ -1392,6 +1431,7 @@ class Graphiti:
                     edge_types,
                     edge_type_map or edge_type_map_default,
                     episodes,
+                    driver=driver,
                 )
 
                 # Resolved pointers for episodic edges
@@ -1399,7 +1439,7 @@ class Graphiti:
 
                 # save data to KG
                 await add_nodes_and_edges_bulk(
-                    self.driver,
+                    driver,
                     episodes,
                     resolved_episodic_edges,
                     final_hydrated_nodes,
@@ -1416,7 +1456,9 @@ class Graphiti:
                         # episode window rather than the time this run started.
                         valid_ats = [ep.valid_at for ep in episodes if ep.valid_at is not None]
                         saga_created_at = min(valid_ats) if valid_ats else now
-                        saga_node = await self._get_or_create_saga(saga, group_id, saga_created_at)
+                        saga_node = await self._get_or_create_saga(
+                            saga, group_id, saga_created_at, driver=driver
+                        )
                     else:
                         saga_node = saga
 
@@ -1425,7 +1467,7 @@ class Graphiti:
 
                     # Find the most recent episode already in the saga
                     previous_episode_uuid = await self._saga_get_previous_episode_uuid(
-                        saga_node.uuid, ''
+                        saga_node.uuid, '', driver=driver
                     )
 
                     for episode in sorted_episodes:
@@ -1437,7 +1479,7 @@ class Graphiti:
                                 group_id=group_id,
                                 created_at=now,
                             )
-                            await next_episode_edge.save(self.driver)
+                            await next_episode_edge.save(driver)
 
                         # Create HAS_EPISODE edge from saga to episode
                         has_episode_edge = HasEpisodeEdge(
@@ -1446,7 +1488,7 @@ class Graphiti:
                             group_id=group_id,
                             created_at=now,
                         )
-                        await has_episode_edge.save(self.driver)
+                        await has_episode_edge.save(driver)
 
                         # Update previous_episode_uuid for the next iteration
                         previous_episode_uuid = episode.uuid
@@ -1456,7 +1498,7 @@ class Graphiti:
                         if saga_node.first_episode_uuid is None:
                             saga_node.first_episode_uuid = sorted_episodes[0].uuid
                         saga_node.last_episode_uuid = sorted_episodes[-1].uuid
-                        await saga_node.save(self.driver)
+                        await saga_node.save(driver)
 
                 end = time()
 

--- a/tests/test_falkor_concurrency.py
+++ b/tests/test_falkor_concurrency.py
@@ -1,0 +1,251 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Tests for FalkorDB concurrency / group isolation.
+
+These tests cover the fix for the race condition where concurrent
+``add_episode`` calls with different ``group_id`` values could interleave
+and end up writing to the wrong graph because of shared mutable
+``self.driver`` state.
+
+The tests are written so they don't need a live FalkorDB instance: the
+client/connection is mocked, and we patch the heavy code paths
+(``build_indices_and_constraints`` for the driver tests, and the bulk
+write helper / LLM extraction helpers for the Graphiti tests) to keep
+the focus on driver routing and group isolation.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graphiti_core import Graphiti
+from graphiti_core.cross_encoder.client import CrossEncoderClient
+from graphiti_core.driver.falkordb_driver import FalkorDriver
+from graphiti_core.embedder.client import EmbedderClient
+from graphiti_core.llm_client.client import LLMClient
+from graphiti_core.llm_client.config import LLMConfig
+from graphiti_core.nodes import EntityNode
+
+pytest_plugins = ('pytest_asyncio',)
+
+
+def _make_falkor_driver(database: str = 'default_db') -> FalkorDriver:
+    """Construct a FalkorDriver with a mocked underlying client.
+
+    We bypass the real ``FalkorDB`` connection by passing a ``MagicMock``
+    as ``falkor_db``. The driver only needs the object to be present for
+    ``__init__`` to succeed; the tests never exercise the real Redis
+    connection because the heavy paths are patched.
+    """
+    fake_client = MagicMock()
+    return FalkorDriver(falkor_db=fake_client, database=database)
+
+
+class _MockLLMClient(LLMClient):
+    def __init__(self) -> None:
+        super().__init__(LLMConfig())
+        self._mock_generate = AsyncMock(return_value={'edges': []})
+
+    async def _generate_response(
+        self, messages, response_model=None, max_tokens=100, model_size=None
+    ):
+        return await self._mock_generate(messages, response_model, max_tokens, model_size)
+
+
+class _MockEmbedderClient(EmbedderClient):
+    def __init__(self) -> None:
+        self._mock_create = AsyncMock(return_value=[0.1] * 1536)
+
+    async def create(self, input_data):
+        return await self._mock_create(input_data)
+
+    async def create_batch(self, input_data_list):
+        return [[0.1] * 1536 for _ in input_data_list]
+
+
+class _MockCrossEncoderClient(CrossEncoderClient):
+    async def rank(self, query, passages):
+        return [(passage, 1.0) for passage in passages]
+
+
+@pytest.mark.asyncio
+async def test_clone_does_not_trigger_init():
+    """``clone()`` must not run ``build_indices_and_constraints`` on the
+    new database. Index building is deferred to
+    ``ensure_database_initialized``.
+    """
+    driver = _make_falkor_driver(database='base')
+
+    with patch.object(
+        FalkorDriver, 'build_indices_and_constraints', new_callable=AsyncMock
+    ) as build:
+        cloned = driver.clone(database='other_db')
+
+        # Sanity check: clone returned a different object pointed at the new DB.
+        assert cloned is not driver
+        assert cloned._database == 'other_db'
+        # The fix: cloning must NOT call build_indices_and_constraints.
+        assert build.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_ensure_database_initialized_idempotent():
+    """``ensure_database_initialized`` should call
+    ``build_indices_and_constraints`` exactly once per database, even
+    across repeated calls and across clones that share the
+    ``_initialized_databases`` set.
+    """
+    driver = _make_falkor_driver(database='base')
+
+    with patch.object(
+        FalkorDriver, 'build_indices_and_constraints', new_callable=AsyncMock
+    ) as build:
+        cloned = driver.clone(database='group_x')
+
+        # Clear out any side-effects from __init__ tracking 'base'.
+        driver._initialized_databases.discard('group_x')
+
+        await cloned.ensure_database_initialized()
+        await cloned.ensure_database_initialized()
+
+        # Second call should be a no-op for the same database.
+        assert build.call_count == 1
+        assert 'group_x' in cloned._initialized_databases
+        # The set is shared via shallow copy.
+        assert 'group_x' in driver._initialized_databases
+
+
+@pytest.mark.asyncio
+async def test_concurrent_add_episode_isolates_drivers():
+    """Two concurrent ``add_episode`` calls with different ``group_id``
+    values must each see a driver targeted at their own database. With
+    the old buggy code, Task A would resume to find ``self.driver``
+    pointing at Task B's database.
+    """
+    driver = _make_falkor_driver(database='default_db')
+    # Pre-mark all relevant DBs as initialized so ensure_database_initialized
+    # is a no-op (no real Redis available in this test).
+    driver._initialized_databases.update({'default_db', 'group_a', 'group_b'})
+
+    graphiti = Graphiti(
+        graph_driver=driver,
+        llm_client=_MockLLMClient(),
+        embedder=_MockEmbedderClient(),
+        cross_encoder=_MockCrossEncoderClient(),
+    )
+
+    # Capture the driver's _database at the moment of the bulk write.
+    captured_databases: list[str] = []
+    capture_lock = asyncio.Lock()
+
+    async def capture_database(driver_arg, *args, **kwargs):
+        async with capture_lock:
+            captured_databases.append(driver_arg._database)
+
+    # Task A waits for Task B to start before completing extraction so we
+    # exercise the interleaving path.
+    task_a_in_extract = asyncio.Event()
+    task_b_done = asyncio.Event()
+
+    async def mocked_extract_nodes(
+        clients,
+        episode,
+        previous_episodes,
+        entity_types,
+        excluded_entity_types,
+        custom_extraction_instructions=None,
+    ):
+        if episode.group_id == 'group_a':
+            task_a_in_extract.set()
+            await task_b_done.wait()
+        nodes = [
+            EntityNode(
+                name=f'Node_{episode.group_id}',
+                labels=['Entity'],
+                group_id=episode.group_id,
+            )
+        ]
+        return nodes, {}
+
+    async def mocked_resolve_nodes(
+        clients, extracted_nodes, episode, previous_episodes, entity_types
+    ):
+        return extracted_nodes, {n.uuid: n.uuid for n in extracted_nodes}, []
+
+    async def mocked_extract_attributes(
+        clients,
+        nodes,
+        episode,
+        previous_episodes,
+        entity_types,
+        edges=None,
+    ):
+        return nodes
+
+    async def mocked_extract_resolve_edges(*args, **kwargs):
+        return [], [], []
+
+    async def mocked_retrieve_episodes(*args, **kwargs):
+        return []
+
+    import graphiti_core.graphiti as graphiti_module
+
+    with (
+        patch.object(graphiti_module, 'extract_nodes', side_effect=mocked_extract_nodes),
+        patch.object(graphiti_module, 'resolve_extracted_nodes', side_effect=mocked_resolve_nodes),
+        patch.object(
+            graphiti_module, 'extract_attributes_from_nodes', side_effect=mocked_extract_attributes
+        ),
+        patch.object(graphiti_module, 'add_nodes_and_edges_bulk', side_effect=capture_database),
+        patch.object(graphiti_module, 'retrieve_episodes', side_effect=mocked_retrieve_episodes),
+        patch.object(
+            Graphiti,
+            '_extract_and_resolve_edges',
+            new=AsyncMock(side_effect=mocked_extract_resolve_edges),
+        ),
+    ):
+
+        async def run_a():
+            await graphiti.add_episode(
+                name='Episode A',
+                episode_body='Content A',
+                source_description='Source A',
+                reference_time=datetime.now(timezone.utc),
+                group_id='group_a',
+            )
+
+        async def run_b():
+            await task_a_in_extract.wait()
+            try:
+                await graphiti.add_episode(
+                    name='Episode B',
+                    episode_body='Content B',
+                    source_description='Source B',
+                    reference_time=datetime.now(timezone.utc),
+                    group_id='group_b',
+                )
+            finally:
+                task_b_done.set()
+
+        await asyncio.gather(run_a(), run_b())
+
+    # Each task should have written to its own database. With the bug,
+    # Task A would have written to 'group_b' (or vice versa).
+    assert sorted(captured_databases) == ['group_a', 'group_b'], (
+        f'Cross-group leak detected: writes went to {captured_databases}'
+    )

--- a/tests/test_handle_multiple_group_ids.py
+++ b/tests/test_handle_multiple_group_ids.py
@@ -27,10 +27,19 @@ class _FakeDriver:
         self._database = database
         self.provider = provider
         self.clone_calls: list[str] = []
+        self.init_calls: list[str] = []
 
     def clone(self, database: str) -> '_FakeDriver':
         self.clone_calls.append(database)
-        return _FakeDriver(database, self.provider)
+        cloned = _FakeDriver(database, self.provider)
+        # Share call tracking with clones, mirroring FalkorDriver's shared
+        # _initialized_databases set.
+        cloned.clone_calls = self.clone_calls
+        cloned.init_calls = self.init_calls
+        return cloned
+
+    async def ensure_database_initialized(self) -> None:
+        self.init_calls.append(self._database)
 
 
 class _Host:


### PR DESCRIPTION
Closes #1331
Closes #1795
Closes #1676

Related: #1651 (MCP `get_episodes` / `delete_episode` bypass group routing in `mcp_server`; separate fix, but the "last-written group" half of that symptom goes away once the shared driver stops being rebound here).

## Summary
Fix a race condition where FalkorDB driver state was mutated in-place when `group_id` differed from the current database, causing concurrent calls to corrupt each other's database context.

Scope after the 2026-07-24 rebase: this PR covers the write path (`add_episode` / `add_episode_bulk`) only. Read-path routing for `get_by_group_ids` landed in #1675.

## Type of Change
- [x] Bug fix
- [x] Documentation/Tests

## Objective
When `add_episode` or `add_episode_bulk` was called with a `group_id` different from the FalkorDB driver's current database, the code mutated shared state:
```python
self.driver = self.driver.clone(database=group_id)
self.clients.driver = self.driver
```
Under concurrent calls (e.g., `asyncio.gather` with different tenants), coroutines would overwrite each other's driver, writing data to the wrong database. On a long-lived multi-group client (the MCP server), every subsequent read also ran inside whichever group wrote last and silently returned empty for other groups (#1795).

### Changes

**Core fix -- driver isolation (`graphiti_core/graphiti.py`):**
- Removed the in-place `self.driver` / `self.clients.driver` mutation from both `add_episode` and `add_episode_bulk`
- Both methods now accept an optional `driver` kwarg, create a local `clients = self.clients.model_copy(update={'driver': driver})`, and thread that through all internal calls
- All internal helpers (`_process_episode_data`, `_extract_and_dedupe_nodes_and_edges`, `_resolve_nodes_and_edges_bulk`, `_get_or_create_saga`, `_saga_get_previous_episode_uuid`, `_extract_and_resolve_edges`) updated to accept and propagate `driver`
- Every `self.driver` / `self.clients` reference in these methods replaced with the local `driver` / `clients`

**Decorator-based group_id handling (`graphiti_core/decorators.py`):**
- Added `@handle_single_group_id` -- detects FalkorDB provider, clones the driver scoped to the group_id, calls `ensure_database_initialized()`, and injects as `driver` kwarg. The original `self.clients.driver` is never touched.
- Updated `@handle_multiple_group_ids` -- now calls `ensure_database_initialized()` on each cloned driver

**FalkorDB driver (`graphiti_core/driver/falkordb_driver.py`):**
- `clone()` now uses `copy.copy(self)` instead of constructing a new `FalkorDriver`, avoiding re-running `__init__` (which schedules index builds, creates new operation objects, etc.)
- Added `_initialized_databases: set[str]` -- shared by reference across all clones via shallow copy
- Added `ensure_database_initialized()` -- idempotent guard that calls `build_indices_and_constraints()` only once per database across all clones

**Base driver (`graphiti_core/driver/driver.py`):**
- Added no-op `ensure_database_initialized()` to `GraphDriver` base class

## Testing
- [x] Unit tests added/updated
- [x] All existing tests pass

| File | Tests | Type |
|------|-------|------|
| `tests/test_falkor_concurrency.py` | 3 | Unit -- `clone()` is side-effect free, `ensure_database_initialized()` is idempotent, concurrent `add_episode` calls with different `group_id`s never share or mutate a driver |
| `tests/test_handle_multiple_group_ids.py` | updated | Unit -- decorator calls `ensure_database_initialized()` on each cloned driver |

Repro from #1331 / #1676 / #1795 still fails on current `main` without this change and passes with it.

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed
