### PR TITLE
fix: pass base_url to OpenAI LLM client for custom endpoint support

### DIFF
--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -121,6 +121,7 @@ class LLMClientFactory:
 
                 llm_config = CoreLLMConfig(
                     api_key=api_key,
+                    base_url=config.providers.openai.api_url,  # Support custom endpoints (Ollama, Gemini, etc.)
                     model=config.model,
                     small_model=small_model,
                     temperature=config.temperature,


### PR DESCRIPTION
## What's the problem?

When using the `openai` provider with a custom `api_url` (Ollama, Gemini OpenAI-compat, vLLM, LM Studio, etc.), the LLM client ignores the configured endpoint and always hits `https://api.openai.com/v1`, resulting in 401 errors.

Interestingly, the **embedder** works perfectly with custom endpoints — it's just the LLM path that's broken.

## How I found it

I was setting up the MCP server with Google Gemini through their OpenAI-compatible endpoint. `add_memory` calls would silently queue but background processing always failed. `search_memory_facts` calls failed immediately with 401s from `api.openai.com`.

I tried:
- Setting `api_url` in config.yaml ❌
- Setting `OPENAI_BASE_URL` env var ❌
- Setting `OPENAI_API_URL` env var ❌

None of them worked, which was confusing since the embedder was fine.

## Root cause

In `mcp_server/src/services/factories.py`, the **Embedder** factory correctly passes the custom endpoint:

```python
# Embedder factory — works fine
embedder_config = OpenAIEmbedderConfig(
    api_key=api_key,
    base_url=config.providers.openai.api_url,  # ← passed correctly
    ...
)
```

But the **LLM** factory doesn't:

```python
# LLM factory — missing base_url
llm_config = CoreLLMConfig(
    api_key=api_key,
    model=config.model,
    # base_url not passed!
    ...
)
```

The `OPENAI_BASE_URL` env var doesn't help either because `graphiti_core`'s `OpenAIClient` explicitly passes `base_url=config.base_url` to `AsyncOpenAI()`. When `config.base_url` is `None`, the explicit `None` overrides the env var — the SDK only reads the env var when `base_url` isn't passed at all.

## The fix

One line — pass `base_url=config.providers.openai.api_url` to `CoreLLMConfig`, matching what the embedder already does:

```python
llm_config = CoreLLMConfig(
    api_key=api_key,
    base_url=config.providers.openai.api_url,  # Support custom endpoints
    model=config.model,
    ...
)
```

When `api_url` is the default (`https://api.openai.com/v1`), behavior is unchanged. When set to a custom URL, it's now correctly forwarded.

## Testing

Verified with Gemini's OpenAI-compatible endpoint — both LLM and embedder calls now correctly go to the configured endpoint instead of `api.openai.com`.

Fixes #1116