### PR TITLE
fix: sort episode_mentions_reranker descending by mention count

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -650,10 +650,10 @@ class FalkorSearchOperations(SearchOperations):
 
         for uuid in node_uuids:
             if uuid not in scores:
-                scores[uuid] = float('inf')
+                scores[uuid] = 0
 
         sorted_uuids = list(node_uuids)
-        sorted_uuids.sort(key=lambda cur_uuid: scores[cur_uuid])
+        sorted_uuids.sort(key=lambda cur_uuid: scores[cur_uuid], reverse=True)
 
         reranked_uuids = [u for u in sorted_uuids if scores[u] >= min_score]
 

--- a/graphiti_core/driver/kuzu/operations/search_ops.py
+++ b/graphiti_core/driver/kuzu/operations/search_ops.py
@@ -715,10 +715,10 @@ class KuzuSearchOperations(SearchOperations):
 
         for uuid in node_uuids:
             if uuid not in scores:
-                scores[uuid] = float('inf')
+                scores[uuid] = 0
 
         sorted_uuids = list(node_uuids)
-        sorted_uuids.sort(key=lambda cur_uuid: scores[cur_uuid])
+        sorted_uuids.sort(key=lambda cur_uuid: scores[cur_uuid], reverse=True)
 
         reranked_uuids = [u for u in sorted_uuids if scores[u] >= min_score]
 

--- a/graphiti_core/driver/neo4j/operations/search_ops.py
+++ b/graphiti_core/driver/neo4j/operations/search_ops.py
@@ -607,10 +607,10 @@ class Neo4jSearchOperations(SearchOperations):
 
         for uuid in node_uuids:
             if uuid not in scores:
-                scores[uuid] = float('inf')
+                scores[uuid] = 0
 
         sorted_uuids = list(node_uuids)
-        sorted_uuids.sort(key=lambda cur_uuid: scores[cur_uuid])
+        sorted_uuids.sort(key=lambda cur_uuid: scores[cur_uuid], reverse=True)
 
         reranked_uuids = [u for u in sorted_uuids if scores[u] >= min_score]
 

--- a/graphiti_core/driver/neptune/operations/search_ops.py
+++ b/graphiti_core/driver/neptune/operations/search_ops.py
@@ -650,10 +650,10 @@ class NeptuneSearchOperations(SearchOperations):
 
         for uuid in node_uuids:
             if uuid not in scores:
-                scores[uuid] = float('inf')
+                scores[uuid] = 0
 
         sorted_uuids = list(node_uuids)
