### PR TITLE
feat: add MiniMax LLM provider with M3 default

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Requirements:
 
 Optional:
 
-- Google Gemini, Anthropic, or Groq API key (for alternative LLM providers)
+- Google Gemini, Anthropic, Groq, or MiniMax API key (for alternative LLM providers)
 
 > [!TIP]
 > The simplest way to install Neo4j is via [Neo4j Desktop](https://neo4j.com/download/). It provides a user-friendly
@@ -265,8 +265,8 @@ performance.
 > [!IMPORTANT]
 > Graphiti defaults to using OpenAI for LLM inference and embedding. Ensure that an `OPENAI_API_KEY` is set in your
 > environment.
-> Support for Anthropic and Groq LLM inferences is available, too. Other LLM providers may be supported via OpenAI
-> compatible APIs.
+> Support for Anthropic, Groq, and MiniMax LLM inferences is available, too. Other LLM providers may be supported
+> via OpenAI compatible APIs.
 
 For a complete working example, see the [Quickstart Example](examples/quickstart/README.md) in the examples directory.
 The quickstart demonstrates:
@@ -573,6 +573,43 @@ graphiti = Graphiti(
 
 Ensure Ollama is running (`ollama serve`) and that you have pulled the models you want to use.
 
+## Using Graphiti with MiniMax
+
+Graphiti supports [MiniMax](https://www.minimaxi.com/) models for LLM inference via MiniMax's OpenAI-compatible API.
+MiniMax offers the MiniMax-M2.5 model with a 204K context window, suitable for knowledge graph tasks.
+
+Since MiniMax uses an OpenAI-compatible API, no additional dependencies are required beyond the base `graphiti-core`
+installation.
+
+```python
+from graphiti_core import Graphiti
+from graphiti_core.llm_client.minimax_client import MiniMaxClient
+from graphiti_core.llm_client.config import LLMConfig
+
+# Initialize Graphiti with MiniMax
+graphiti = Graphiti(
+    "bolt://localhost:7687",
+    "neo4j",
+    "password",
+    llm_client=MiniMaxClient(
+        config=LLMConfig(
+            api_key="<your-minimax-api-key>",
+            model="MiniMax-M2.5",
+            small_model="MiniMax-M2.5-highspeed",
+        )
+    ),
+)
+
+# Now you can use Graphiti with MiniMax models
+```
+
+**Key Points:**
+
+- Set the `MINIMAX_API_KEY` environment variable or pass it directly via `LLMConfig`
+- Available models: `MiniMax-M2.5` (full capability) and `MiniMax-M2.5-highspeed` (optimized for speed)
+- MiniMax requires temperature in the range (0.0, 1.0]; a temperature of 0 is automatically adjusted
+- The MiniMax-M2.5 model supports structured output (JSON mode), making it compatible with Graphiti's entity extraction
+
 ## Documentation
 
 - [Guides and API documentation](https://help.getzep.com/graphiti).
@@ -592,7 +629,7 @@ When you initialize a Graphiti instance, we collect:
 - **System information**: Operating system, Python version, and system architecture
 - **Graphiti version**: The version you're using
 - **Configuration choices**:
-  - LLM provider type (OpenAI, Azure, Anthropic, etc.)
+  - LLM provider type (OpenAI, Azure, Anthropic, MiniMax, etc.)
   - Database backend (Neo4j, FalkorDB, Kuzu, Amazon Neptune Database or Neptune Analytics)
   - Embedder provider (OpenAI, Azure, Voyage, etc.)
 

--- a/README.md
+++ b/README.md
@@ -576,7 +576,8 @@ Ensure Ollama is running (`ollama serve`) and that you have pulled the models yo
 ## Using Graphiti with MiniMax
 
 Graphiti supports [MiniMax](https://www.minimaxi.com/) models for LLM inference via MiniMax's OpenAI-compatible API.
-MiniMax offers the MiniMax-M2.5 model with a 204K context window, suitable for knowledge graph tasks.
+MiniMax offers the MiniMax-M3 model with a 512K context window (and up to 128K output, with image input support),
+suitable for knowledge graph tasks.
 
 Since MiniMax uses an OpenAI-compatible API, no additional dependencies are required beyond the base `graphiti-core`
 installation.
@@ -594,8 +595,8 @@ graphiti = Graphiti(
     llm_client=MiniMaxClient(
         config=LLMConfig(
             api_key="<your-minimax-api-key>",
-            model="MiniMax-M2.5",
-            small_model="MiniMax-M2.5-highspeed",
+            model="MiniMax-M3",
+            small_model="MiniMax-M2.7-highspeed",
         )
     ),
 )
@@ -606,9 +607,9 @@ graphiti = Graphiti(
 **Key Points:**
 
 - Set the `MINIMAX_API_KEY` environment variable or pass it directly via `LLMConfig`
-- Available models: `MiniMax-M2.5` (full capability) and `MiniMax-M2.5-highspeed` (optimized for speed)
+- Available models: `MiniMax-M3` (default, full capability), `MiniMax-M2.7` (previous generation), and `MiniMax-M2.7-highspeed` (optimized for speed)
 - MiniMax requires temperature in the range (0.0, 1.0]; a temperature of 0 is automatically adjusted
-- The MiniMax-M2.5 model supports structured output (JSON mode), making it compatible with Graphiti's entity extraction
+- The MiniMax-M3 model supports structured output (JSON mode), making it compatible with Graphiti's entity extraction
 
 ## Documentation
 

--- a/graphiti_core/llm_client/__init__.py
+++ b/graphiti_core/llm_client/__init__.py
@@ -17,11 +17,13 @@ limitations under the License.
 from .client import LLMClient
 from .config import LLMConfig
 from .errors import RateLimitError
+from .minimax_client import MiniMaxClient
 from .openai_client import OpenAIClient
 from .token_tracker import TokenUsage, TokenUsageTracker
 
 __all__ = [
     'LLMClient',
+    'MiniMaxClient',
     'OpenAIClient',
     'LLMConfig',
     'RateLimitError',

--- a/graphiti_core/llm_client/client.py
+++ b/graphiti_core/llm_client/client.py
@@ -229,6 +229,8 @@ class LLMClient(ABC):
             return 'gemini'
         elif 'groq' in class_name:
             return 'groq'
+        elif 'minimax' in class_name:
+            return 'minimax'
         else:
             return 'unknown'
 

--- a/graphiti_core/llm_client/minimax_client.py
+++ b/graphiti_core/llm_client/minimax_client.py
@@ -1,0 +1,212 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+import logging
+import typing
+from typing import Any, ClassVar
+
+import openai
+from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletionMessageParam
+from pydantic import BaseModel
+
+from ..prompts.models import Message
+from .client import LLMClient, get_extraction_language_instruction
+from .config import DEFAULT_MAX_TOKENS, LLMConfig, ModelSize
+from .errors import RateLimitError, RefusalError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = 'MiniMax-M2.5'
+DEFAULT_SMALL_MODEL = 'MiniMax-M2.5-highspeed'
+DEFAULT_BASE_URL = 'https://api.minimax.io/v1'
+
+
+class MiniMaxClient(LLMClient):
+    """
+    MiniMaxClient is a client class for interacting with MiniMax's language models.
+
+    MiniMax provides an OpenAI-compatible API, so this client uses the OpenAI SDK
+    with MiniMax's base URL and model names.
+
+    Available models:
+        - MiniMax-M2.5: Full capability model with 204K context window
+        - MiniMax-M2.5-highspeed: Fast model optimized for speed
+
+    Note:
+        MiniMax requires temperature to be in the range (0.0, 1.0].
+        A temperature of 0 is not allowed and will be automatically adjusted to 0.01.
+
+    Attributes:
+        client (AsyncOpenAI): The OpenAI-compatible client configured for MiniMax API.
+    """
+
+    # Class-level constants
+    MAX_RETRIES: ClassVar[int] = 2
+
+    def __init__(
+        self,
+        config: LLMConfig | None = None,
+        cache: bool = False,
+        client: typing.Any = None,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ):
+        if cache:
+            raise NotImplementedError('Caching is not implemented for MiniMax client')
+
+        if config is None:
+            config = LLMConfig()
+
+        # Set MiniMax-specific defaults
+        if config.base_url is None:
+            config.base_url = DEFAULT_BASE_URL
+        if config.model is None:
+            config.model = DEFAULT_MODEL
+        if config.small_model is None:
+            config.small_model = DEFAULT_SMALL_MODEL
+
+        # MiniMax requires temperature > 0
+        if config.temperature <= 0:
+            config.temperature = 0.01
+
+        super().__init__(config, cache)
+        self.max_tokens = max_tokens
+
+        if client is None:
+            self.client = AsyncOpenAI(api_key=config.api_key, base_url=config.base_url)
+        else:
+            self.client = client
+
+    async def _generate_response(
+        self,
+        messages: list[Message],
+        response_model: type[BaseModel] | None = None,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        model_size: ModelSize = ModelSize.medium,
+    ) -> dict[str, typing.Any]:
+        openai_messages: list[ChatCompletionMessageParam] = []
+        for m in messages:
+            m.content = self._clean_input(m.content)
+            if m.role == 'user':
+                openai_messages.append({'role': 'user', 'content': m.content})
+            elif m.role == 'system':
+                openai_messages.append({'role': 'system', 'content': m.content})
+
+        model = self.model or DEFAULT_MODEL
+        if model_size == ModelSize.small:
+            model = self.small_model or DEFAULT_SMALL_MODEL
+
+        try:
+            response_format: dict[str, Any] = {'type': 'json_object'}
+            if response_model is not None:
+                schema_name = getattr(response_model, '__name__', 'structured_response')
+                json_schema = response_model.model_json_schema()
+                response_format = {
+                    'type': 'json_schema',
+                    'json_schema': {
+                        'name': schema_name,
+                        'schema': json_schema,
+                    },
+                }
+
+            response = await self.client.chat.completions.create(
+                model=model,
+                messages=openai_messages,
+                temperature=self.temperature,
+                max_tokens=max_tokens or self.max_tokens,
+                response_format=response_format,  # type: ignore[arg-type]
+            )
+            result = response.choices[0].message.content or ''
+            return json.loads(result)
+        except openai.RateLimitError as e:
+            raise RateLimitError from e
+        except Exception as e:
+            logger.error(f'Error in generating MiniMax LLM response: {e}')
+            raise
+
+    async def generate_response(
+        self,
+        messages: list[Message],
+        response_model: type[BaseModel] | None = None,
+        max_tokens: int | None = None,
+        model_size: ModelSize = ModelSize.medium,
+        group_id: str | None = None,
+        prompt_name: str | None = None,
+    ) -> dict[str, typing.Any]:
+        if max_tokens is None:
+            max_tokens = self.max_tokens
+
+        # Add multilingual extraction instructions
+        messages[0].content += get_extraction_language_instruction(group_id)
+
+        # Wrap entire operation in tracing span
+        with self.tracer.start_span('llm.generate') as span:
+            attributes = {
+                'llm.provider': 'minimax',
+                'model.size': model_size.value,
+                'max_tokens': max_tokens,
+            }
+            if prompt_name:
+                attributes['prompt.name'] = prompt_name
+            span.add_attributes(attributes)
+
+            retry_count = 0
+            last_error = None
+
+            while retry_count <= self.MAX_RETRIES:
+                try:
+                    response = await self._generate_response(
+                        messages, response_model, max_tokens=max_tokens, model_size=model_size
+                    )
+                    return response
+                except (RateLimitError, RefusalError):
+                    span.set_status('error', str(last_error))
+                    raise
+                except (
+                    openai.APITimeoutError,
+                    openai.APIConnectionError,
+                    openai.InternalServerError,
+                ):
+                    span.set_status('error', str(last_error))
+                    raise
+                except Exception as e:
+                    last_error = e
+
+                    if retry_count >= self.MAX_RETRIES:
+                        logger.error(f'Max retries ({self.MAX_RETRIES}) exceeded. Last error: {e}')
+                        span.set_status('error', str(e))
+                        span.record_exception(e)
+                        raise
+
+                    retry_count += 1
+
+                    error_context = (
+                        f'The previous response attempt was invalid. '
+                        f'Error type: {e.__class__.__name__}. '
+                        f'Error details: {str(e)}. '
+                        f'Please try again with a valid response, ensuring the output matches '
+                        f'the expected format and constraints.'
+                    )
+
+                    error_message = Message(role='user', content=error_context)
+                    messages.append(error_message)
+                    logger.warning(
+                        f'Retrying after application error (attempt {retry_count}/{self.MAX_RETRIES}): {e}'
+                    )
+
+            span.set_status('error', str(last_error))
+            raise last_error or Exception('Max retries exceeded with no specific error')

--- a/graphiti_core/llm_client/minimax_client.py
+++ b/graphiti_core/llm_client/minimax_client.py
@@ -31,9 +31,16 @@ from .errors import RateLimitError, RefusalError
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = 'MiniMax-M2.5'
-DEFAULT_SMALL_MODEL = 'MiniMax-M2.5-highspeed'
+DEFAULT_MODEL = 'MiniMax-M3'
+DEFAULT_SMALL_MODEL = 'MiniMax-M2.7-highspeed'
 DEFAULT_BASE_URL = 'https://api.minimax.io/v1'
+
+# Available MiniMax models (M3 is the current default; M2.7 retained for compatibility)
+AVAILABLE_MODELS: list[str] = [
+    'MiniMax-M3',
+    'MiniMax-M2.7',
+    'MiniMax-M2.7-highspeed',
+]
 
 
 class MiniMaxClient(LLMClient):
@@ -44,8 +51,9 @@ class MiniMaxClient(LLMClient):
     with MiniMax's base URL and model names.
 
     Available models:
-        - MiniMax-M2.5: Full capability model with 204K context window
-        - MiniMax-M2.5-highspeed: Fast model optimized for speed
+        - MiniMax-M3: Latest default model with 512K context window and image input support
+        - MiniMax-M2.7: Previous generation model
+        - MiniMax-M2.7-highspeed: Previous generation low-latency model
 
     Note:
         MiniMax requires temperature to be in the range (0.0, 1.0].


### PR DESCRIPTION
## Summary

Add `MiniMaxClient` for [MiniMax](https://www.minimaxi.com/)'s OpenAI-compatible API and upgrade the default model to MiniMax-M3.

- Add `MiniMaxClient` (OpenAI-compatible, follows the existing `OpenAIGenericClient` / `GroqClient` pattern)
- Default model upgraded to **MiniMax-M3** (512K context, up to 128K output, image input support)
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as available alternatives
- No new dependencies required — MiniMax uses an OpenAI-compatible API, so the existing `openai` SDK is sufficient

## Changes

- **New file**: `graphiti_core/llm_client/minimax_client.py` — `MiniMaxClient` with MiniMax-specific defaults (base URL, model names, temperature validation) and an `AVAILABLE_MODELS` list (`MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`)
- **Modified**: `graphiti_core/llm_client/__init__.py` — Export `MiniMaxClient`
- **Modified**: `graphiti_core/llm_client/client.py` — Add `minimax` to provider type detection for telemetry
- **Modified**: `README.md` — Document MiniMax setup, M3 default, M2.7 / M2.7-highspeed alternatives, usage example, and key configuration points

## Key Implementation Details

- Default base URL: `https://api.minimax.io/v1`
- Default models: `MiniMax-M3` (default, 512K context) / `MiniMax-M2.7` (previous generation) / `MiniMax-M2.7-highspeed` (low-latency alternative)
- Temperature constraint: MiniMax requires temperature in (0.0, 1.0]; automatically adjusts 0 → 0.01
- Supports structured output (JSON mode) for entity extraction
- Follows the same retry and error handling patterns as other providers

## Usage

```python
from graphiti_core import Graphiti
from graphiti_core.llm_client.minimax_client import MiniMaxClient
from graphiti_core.llm_client.config import LLMConfig

graphiti = Graphiti(
    "bolt://localhost:7687", "neo4j", "password",
    llm_client=MiniMaxClient(
        config=LLMConfig(
            api_key="<your-minimax-api-key>",
            model="MiniMax-M3",
            small_model="MiniMax-M2.7-highspeed",
        )
    ),
)
```

## Test Plan

- [x] All existing unit tests pass
- [x] Ruff lint passes with no errors
- [x] Ruff format check passes
- [x] Pyright type check passes (0 errors)
- [x] Import and initialization verified programmatically
- [x] Temperature=0 auto-adjustment verified
- [x] Default model resolves to `MiniMax-M3`; M2.7 / M2.7-highspeed remain in `AVAILABLE_MODELS`