### PR TITLE
fix: wrap group_ids OR clause in parentheses for BM25 fulltext query

### DIFF
--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -101,7 +101,7 @@ def fulltext_query(query: str, group_ids: list[str] | None, driver: GraphDriver)
     for f in group_ids_filter_list:
         group_ids_filter += f if not group_ids_filter else f' OR {f}'
 
-    group_ids_filter += ' AND ' if group_ids_filter else ''
+    group_ids_filter = f'({group_ids_filter}) AND ' if group_ids_filter else ''
 
     lucene_query = lucene_sanitize(query)
     # If the lucene query is too long return no query

--- a/tests/utils/search/test_fulltext_query.py
+++ b/tests/utils/search/test_fulltext_query.py
@@ -1,0 +1,38 @@
+from unittest.mock import Mock
+
+import pytest
+
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.search.search_utils import fulltext_query
+
+
+@pytest.fixture
+def neo4j_driver():
+    driver = Mock()
+    driver.provider = GraphProvider.NEO4J
+    driver.fulltext_syntax = ''
+    return driver
+
+
+class TestFulltextQueryGroupIds:
+    """Regression tests for issue #1249: BM25 query must wrap group_id OR
+    clauses in parentheses so that all group_ids are applied as a filter."""
+
+    def test_single_group_id(self, neo4j_driver):
+        result = fulltext_query('alice', ['g1'], neo4j_driver)
+        assert result.startswith('(group_id:"g1") AND ')
+
+    def test_multiple_group_ids_wrapped_in_parentheses(self, neo4j_driver):
+        result = fulltext_query('alice', ['g1', 'g2', 'g3'], neo4j_driver)
+        # The OR clause must be wrapped so AND binds correctly
+        assert result.startswith('(group_id:"g1" OR group_id:"g2" OR group_id:"g3") AND ')
+
+    def test_no_group_ids(self, neo4j_driver):
+        result = fulltext_query('alice', None, neo4j_driver)
+        # No group filter prefix
+        assert not result.startswith('(group_id')
+        assert '(alice)' in result
+
+    def test_empty_group_ids(self, neo4j_driver):
+        result = fulltext_query('alice', [], neo4j_driver)
+        assert not result.startswith('(group_id')


### PR DESCRIPTION
## Summary

Fixes #1249 — BM25 fulltext search with multiple `group_ids` only filtered by the last group due to missing parentheses around the OR clause.

## Problem

Without parentheses, Lucene operator precedence causes `AND` to bind tighter than `OR`:

```
group_id:"1" OR group_id:"2" OR group_id:"3" AND (query)
```

is parsed as:

```
group_id:"1" OR group_id:"2" OR (group_id:"3" AND query)
```

## Fix

Wrap the OR clause in parentheses in `fulltext_query()` (`search_utils.py` line 101):

```python
# Before
group_ids_filter += ' AND ' if group_ids_filter else ''

# After
group_ids_filter = f'({group_ids_filter}) AND ' if group_ids_filter else ''
```

Now produces the correct query:

```
(group_id:"1" OR group_id:"2" OR group_id:"3") AND (query)
```

## Tests

Added `tests/utils/search/test_fulltext_query.py` with 4 test cases covering single, multiple, no, and empty group_ids.