### PR TITLE
Add hiring promotion section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Graphiti
 
 </div>
 
+> [!NOTE]
+> **We're Hiring!** Build context graphs that power reliable, personalized, fast production AI agents.
+> Come build with us — we're hiring Engineers and Developer Relations folks. [View open roles](https://www.getzep.com/careers/).
+
 ⭐ *Help us reach more developers and grow the Graphiti community. Star this repo!*
 
 &nbsp;


### PR DESCRIPTION
## Summary
Add a prominent 'We're Hiring!' callout to the README promoting open Engineer and Developer Relations positions at Zep, with a link to the careers page.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
Increase visibility of open roles and drive recruitment by featuring hiring information prominently in the project's README and pinned GitHub issue.

## Checklist
- [x] No breaking changes
- [x] Documentation updated (README)