### PR TITLE
Guard against null/invalid embeddings in similarity search queries

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -188,6 +188,9 @@ class FalkorSearchOperations(SearchOperations):
             filter_queries.append('n.group_id IN $group_ids')
             filter_params['group_ids'] = group_ids
 
+        filter_queries.append('n.name_embedding IS NOT NULL')
+        filter_queries.append('size(n.name_embedding) = size($search_vector)')
+
         filter_query = ''
         if filter_queries:
             filter_query = ' WHERE ' + (' AND '.join(filter_queries))
@@ -352,6 +355,9 @@ class FalkorSearchOperations(SearchOperations):
             if target_node_uuid is not None:
                 filter_params['target_uuid'] = target_node_uuid
                 filter_queries.append('m.uuid = $target_uuid')
+
+        filter_queries.append('e.fact_embedding IS NOT NULL')
+        filter_queries.append('size(e.fact_embedding) = size($search_vector)')
 
         filter_query = ''
         if filter_queries:
@@ -537,14 +543,19 @@ class FalkorSearchOperations(SearchOperations):
     ) -> list[CommunityNode]:
         query_params: dict[str, Any] = {}
 
-        group_filter_query = ''
+        filter_clauses = [
+            'c.name_embedding IS NOT NULL',
+            'size(c.name_embedding) = size($search_vector)',
+        ]
         if group_ids is not None:
-            group_filter_query += ' WHERE c.group_id IN $group_ids'
+            filter_clauses.append('c.group_id IN $group_ids')
             query_params['group_ids'] = group_ids
+
+        filter_query = ' WHERE ' + ' AND '.join(filter_clauses)
 
         cypher = (
             'MATCH (c:Community)'
-            + group_filter_query
+            + filter_query
             + """
             WITH c,
             """

--- a/graphiti_core/driver/neo4j/operations/search_ops.py
+++ b/graphiti_core/driver/neo4j/operations/search_ops.py
@@ -142,6 +142,9 @@ class Neo4jSearchOperations(SearchOperations):
             filter_queries.append('n.group_id IN $group_ids')
             filter_params['group_ids'] = group_ids
 
+        filter_queries.append('n.name_embedding IS NOT NULL')
+        filter_queries.append('size(n.name_embedding) = size($search_vector)')
+
         filter_query = ''
         if filter_queries:
             filter_query = ' WHERE ' + (' AND '.join(filter_queries))
@@ -307,6 +310,9 @@ class Neo4jSearchOperations(SearchOperations):
             if target_node_uuid is not None:
                 filter_params['target_uuid'] = target_node_uuid
                 filter_queries.append('m.uuid = $target_uuid')
+
+        filter_queries.append('e.fact_embedding IS NOT NULL')
+        filter_queries.append('size(e.fact_embedding) = size($search_vector)')
 
         filter_query = ''
         if filter_queries:
@@ -490,14 +496,19 @@ class Neo4jSearchOperations(SearchOperations):
     ) -> list[CommunityNode]:
         query_params: dict[str, Any] = {}
 
-        group_filter_query = ''
+        filter_clauses = [
+            'c.name_embedding IS NOT NULL',
+            'size(c.name_embedding) = size($search_vector)',
+        ]
         if group_ids is not None:
-            group_filter_query += ' WHERE c.group_id IN $group_ids'
+            filter_clauses.append('c.group_id IN $group_ids')
             query_params['group_ids'] = group_ids
+
+        filter_query = ' WHERE ' + ' AND '.join(filter_clauses)
 
         cypher = (
             'MATCH (c:Community)'
-            + group_filter_query
+            + filter_query
             + """
             WITH c,
             """


### PR DESCRIPTION
## Summary

Fixes #1328

Edges and nodes can end up with `null` or dimension-mismatched embeddings in the database when:
- The embedding API call fails or times out during `add_episode()` but the edge/node is still written
- A different embedding model with different dimensions was used at some point
- The embedding returns NaN values (related to #945)

In these cases, calling `vector.similarity.cosine()` throws `Neo.ClientError.Statement.ArgumentError`, failing the entire search query.

This PR adds `IS NOT NULL` and dimension-size guard clauses **before** the cosine similarity call in all three affected methods, for both Neo4j and FalkorDB backends:

- `node_similarity_search` — guards `n.name_embedding`
- `edge_similarity_search` — guards `e.fact_embedding`
- `community_similarity_search` — guards `c.name_embedding`

The generated Cypher now looks like:
```cypher
WHERE e.fact_embedding IS NOT NULL
  AND size(e.fact_embedding) = size($search_vector)
```

Invalid records are silently skipped and valid results are still returned, rather than the entire query crashing.