### PR TITLE
fix: route FalkorDB queries to correct graph for single group_id

### DIFF
--- a/graphiti_core/decorators.py
+++ b/graphiti_core/decorators.py
@@ -44,13 +44,13 @@ def handle_multiple_group_ids(func: F) -> F:
         if group_ids is None and group_ids_pos is not None and len(args) > group_ids_pos:
             group_ids = args[group_ids_pos]
 
-        # Only handle FalkorDB with multiple group_ids
+        # Only handle FalkorDB with one or more group_ids
         if (
             hasattr(self, 'clients')
             and hasattr(self.clients, 'driver')
             and self.clients.driver.provider == GraphProvider.FALKORDB
             and group_ids
-            and len(group_ids) > 1
+            and len(group_ids) >= 1
         ):
             # Execute for each group_id concurrently
             driver = self.clients.driver

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,106 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graphiti_core.decorators import handle_multiple_group_ids
+from graphiti_core.driver.driver import GraphProvider
+
+
+def make_falkordb_service(call_tracker):
+    """Build a mock service that looks like it uses FalkorDB."""
+    driver = MagicMock()
+    driver.provider = GraphProvider.FALKORDB
+    driver.clone = MagicMock(return_value=driver)
+
+    clients = MagicMock()
+    clients.driver = driver
+
+    class FakeService:
+        def __init__(self):
+            self.clients = clients
+            self.max_coroutines = None
+
+        @handle_multiple_group_ids
+        async def search(self, query: str, group_ids: list[str] | None = None, driver=None):
+            call_tracker.append(group_ids)
+            return []
+
+    return FakeService()
+
+
+def make_neo4j_service(call_tracker):
+    """Build a mock service that looks like it uses Neo4j."""
+    driver = MagicMock()
+    driver.provider = GraphProvider.NEO4J
+
+    clients = MagicMock()
+    clients.driver = driver
+
+    class FakeService:
+        def __init__(self):
+            self.clients = clients
+            self.max_coroutines = None
+
+        @handle_multiple_group_ids
+        async def search(self, query: str, group_ids: list[str] | None = None, driver=None):
+            call_tracker.append(group_ids)
+            return []
+
+    return FakeService()
+
+
+@pytest.mark.asyncio
+async def test_falkordb_single_group_id_routes_correctly():
+    """Single group_id on FalkorDB must route to the correct graph, not default_db."""
+    calls = []
+    svc = make_falkordb_service(calls)
+    await svc.search('test query', group_ids=['my-group'])
+    assert len(calls) == 1, 'Expected exactly one call for a single group_id'
+    assert calls[0] == ['my-group'], f'Expected group_id to be passed through, got {calls[0]}'
+
+
+@pytest.mark.asyncio
+async def test_falkordb_multiple_group_ids_routes_each():
+    """Multiple group_ids on FalkorDB must produce one call per group_id."""
+    calls = []
+    svc = make_falkordb_service(calls)
+    await svc.search('test query', group_ids=['group-a', 'group-b', 'group-c'])
+    assert len(calls) == 3, f'Expected 3 calls (one per group_id), got {len(calls)}'
+    passed = {c[0] for c in calls}
+    assert passed == {'group-a', 'group-b', 'group-c'}
+
+
+@pytest.mark.asyncio
+async def test_falkordb_no_group_ids_falls_through():
+    """No group_ids → normal execution path (no per-group routing)."""
+    calls = []
+    svc = make_falkordb_service(calls)
+    await svc.search('test query', group_ids=None)
+    assert len(calls) == 1
+    assert calls[0] is None
+
+
+@pytest.mark.asyncio
+async def test_neo4j_single_group_id_falls_through():
+    """Neo4j does not use the FalkorDB routing path — should pass through unchanged."""
+    calls = []
+    svc = make_neo4j_service(calls)
+    await svc.search('test query', group_ids=['my-group'])
+    assert len(calls) == 1
+    assert calls[0] == ['my-group']


### PR DESCRIPTION
## Problem

The `handle_multiple_group_ids` decorator uses `len(group_ids) > 1`, so searches with a **single** `group_id` fall through to the normal execution path. On FalkorDB, normal execution queries the graph the driver is currently pointing at — typically `default_db` — rather than the group's graph. The result is silent empty results for any single-group_id search.

Reported in #1161 and #1325.

## Fix

Change `> 1` to `>= 1` on line 53 of `graphiti_core/decorators.py`:

```python
# Before
and len(group_ids) > 1

# After  
and len(group_ids) >= 1
```

This ensures single group_id searches use `driver.clone(database=gid)` to route to the correct FalkorDB graph, consistent with multi-group_id behaviour.

## Tests

Added `tests/test_decorators.py` with 4 unit tests (no database required):

- `test_falkordb_single_group_id_routes_correctly` — the regression test for this bug
- `test_falkordb_multiple_group_ids_routes_each` — existing multi-group behaviour unchanged
- `test_falkordb_no_group_ids_falls_through` — None group_ids still use normal path
- `test_neo4j_single_group_id_falls_through` — Neo4j unaffected

```
4 passed in 0.02s
```

## Notes

This is the minimal fix. A more comprehensive fix (also routing `get_by_group_ids` classmethods on node/edge types) is proposed in #1326 — that PR and this one are complementary.