### PR TITLE
fix: use OpenAIGenericClient for non-OpenAI endpoints (Gemini, Ollama, vLLM)

### DIFF
--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -19,6 +19,15 @@ from graphiti_core.embedder import EmbedderClient, OpenAIEmbedder
 from graphiti_core.llm_client import LLMClient, OpenAIClient
 from graphiti_core.llm_client.config import LLMConfig as GraphitiLLMConfig
 
+# OpenAIGenericClient uses /chat/completions (compatible with Gemini, Ollama, etc.)
+# instead of /responses (OpenAI-only)
+try:
+    from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
+
+    HAS_OPENAI_GENERIC = True
+except ImportError:
+    HAS_OPENAI_GENERIC = False
+
 # Try to import additional providers if available
 try:
     from graphiti_core.embedder.azure_openai import AzureOpenAIEmbedderClient
@@ -119,13 +128,32 @@ class LLMClientFactory:
                 # Use the same model for both main and small model slots
                 small_model = config.model
 
+                # Detect custom (non-OpenAI) endpoints like Gemini, Ollama, vLLM
+                custom_url = config.providers.openai.api_url
+                is_custom_endpoint = (
+                    custom_url
+                    and 'api.openai.com' not in custom_url
+                )
+
                 llm_config = CoreLLMConfig(
                     api_key=api_key,
+                    base_url=config.providers.openai.api_url,
                     model=config.model,
                     small_model=small_model,
                     temperature=config.temperature,
                     max_tokens=config.max_tokens,
                 )
+
+                # Use OpenAIGenericClient for non-OpenAI endpoints (Gemini, Ollama, etc.)
+                # because OpenAIClient uses the /responses API for structured outputs,
+                # which only works with api.openai.com. OpenAIGenericClient uses
+                # /chat/completions with response_format instead, which is compatible
+                # with all OpenAI-compatible endpoints.
+                if is_custom_endpoint and HAS_OPENAI_GENERIC:
+                    logger.info(
+                        f'Using OpenAIGenericClient for custom endpoint: {custom_url}'
+                    )
+                    return OpenAIGenericClient(config=llm_config)
 
                 # Check if this is a reasoning model (o1, o3, gpt-5 family)
                 reasoning_prefixes = ('o1', 'o3', 'gpt-5')


### PR DESCRIPTION
## Problem

When configuring the MCP server's `openai` LLM provider with a custom `api_url` pointing to a non-OpenAI endpoint (like Google Gemini's OpenAI-compatible API, Ollama, vLLM, etc.), the LLM client fails with HTTP 404 errors even after fixing the `base_url` pass-through (#1116).

**Root cause:** `OpenAIClient` uses the OpenAI **Responses API** (`/responses`) for structured outputs via `self.client.responses.parse()`. This endpoint is OpenAI-specific — no other provider supports it. OpenAI-compatible endpoints only implement the standard `/chat/completions` endpoint.

## What this PR does

This PR makes two changes to `LLMClientFactory.create()`:

1. **Passes `base_url` from config to `CoreLLMConfig`** — This is the same fix as #1338, included here because the two changes work together.

2. **Auto-detects custom endpoints and uses `OpenAIGenericClient`** — When `api_url` is set to a non-OpenAI domain (doesn't contain `api.openai.com`), the factory returns `OpenAIGenericClient` instead of `OpenAIClient`. The generic client uses `/chat/completions` with `response_format` for structured outputs, which all OpenAI-compatible endpoints support.

The detection is simple and conservative:
```python
custom_url = config.providers.openai.api_url
is_custom_endpoint = custom_url and 'api.openai.com' not in custom_url
```

If `OpenAIGenericClient` is not available in the installed version of `graphiti-core`, it falls back to the standard `OpenAIClient` behavior (guarded by a try/except import).

## How I found this

While working through issue #1116, I fixed the missing `base_url` and confirmed requests were correctly routed to Gemini. But I was still getting 404 errors. The container logs showed:

```
HTTP Request: POST .../v1beta/openai/responses "HTTP/1.1 404 Not Found"
```

After tracing through `openai_client.py`, I found that `_create_structured_completion` (line 99) calls `self.client.responses.parse()` — the Responses API that Gemini doesn't implement. Meanwhile, `OpenAIGenericClient._generate_response` uses `self.client.chat.completions.create()` with `response_format`, which Gemini supports fine.

After applying both fixes:
```
HTTP Request: POST .../chat/completions "HTTP/1.1 200 OK"
HTTP Request: POST .../embeddings "HTTP/1.1 200 OK"
Successfully processed episode for group modelforge
```

## Testing

Tested with the following configuration:
- LLM provider: `openai` with `api_url` pointing to `https://generativelanguage.googleapis.com/v1beta/openai`
- LLM model: `gemini-2.5-flash`
- Embedder: `openai` with `gemini-embedding-001`

Full write/read cycle verified — episodes are stored and facts are retrievable from the knowledge graph.

## Related

- Fixes #1116
- Supersedes #1338 (which only had the `base_url` fix)
- Related to #1226 (supporting local model deployments)