-        sorted_uuids.sort(key=lambda cur_uuid: scores[cur_uuid])
+        sorted_uuids.sort(key=lambda cur_uuid: scores[cur_uuid], reverse=True)
 
         reranked_uuids = [u for u in sorted_uuids if scores[u] >= min_score]
 

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -1872,7 +1872,6 @@ async def episode_mentions_reranker(
     sorted_uuids, _ = rrf(node_uuids)
     scores: dict[str, float] = {}
 
-    # Find the shortest path to center node
     results, _, _ = await driver.execute_query(
         """
         UNWIND $node_uuids AS node_uuid
@@ -1888,10 +1887,9 @@ async def episode_mentions_reranker(
 
     for uuid in sorted_uuids:
         if uuid not in scores:
-            scores[uuid] = float('inf')
+            scores[uuid] = 0
 
-    # rerank on shortest distance
-    sorted_uuids.sort(key=lambda cur_uuid: scores[cur_uuid])
+    sorted_uuids.sort(key=lambda cur_uuid: scores[cur_uuid], reverse=True)
 
     return [uuid for uuid in sorted_uuids if scores[uuid] >= min_score], [
         scores[uuid] for uuid in sorted_uuids if scores[uuid] >= min_score

--- a/tests/test_graphiti_mock.py
+++ b/tests/test_graphiti_mock.py
@@ -1933,7 +1933,6 @@ async def test_episode_mentions_reranker(graph_driver, mock_embedder):
     if graph_driver.provider == GraphProvider.FALKORDB:
         pytest.skip('Skipping as tests fail on Falkordb')
 
-    # Create episodic nodes
     episodic_node_1 = EpisodicNode(
         name='test_episodic_1',
         content='test_content',
@@ -1943,8 +1942,25 @@ async def test_episode_mentions_reranker(graph_driver, mock_embedder):
         source=EpisodeType.message,
         source_description='Description about Alice',
     )
+    episodic_node_2 = EpisodicNode(
+        name='test_episodic_2',
+        content='test_content_2',
+        created_at=datetime.now(),
+        valid_at=datetime.now(),
+        group_id=group_id,
+        source=EpisodeType.message,
+        source_description='Description about Bob',
+    )
+    episodic_node_3 = EpisodicNode(
+        name='test_episodic_3',
+        content='test_content_3',
+        created_at=datetime.now(),
+        valid_at=datetime.now(),
+        group_id=group_id,
+        source=EpisodeType.message,
+        source_description='More about Alice',
+    )
 
-    # Create entity nodes
     entity_node_1 = EntityNode(
         name='test_entity_1',
         labels=[],
@@ -1960,21 +1976,34 @@ async def test_episode_mentions_reranker(graph_driver, mock_embedder):
     )
     await entity_node_2.generate_name_embedding(mock_embedder)
 
-    # Create entity edges
     episodic_edge_1 = EpisodicEdge(
         source_node_uuid=episodic_node_1.uuid,
         target_node_uuid=entity_node_1.uuid,
         created_at=datetime.now(),
         group_id=group_id,
     )
+    episodic_edge_2 = EpisodicEdge(
+        source_node_uuid=episodic_node_2.uuid,
+        target_node_uuid=entity_node_2.uuid,
+        created_at=datetime.now(),
+        group_id=group_id,
+    )
+    episodic_edge_3 = EpisodicEdge(
+        source_node_uuid=episodic_node_3.uuid,
+        target_node_uuid=entity_node_1.uuid,
+        created_at=datetime.now(),
+        group_id=group_id,
+    )
 
-    # Save the graph
     await entity_node_1.save(graph_driver)
     await entity_node_2.save(graph_driver)
     await episodic_node_1.save(graph_driver)
+    await episodic_node_2.save(graph_driver)
+    await episodic_node_3.save(graph_driver)
     await episodic_edge_1.save(graph_driver)
+    await episodic_edge_2.save(graph_driver)
+    await episodic_edge_3.save(graph_driver)
 
-    # Test reranker
     reranked_uuids, reranked_scores = await episode_mentions_reranker(
         graph_driver,
         [[entity_node_1.uuid, entity_node_2.uuid]],
@@ -1982,7 +2011,7 @@ async def test_episode_mentions_reranker(graph_driver, mock_embedder):
     uuid_to_name = {entity_node_1.uuid: entity_node_1.name, entity_node_2.uuid: entity_node_2.name}
     names = [uuid_to_name[uuid] for uuid in reranked_uuids]
     assert names == [entity_node_1.name, entity_node_2.name]
-    assert np.allclose(reranked_scores, [1.0, float('inf')])
+    assert np.allclose(reranked_scores, [2.0, 1.0])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Fixes #1342.
**Root cause:** `episode_mentions_reranker` was copy-pasted from `node_distance_reranker` which correctly uses ascending sort (distance: smaller = closer = better). For mention counts, larger = more prominent = better, so descending sort is needed. The `float('inf')` sentinel for unmentioned nodes also interacts badly with descending sort — changed to `0`.
**Fix:** Two changes across all implementations: sentinel `float('inf')` to `0`, sort direction to `reverse=True`.

## Changes
- `graphiti_core/search/search_utils.py`: fix sort direction and sentinel in fallback path
- `graphiti_core/driver/neo4j/operations/search_ops.py`: same fix in Neo4j driver
- `graphiti_core/driver/neptune/operations/search_ops.py`: same fix in Neptune driver
- `graphiti_core/driver/falkordb/operations/search_ops.py`: same fix in FalkorDB driver
- `graphiti_core/driver/kuzu/operations/search_ops.py`: same fix in Kuzu driver
- `tests/test_graphiti_mock.py`: add second mentioned entity so both nodes have positive counts, catching the bug the original test missed

## Testing
- Updated `test_episode_mentions_reranker` with two entities that each have positive mention counts (2 and 1), asserting descending order
- Original test passed by accident because it compared 1 mention vs 0 mentions where `float('inf')` < ascending sort still produced correct relative ordering