### PR TITLE
Bump mcp-server to 1.0.2 and require graphiti-core>=0.28.2

### DIFF
--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 description = "Graphiti MCP Server"
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
     "mcp>=1.9.4",
     "openai>=1.91.0",
-    "graphiti-core[falkordb]==0.28.1",
+    "graphiti-core[falkordb]>=0.28.2",
     "pydantic-settings>=2.0.0",
     "pyyaml>=6.0",
     "typing-extensions>=4.0.0",

--- a/mcp_server/uv.lock
+++ b/mcp_server/uv.lock
@@ -708,7 +708,7 @@ wheels = [
 
 [[package]]
 name = "graphiti-core"
-version = "0.28.1"
+version = "0.28.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "neo4j" },
@@ -719,9 +719,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/37/16fbfe70ac27be1eaffc024d4ff6cde93fd69937129aac058e02d530dad4/graphiti_core-0.28.1.tar.gz", hash = "sha256:8ce03b9d4d6f513e816dda8df84212e3a7d8cbfee215b0d19ed1604215d4c8a3", size = 6829248, upload-time = "2026-02-19T15:10:29.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/6d/81b78aec2030bff0030bbabb8b227a6fa3c5fb49fb11e8501e7d0f39f3fe/graphiti_core-0.28.2.tar.gz", hash = "sha256:9b2a72f117827e015a21b610eb2c3acbe05310b79736abef7372e81247578e9d", size = 6846195, upload-time = "2026-03-11T16:20:02.736Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/38/30ee63b4b07691f500e392929224368e0df78fa9ec3f5e743bde48461ce2/graphiti_core-0.28.1-py3-none-any.whl", hash = "sha256:c437362e092dc34933070d54c69232892b72bba6fea9a02c964bd769d9281ea4", size = 311602, upload-time = "2026-02-19T15:10:27.304Z" },
+    { url = "https://files.pythonhosted.org/packages/81/cd/e6203f1fee0a8e2a797f2d5f9a867513e0c63af4e19fdd1c5a7e14a47670/graphiti_core-0.28.2-py3-none-any.whl", hash = "sha256:4e1c19b7bc70a73a612a473144ed4b3fe615ac6d4c5d6b10f48e206a858bcb53", size = 314919, upload-time = "2026-03-11T16:20:01.037Z" },
 ]
 
 [package.optional-dependencies]
@@ -1121,7 +1121,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 source = { virtual = "." }
 dependencies = [
     { name = "graphiti-core", extra = ["falkordb"] },
@@ -1162,7 +1162,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'providers'", specifier = ">=0.49.0" },
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.21.0" },
     { name = "google-genai", marker = "extra == 'providers'", specifier = ">=1.62.0" },
-    { name = "graphiti-core", extras = ["falkordb"], specifier = "==0.28.1" },
+    { name = "graphiti-core", extras = ["falkordb"], specifier = ">=0.28.2" },
     { name = "groq", marker = "extra == 'providers'", specifier = ">=0.2.0" },
     { name = "mcp", specifier = ">=1.9.4" },
     { name = "openai", specifier = ">=1.91.0" },


### PR DESCRIPTION
## Summary
Updates mcp-server to version 1.0.2 and requires graphiti-core>=0.28.2 to address a security vulnerability. Version 0.28.2 includes hardening against Cypher injection attacks.

## Type of Change
- [x] Bug fix (security vulnerability)

## Testing
- [x] All existing tests pass

## Checklist
- [x] No secrets or sensitive information committed

🤖 Generated with Claude Code