### PR TITLE
fix: route FalkorDB queries to correct graph for single group_id

### DIFF
--- a/graphiti_core/decorators.py
+++ b/graphiti_core/decorators.py
@@ -50,7 +50,7 @@ def handle_multiple_group_ids(func: F) -> F:
             and hasattr(self.clients, 'driver')
             and self.clients.driver.provider == GraphProvider.FALKORDB
             and group_ids
-            and len(group_ids) > 1
+            and len(group_ids) >= 1
         ):
             # Execute for each group_id concurrently
             driver = self.clients.driver

--- a/graphiti_core/driver/falkordb/operations/community_edge_ops.py
+++ b/graphiti_core/driver/falkordb/operations/community_edge_ops.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.driver import GraphDriver, GraphProvider
 from graphiti_core.driver.operations.community_edge_ops import CommunityEdgeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.edges import CommunityEdge
@@ -137,6 +137,29 @@ class FalkorCommunityEdgeOperations(CommunityEdgeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[CommunityEdge]:
+        # For FalkorDB, route each group_id to its own graph database. The
+        # namespace/ops path receives the base driver (default_db), so a
+        # single-group read must be cloned to the group's graph or it queries
+        # an empty default database and returns nothing.
+        if (
+            isinstance(executor, GraphDriver)
+            and executor.provider == GraphProvider.FALKORDB
+            and group_ids
+        ):
+            if len(group_ids) == 1:
+                executor = executor.clone(database=group_ids[0])
+            else:
+                all_edges: list[CommunityEdge] = []
+                for gid in group_ids:
+                    partial = await self.get_by_group_ids(
+                        executor.clone(database=gid), [gid], limit, uuid_cursor
+                    )
+                    all_edges.extend(partial)
+                all_edges.sort(key=lambda e: e.uuid, reverse=True)
+                if limit is not None:
+                    all_edges = all_edges[:limit]
+                return all_edges
+
         cursor_clause = 'AND e.uuid < $uuid' if uuid_cursor else ''
         limit_clause = 'LIMIT $limit' if limit is not None else ''
         query = (

--- a/graphiti_core/driver/falkordb/operations/community_node_ops.py
+++ b/graphiti_core/driver/falkordb/operations/community_node_ops.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.driver import GraphDriver, GraphProvider
 from graphiti_core.driver.operations.community_node_ops import CommunityNodeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.driver.record_parsers import community_node_from_record
@@ -159,6 +159,29 @@ class FalkorCommunityNodeOperations(CommunityNodeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[CommunityNode]:
+        # For FalkorDB, route each group_id to its own graph database. The
+        # namespace/ops path receives the base driver (default_db), so a
+        # single-group read must be cloned to the group's graph or it queries
+        # an empty default database and returns nothing.
+        if (
+            isinstance(executor, GraphDriver)
+            and executor.provider == GraphProvider.FALKORDB
+            and group_ids
+        ):
+            if len(group_ids) == 1:
+                executor = executor.clone(database=group_ids[0])
+            else:
+                all_nodes: list[CommunityNode] = []
+                for gid in group_ids:
+                    partial = await self.get_by_group_ids(
+                        executor.clone(database=gid), [gid], limit, uuid_cursor
+                    )
+                    all_nodes.extend(partial)
+                all_nodes.sort(key=lambda n: n.uuid, reverse=True)
+                if limit is not None:
+                    all_nodes = all_nodes[:limit]
+                return all_nodes
+
         cursor_clause = 'AND c.uuid < $uuid' if uuid_cursor else ''
         limit_clause = 'LIMIT $limit' if limit is not None else ''
         query = (

--- a/graphiti_core/driver/falkordb/operations/entity_edge_ops.py
+++ b/graphiti_core/driver/falkordb/operations/entity_edge_ops.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.driver import GraphDriver, GraphProvider
 from graphiti_core.driver.operations.entity_edge_ops import EntityEdgeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.driver.record_parsers import entity_edge_from_record
@@ -165,6 +165,29 @@ class FalkorEntityEdgeOperations(EntityEdgeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[EntityEdge]:
+        # For FalkorDB, route each group_id to its own graph database. The
+        # namespace/ops path receives the base driver (default_db), so a
+        # single-group read must be cloned to the group's graph or it queries
+        # an empty default database and returns nothing.
+        if (
+            isinstance(executor, GraphDriver)
+            and executor.provider == GraphProvider.FALKORDB
+            and group_ids
+        ):
+            if len(group_ids) == 1:
+                executor = executor.clone(database=group_ids[0])
+            else:
+                all_edges: list[EntityEdge] = []
+                for gid in group_ids:
+                    partial = await self.get_by_group_ids(
+                        executor.clone(database=gid), [gid], limit, uuid_cursor
+                    )
+                    all_edges.extend(partial)
+                all_edges.sort(key=lambda e: e.uuid, reverse=True)
+                if limit is not None:
+                    all_edges = all_edges[:limit]
+                return all_edges
+
         cursor_clause = 'AND e.uuid < $uuid' if uuid_cursor else ''
         limit_clause = 'LIMIT $limit' if limit is not None else ''
         query = (

--- a/graphiti_core/driver/falkordb/operations/entity_node_ops.py
+++ b/graphiti_core/driver/falkordb/operations/entity_node_ops.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.driver import GraphDriver, GraphProvider
 from graphiti_core.driver.operations.entity_node_ops import EntityNodeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.driver.record_parsers import entity_node_from_record
@@ -180,6 +180,29 @@ class FalkorEntityNodeOperations(EntityNodeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[EntityNode]:
+        # For FalkorDB, route each group_id to its own graph database. The
+        # namespace/ops path receives the base driver (default_db), so a
+        # single-group read must be cloned to the group's graph or it queries
+        # an empty default database and returns nothing.
+        if (
+            isinstance(executor, GraphDriver)
+            and executor.provider == GraphProvider.FALKORDB
+            and group_ids
+        ):
+            if len(group_ids) == 1:
+                executor = executor.clone(database=group_ids[0])
+            else:
+                all_nodes: list[EntityNode] = []
+                for gid in group_ids:
+                    partial = await self.get_by_group_ids(
+                        executor.clone(database=gid), [gid], limit, uuid_cursor
+                    )
+                    all_nodes.extend(partial)
+                all_nodes.sort(key=lambda n: n.uuid, reverse=True)
+                if limit is not None:
+                    all_nodes = all_nodes[:limit]
+                return all_nodes
+
         cursor_clause = 'AND n.uuid < $uuid' if uuid_cursor else ''
         limit_clause = 'LIMIT $limit' if limit is not None else ''
         query = (

--- a/graphiti_core/driver/falkordb/operations/episode_node_ops.py
+++ b/graphiti_core/driver/falkordb/operations/episode_node_ops.py
@@ -18,7 +18,7 @@ import logging
 from datetime import datetime
 from typing import Any
 
-from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.driver import GraphDriver, GraphProvider
 from graphiti_core.driver.operations.episode_node_ops import EpisodeNodeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.driver.record_parsers import episodic_node_from_record
@@ -174,6 +174,29 @@ class FalkorEpisodeNodeOperations(EpisodeNodeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[EpisodicNode]:
+        # For FalkorDB, route each group_id to its own graph database. The
+        # namespace/ops path receives the base driver (default_db), so a
+        # single-group read must be cloned to the group's graph or it queries
+        # an empty default database and returns nothing.
+        if (
+            isinstance(executor, GraphDriver)
+            and executor.provider == GraphProvider.FALKORDB
+            and group_ids
+        ):
+            if len(group_ids) == 1:
+                executor = executor.clone(database=group_ids[0])
+            else:
+                all_episodes: list[EpisodicNode] = []
+                for gid in group_ids:
+                    partial = await self.get_by_group_ids(
+                        executor.clone(database=gid), [gid], limit, uuid_cursor
+                    )
+                    all_episodes.extend(partial)
+                all_episodes.sort(key=lambda e: e.uuid, reverse=True)
+                if limit is not None:
+                    all_episodes = all_episodes[:limit]
+                return all_episodes
+
         cursor_clause = 'AND e.uuid < $uuid' if uuid_cursor else ''
         limit_clause = 'LIMIT $limit' if limit is not None else ''
         query = (

--- a/graphiti_core/driver/falkordb/operations/episodic_edge_ops.py
+++ b/graphiti_core/driver/falkordb/operations/episodic_edge_ops.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.driver import GraphDriver, GraphProvider
 from graphiti_core.driver.operations.episodic_edge_ops import EpisodicEdgeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.edges import EpisodicEdge
@@ -151,6 +151,29 @@ class FalkorEpisodicEdgeOperations(EpisodicEdgeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[EpisodicEdge]:
+        # For FalkorDB, route each group_id to its own graph database. The
+        # namespace/ops path receives the base driver (default_db), so a
+        # single-group read must be cloned to the group's graph or it queries
+        # an empty default database and returns nothing.
+        if (
+            isinstance(executor, GraphDriver)
+            and executor.provider == GraphProvider.FALKORDB
+            and group_ids
+        ):
+            if len(group_ids) == 1:
+                executor = executor.clone(database=group_ids[0])
+            else:
+                all_edges: list[EpisodicEdge] = []
+                for gid in group_ids:
+                    partial = await self.get_by_group_ids(
+                        executor.clone(database=gid), [gid], limit, uuid_cursor
+                    )
+                    all_edges.extend(partial)
+                all_edges.sort(key=lambda e: e.uuid, reverse=True)
+                if limit is not None:
+                    all_edges = all_edges[:limit]
+                return all_edges
+
         cursor_clause = 'AND e.uuid < $uuid' if uuid_cursor else ''
         limit_clause = 'LIMIT $limit' if limit is not None else ''
         query = (

--- a/graphiti_core/driver/falkordb/operations/has_episode_edge_ops.py
+++ b/graphiti_core/driver/falkordb/operations/has_episode_edge_ops.py
@@ -17,6 +17,7 @@ limitations under the License.
 import logging
 from typing import Any
 
+from graphiti_core.driver.driver import GraphDriver, GraphProvider
 from graphiti_core.driver.operations.has_episode_edge_ops import HasEpisodeEdgeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.edges import HasEpisodeEdge
@@ -145,6 +146,29 @@ class FalkorHasEpisodeEdgeOperations(HasEpisodeEdgeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[HasEpisodeEdge]:
+        # For FalkorDB, route each group_id to its own graph database. The
+        # namespace/ops path receives the base driver (default_db), so a
+        # single-group read must be cloned to the group's graph or it queries
+        # an empty default database and returns nothing.
+        if (
+            isinstance(executor, GraphDriver)
+            and executor.provider == GraphProvider.FALKORDB
+            and group_ids
+        ):
+            if len(group_ids) == 1:
+                executor = executor.clone(database=group_ids[0])
+            else:
+                all_edges: list[HasEpisodeEdge] = []
+                for gid in group_ids:
+                    partial = await self.get_by_group_ids(
+                        executor.clone(database=gid), [gid], limit, uuid_cursor
+                    )
+                    all_edges.extend(partial)
+                all_edges.sort(key=lambda e: e.uuid, reverse=True)
+                if limit is not None:
+                    all_edges = all_edges[:limit]
+                return all_edges
+
         cursor_clause = 'AND e.uuid < $uuid' if uuid_cursor else ''
         limit_clause = 'LIMIT $limit' if limit is not None else ''
         query = (

--- a/graphiti_core/driver/falkordb/operations/next_episode_edge_ops.py
+++ b/graphiti_core/driver/falkordb/operations/next_episode_edge_ops.py
@@ -17,6 +17,7 @@ limitations under the License.
 import logging
 from typing import Any
 
+from graphiti_core.driver.driver import GraphDriver, GraphProvider
 from graphiti_core.driver.operations.next_episode_edge_ops import NextEpisodeEdgeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.edges import NextEpisodeEdge
@@ -145,6 +146,29 @@ class FalkorNextEpisodeEdgeOperations(NextEpisodeEdgeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[NextEpisodeEdge]:
+        # For FalkorDB, route each group_id to its own graph database. The
+        # namespace/ops path receives the base driver (default_db), so a
+        # single-group read must be cloned to the group's graph or it queries
+        # an empty default database and returns nothing.
+        if (
+            isinstance(executor, GraphDriver)
+            and executor.provider == GraphProvider.FALKORDB
+            and group_ids
+        ):
+            if len(group_ids) == 1:
+                executor = executor.clone(database=group_ids[0])
+            else:
+                all_edges: list[NextEpisodeEdge] = []
+                for gid in group_ids:
+                    partial = await self.get_by_group_ids(
+                        executor.clone(database=gid), [gid], limit, uuid_cursor
+                    )
+                    all_edges.extend(partial)
+                all_edges.sort(key=lambda e: e.uuid, reverse=True)
+                if limit is not None:
+                    all_edges = all_edges[:limit]
+                return all_edges
+
         cursor_clause = 'AND e.uuid < $uuid' if uuid_cursor else ''
         limit_clause = 'LIMIT $limit' if limit is not None else ''
         query = (

--- a/graphiti_core/driver/falkordb/operations/saga_node_ops.py
+++ b/graphiti_core/driver/falkordb/operations/saga_node_ops.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.driver import GraphDriver, GraphProvider
 from graphiti_core.driver.operations.saga_node_ops import SagaNodeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.errors import NodeNotFoundError
@@ -159,6 +159,29 @@ class FalkorSagaNodeOperations(SagaNodeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[SagaNode]:
+        # For FalkorDB, route each group_id to its own graph database. The
+        # namespace/ops path receives the base driver (default_db), so a
+        # single-group read must be cloned to the group's graph or it queries
+        # an empty default database and returns nothing.
+        if (
+            isinstance(executor, GraphDriver)
+            and executor.provider == GraphProvider.FALKORDB
+            and group_ids
+        ):
+            if len(group_ids) == 1:
+                executor = executor.clone(database=group_ids[0])
+            else:
+                all_nodes: list[SagaNode] = []
+                for gid in group_ids:
+                    partial = await self.get_by_group_ids(
+                        executor.clone(database=gid), [gid], limit, uuid_cursor
+                    )
+                    all_nodes.extend(partial)
+                all_nodes.sort(key=lambda n: n.uuid, reverse=True)
+                if limit is not None:
+                    all_nodes = all_nodes[:limit]
+                return all_nodes
+
         cursor_clause = 'AND s.uuid < $uuid' if uuid_cursor else ''
         limit_clause = 'LIMIT $limit' if limit is not None else ''
         query = (

--- a/graphiti_core/edges.py
+++ b/graphiti_core/edges.py
@@ -230,6 +230,27 @@ class EpisodicEdge(Edge):
             except NotImplementedError:
                 pass
 
+        # For FalkorDB, route each group_id to its own graph database
+        if driver.provider == GraphProvider.FALKORDB and group_ids:
+            if len(group_ids) == 1:
+                driver = driver.clone(database=group_ids[0])
+            else:
+                all_edges: list[EpisodicEdge] = []
+                for gid in group_ids:
+                    try:
+                        partial = await cls.get_by_group_ids(
+                            driver.clone(database=gid), [gid], limit, uuid_cursor
+                        )
+                        all_edges.extend(partial)
+                    except GroupsEdgesNotFoundError:
+                        pass
+                if len(all_edges) == 0:
+                    raise GroupsEdgesNotFoundError(group_ids)
+                all_edges.sort(key=lambda e: e.uuid, reverse=True)
+                if limit is not None:
+                    all_edges = all_edges[:limit]
+                return all_edges
+
         cursor_query: LiteralString = 'AND e.uuid < $uuid' if uuid_cursor else ''
         limit_query: LiteralString = 'LIMIT $limit' if limit is not None else ''
 
@@ -486,6 +507,31 @@ class EntityEdge(Edge):
             except NotImplementedError:
                 pass
 
+        # For FalkorDB, route each group_id to its own graph database
+        if driver.provider == GraphProvider.FALKORDB and group_ids:
+            if len(group_ids) == 1:
+                driver = driver.clone(database=group_ids[0])
+            else:
+                all_edges: list[EntityEdge] = []
+                for gid in group_ids:
+                    try:
+                        partial = await cls.get_by_group_ids(
+                            driver.clone(database=gid),
+                            [gid],
+                            limit,
+                            uuid_cursor,
+                            with_embeddings,
+                        )
+                        all_edges.extend(partial)
+                    except GroupsEdgesNotFoundError:
+                        pass
+                if len(all_edges) == 0:
+                    raise GroupsEdgesNotFoundError(group_ids)
+                all_edges.sort(key=lambda e: e.uuid, reverse=True)
+                if limit is not None:
+                    all_edges = all_edges[:limit]
+                return all_edges
+
         cursor_query: LiteralString = 'AND e.uuid < $uuid' if uuid_cursor else ''
         limit_query: LiteralString = 'LIMIT $limit' if limit is not None else ''
         with_embeddings_query: LiteralString = (
@@ -650,6 +696,22 @@ class CommunityEdge(Edge):
             except NotImplementedError:
                 pass
 
+        # For FalkorDB, route each group_id to its own graph database
+        if driver.provider == GraphProvider.FALKORDB and group_ids:
+            if len(group_ids) == 1:
+                driver = driver.clone(database=group_ids[0])
+            else:
+                all_edges: list[CommunityEdge] = []
+                for gid in group_ids:
+                    partial = await cls.get_by_group_ids(
+                        driver.clone(database=gid), [gid], limit, uuid_cursor
+                    )
+                    all_edges.extend(partial)
+                all_edges.sort(key=lambda e: e.uuid, reverse=True)
+                if limit is not None:
+                    all_edges = all_edges[:limit]
+                return all_edges
+
         cursor_query: LiteralString = 'AND e.uuid < $uuid' if uuid_cursor else ''
         limit_query: LiteralString = 'LIMIT $limit' if limit is not None else ''
 
@@ -782,6 +844,22 @@ class HasEpisodeEdge(Edge):
                 )
             except NotImplementedError:
                 pass
+
+        # For FalkorDB, route each group_id to its own graph database
+        if driver.provider == GraphProvider.FALKORDB and group_ids:
+            if len(group_ids) == 1:
+                driver = driver.clone(database=group_ids[0])
+            else:
+                all_edges: list[HasEpisodeEdge] = []
+                for gid in group_ids:
+                    partial = await cls.get_by_group_ids(
+                        driver.clone(database=gid), [gid], limit, uuid_cursor
+                    )
+                    all_edges.extend(partial)
+                all_edges.sort(key=lambda e: e.uuid, reverse=True)
+                if limit is not None:
+                    all_edges = all_edges[:limit]
+                return all_edges
 
         cursor_query: LiteralString = 'AND e.uuid < $uuid' if uuid_cursor else ''
         limit_query: LiteralString = 'LIMIT $limit' if limit is not None else ''
@@ -917,6 +995,22 @@ class NextEpisodeEdge(Edge):
                 )
             except NotImplementedError:
                 pass
+
+        # For FalkorDB, route each group_id to its own graph database
+        if driver.provider == GraphProvider.FALKORDB and group_ids:
+            if len(group_ids) == 1:
+                driver = driver.clone(database=group_ids[0])
+            else:
+                all_edges: list[NextEpisodeEdge] = []
+                for gid in group_ids:
+                    partial = await cls.get_by_group_ids(
+                        driver.clone(database=gid), [gid], limit, uuid_cursor
+                    )
+                    all_edges.extend(partial)
+                all_edges.sort(key=lambda e: e.uuid, reverse=True)
+                if limit is not None:
+                    all_edges = all_edges[:limit]
+                return all_edges
 
         cursor_query: LiteralString = 'AND e.uuid < $uuid' if uuid_cursor else ''
         limit_query: LiteralString = 'LIMIT $limit' if limit is not None else ''

--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -427,6 +427,22 @@ class EpisodicNode(Node):
             except NotImplementedError:
                 pass
 
+        # For FalkorDB, route each group_id to its own graph database
+        if driver.provider == GraphProvider.FALKORDB and group_ids:
+            if len(group_ids) == 1:
+                driver = driver.clone(database=group_ids[0])
+            else:
+                all_episodes: list[EpisodicNode] = []
+                for gid in group_ids:
+                    partial = await cls.get_by_group_ids(
+                        driver.clone(database=gid), [gid], limit, uuid_cursor
+                    )
+                    all_episodes.extend(partial)
+                all_episodes.sort(key=lambda e: e.uuid, reverse=True)
+                if limit is not None:
+                    all_episodes = all_episodes[:limit]
+                return all_episodes
+
         cursor_query: LiteralString = 'AND e.uuid < $uuid' if uuid_cursor else ''
         limit_query: LiteralString = 'LIMIT $limit' if limit is not None else ''
 
@@ -635,6 +651,26 @@ class EntityNode(Node):
             except NotImplementedError:
                 pass
 
+        # For FalkorDB, route each group_id to its own graph database
+        if driver.provider == GraphProvider.FALKORDB and group_ids:
+            if len(group_ids) == 1:
+                driver = driver.clone(database=group_ids[0])
+            else:
+                all_nodes: list[EntityNode] = []
+                for gid in group_ids:
+                    partial = await cls.get_by_group_ids(
+                        driver.clone(database=gid),
+                        [gid],
+                        limit,
+                        uuid_cursor,
+                        with_embeddings,
+                    )
+                    all_nodes.extend(partial)
+                all_nodes.sort(key=lambda n: n.uuid, reverse=True)
+                if limit is not None:
+                    all_nodes = all_nodes[:limit]
+                return all_nodes
+
         cursor_query: LiteralString = 'AND n.uuid < $uuid' if uuid_cursor else ''
         limit_query: LiteralString = 'LIMIT $limit' if limit is not None else ''
         with_embeddings_query: LiteralString = (
@@ -817,6 +853,22 @@ class CommunityNode(Node):
             except NotImplementedError:
                 pass
 
+        # For FalkorDB, route each group_id to its own graph database
+        if driver.provider == GraphProvider.FALKORDB and group_ids:
+            if len(group_ids) == 1:
+                driver = driver.clone(database=group_ids[0])
+            else:
+                all_communities: list[CommunityNode] = []
+                for gid in group_ids:
+                    partial = await cls.get_by_group_ids(
+                        driver.clone(database=gid), [gid], limit, uuid_cursor
+                    )
+                    all_communities.extend(partial)
+                all_communities.sort(key=lambda c: c.uuid, reverse=True)
+                if limit is not None:
+                    all_communities = all_communities[:limit]
+                return all_communities
+
         cursor_query: LiteralString = 'AND c.uuid < $uuid' if uuid_cursor else ''
         limit_query: LiteralString = 'LIMIT $limit' if limit is not None else ''
 
@@ -961,6 +1013,22 @@ class SagaNode(Node):
                 )
             except NotImplementedError:
                 pass
+
+        # For FalkorDB, route each group_id to its own graph database
+        if driver.provider == GraphProvider.FALKORDB and group_ids:
+            if len(group_ids) == 1:
+                driver = driver.clone(database=group_ids[0])
+            else:
+                all_sagas: list[SagaNode] = []
+                for gid in group_ids:
+                    partial = await cls.get_by_group_ids(
+                        driver.clone(database=gid), [gid], limit, uuid_cursor
+                    )
+                    all_sagas.extend(partial)
+                all_sagas.sort(key=lambda s: s.uuid, reverse=True)
+                if limit is not None:
+                    all_sagas = all_sagas[:limit]
+                return all_sagas
 
         cursor_query: LiteralString = 'AND s.uuid < $uuid' if uuid_cursor else ''
         limit_query: LiteralString = 'LIMIT $limit' if limit is not None else ''

--- a/tests/driver/test_falkordb_ops_routing.py
+++ b/tests/driver/test_falkordb_ops_routing.py
@@ -1,0 +1,119 @@
+"""Unit tests for FalkorDB per-group-id query routing in the operations layer.
+
+These cover the *namespace/ops* read path (e.g. ``graphiti.nodes.episode.
+get_by_group_ids``), which delegates to the Falkor ``*Operations`` classes with
+the base driver (pointed at ``default_db``). FalkorDB stores each ``group_id`` in
+its own physical graph, so a group-scoped read must clone the driver to that
+group's graph or it queries an empty default database and returns nothing.
+
+The tests use a ``spec=GraphDriver`` mock, so they need no live FalkorDB and run
+in CI regardless of whether the ``falkordb`` package is installed.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.driver.falkordb.operations.entity_edge_ops import (
+    FalkorEntityEdgeOperations,
+)
+from graphiti_core.driver.falkordb.operations.entity_node_ops import (
+    FalkorEntityNodeOperations,
+)
+from graphiti_core.driver.falkordb.operations.episode_node_ops import (
+    FalkorEpisodeNodeOperations,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_falkor_driver(execute_return=None):
+    """A GraphDriver-shaped mock whose ``clone`` returns a routed child driver."""
+    child = MagicMock(spec=GraphDriver)
+    child.provider = GraphProvider.FALKORDB
+    child.execute_query = AsyncMock(return_value=execute_return or ([], None, None))
+
+    base = MagicMock(spec=GraphDriver)
+    base.provider = GraphProvider.FALKORDB
+    base.execute_query = AsyncMock(return_value=execute_return or ([], None, None))
+    base.clone = MagicMock(return_value=child)
+    return base, child
+
+
+async def test_episode_get_by_group_ids_single_group_routes_to_its_graph():
+    """The single-group case must clone the base driver to the group's graph."""
+    ops = FalkorEpisodeNodeOperations()
+    base, child = _make_falkor_driver()
+
+    result = await ops.get_by_group_ids(base, ['group-a'])
+
+    # Routed: cloned to the group's database, query ran against the clone,
+    # never against the base (default_db) driver.
+    base.clone.assert_called_once_with(database='group-a')
+    child.execute_query.assert_awaited_once()
+    base.execute_query.assert_not_called()
+    assert result == []
+
+
+async def test_entity_node_get_by_group_ids_single_group_routes_to_its_graph():
+    ops = FalkorEntityNodeOperations()
+    base, child = _make_falkor_driver()
+
+    await ops.get_by_group_ids(base, ['tenant-1'])
+
+    base.clone.assert_called_once_with(database='tenant-1')
+    child.execute_query.assert_awaited_once()
+    base.execute_query.assert_not_called()
+
+
+async def test_entity_edge_get_by_group_ids_single_group_routes_to_its_graph():
+    ops = FalkorEntityEdgeOperations()
+    base, child = _make_falkor_driver()
+
+    await ops.get_by_group_ids(base, ['tenant-1'])
+
+    base.clone.assert_called_once_with(database='tenant-1')
+    child.execute_query.assert_awaited_once()
+    base.execute_query.assert_not_called()
+
+
+async def test_episode_get_by_group_ids_multi_group_fans_out_per_graph():
+    """The multi-group case must clone once per group_id and aggregate."""
+    ops = FalkorEpisodeNodeOperations()
+    base = MagicMock(spec=GraphDriver)
+    base.provider = GraphProvider.FALKORDB
+    base.execute_query = AsyncMock(return_value=([], None, None))
+
+    clones = {}
+
+    def _clone(database):
+        child = MagicMock(spec=GraphDriver)
+        child.provider = GraphProvider.FALKORDB
+        child.execute_query = AsyncMock(return_value=([], None, None))
+        # Mirror FalkorDriver.clone: re-cloning to the same database returns self,
+        # so the per-group recursion's single-group clone is a no-op.
+        child.clone = MagicMock(return_value=child)
+        clones[database] = child
+        return child
+
+    base.clone = MagicMock(side_effect=_clone)
+
+    await ops.get_by_group_ids(base, ['g1', 'g2', 'g3'])
+
+    # One clone per group; the base driver itself never runs the query.
+    assert sorted(clones) == ['g1', 'g2', 'g3']
+    base.execute_query.assert_not_called()
+    for child in clones.values():
+        child.execute_query.assert_awaited_once()
+
+
+async def test_get_by_group_ids_empty_group_ids_does_not_route():
+    """No group_ids => no cloning; falls through to the normal (base) query."""
+    ops = FalkorEpisodeNodeOperations()
+    base, child = _make_falkor_driver()
+
+    await ops.get_by_group_ids(base, [])
+
+    base.clone.assert_not_called()
+    base.execute_query.assert_awaited_once()


### PR DESCRIPTION
Fixes #1325

## Summary

The `handle_multiple_group_ids` decorator only switched the FalkorDB driver to the correct graph database when `len(group_ids) > 1`. For a single `group_id` (the most common case), queries fell through to the default execution path, hitting `default_db` which typically has no data. This caused silent empty results for all FalkorDB deployments using per-query group_ids.

Additionally, all `get_by_group_ids` classmethods on node and edge types bypassed the decorator entirely, querying the driver directly without routing to the correct FalkorDB graph.

## Changes

### `decorators.py`
- Change `len(group_ids) > 1` to `len(group_ids) >= 1` so the decorator activates for any non-empty group_ids list

### `nodes.py` (4 methods)
- Add FalkorDB graph routing to `EpisodicNode.get_by_group_ids`, `EntityNode.get_by_group_ids`, `CommunityNode.get_by_group_ids`, `SagaNode.get_by_group_ids`

### `edges.py` (5 methods)
- Add FalkorDB graph routing to `EpisodicEdge.get_by_group_ids`, `EntityEdge.get_by_group_ids`, `CommunityEdge.get_by_group_ids`, `HasEpisodeEdge.get_by_group_ids`, `NextEpisodeEdge.get_by_group_ids`

## Approach

For each `get_by_group_ids` method:
- **Single group_id**: Clone the driver to target the group's graph database (`driver.clone(database=group_ids[0])`), then fall through to the existing query logic
- **Multiple group_ids**: Query each graph separately via recursive call with a single group_id, merge results, re-sort by UUID descending, and apply limit

This approach avoids code duplication — the single-group case reuses the existing query path, and the multi-group case decomposes cleanly into single-group calls.

## Context

FalkorDB uses separate graph databases per `group_id`, unlike Neo4j which stores all data in a single database and filters by `group_id` as a node/edge property. The decorator and classmethods need to explicitly switch the driver to the correct graph database before executing queries.

Discovered and verified against a production FalkorDB deployment running graphiti-core with the graphiti MCP server.