### PR TITLE
Add Novita AI as LLM provider

### DIFF
--- a/graphiti_core/embedder/__init__.py
+++ b/graphiti_core/embedder/__init__.py
@@ -1,8 +1,11 @@
 from .client import EmbedderClient
+from .novita import NovitaEmbedder, NovitaEmbedderConfig
 from .openai import OpenAIEmbedder, OpenAIEmbedderConfig
 
 __all__ = [
     'EmbedderClient',
+    'NovitaEmbedder',
+    'NovitaEmbedderConfig',
     'OpenAIEmbedder',
     'OpenAIEmbedderConfig',
 ]

--- a/graphiti_core/embedder/novita.py
+++ b/graphiti_core/embedder/novita.py
@@ -1,0 +1,139 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+from collections.abc import Iterable
+
+from openai import AsyncOpenAI
+
+from .client import EmbedderClient, EmbedderConfig
+
+DEFAULT_EMBEDDING_MODEL = 'qwen/qwen3-embedding-0.6b'
+DEFAULT_EMBEDDING_DIM = 1024
+DEFAULT_BASE_URL = 'https://api.novita.ai/openai'
+
+
+class NovitaEmbedderConfig(EmbedderConfig):
+    """Configuration for Novita AI embedder."""
+
+    embedding_model: str = DEFAULT_EMBEDDING_MODEL
+    api_key: str | None = None
+    base_url: str = DEFAULT_BASE_URL
+
+
+class NovitaEmbedder(EmbedderClient):
+    """
+    Novita AI Embedder Client.
+
+    This client provides access to Novita AI's embedding models through their
+    OpenAI-compatible API endpoint.
+
+    Novita AI offers cost-effective embedding models including:
+    - qwen/qwen3-embedding-0.6b (default) - 1024 dimensions, 8K max input
+
+    Attributes:
+        client: The AsyncOpenAI client configured for Novita AI.
+        config: The embedder configuration.
+
+    Example:
+        ```python
+        from graphiti_core.embedder.novita import NovitaEmbedder, NovitaEmbedderConfig
+
+        # Using environment variable NOVITA_API_KEY
+        embedder = NovitaEmbedder()
+
+        # Or with explicit configuration
+        embedder = NovitaEmbedder(
+            config=NovitaEmbedderConfig(
+                api_key='your-novita-api-key',
+                embedding_model='qwen/qwen3-embedding-0.6b',
+                embedding_dim=1024,
+            )
+        )
+        ```
+    """
+
+    def __init__(
+        self,
+        config: NovitaEmbedderConfig | None = None,
+        client: AsyncOpenAI | None = None,
+    ):
+        """
+        Initialize the Novita AI embedder client.
+
+        Args:
+            config: Embedder configuration including api_key and model.
+                    If not provided, defaults are used.
+            client: Optional pre-configured AsyncOpenAI client.
+        """
+        if config is None:
+            config = NovitaEmbedderConfig()
+
+        # Set Novita-specific defaults if not provided
+        if config.api_key is None:
+            config.api_key = os.environ.get('NOVITA_API_KEY')
+
+        self.config = config
+
+        if client is not None:
+            self.client = client
+        else:
+            self.client = AsyncOpenAI(api_key=config.api_key, base_url=config.base_url)
+
+    async def create(
+        self, input_data: str | list[str] | Iterable[int] | Iterable[Iterable[int]]
+    ) -> list[float]:
+        """
+        Create an embedding for the input data.
+
+        Args:
+            input_data: The text or tokens to embed. If a list is provided,
+                        only the first item is embedded (use create_batch for
+                        multiple embeddings).
+
+        Returns:
+            The embedding vector.
+        """
+        if isinstance(input_data, str):
+            input_list = [input_data]
+        elif isinstance(input_data, list):
+            input_list = [str(i) for i in input_data if i]
+        else:
+            input_list = [str(i) for i in input_data if i is not None]
+
+        input_list = [i for i in input_list if i]
+        if len(input_list) == 0:
+            return []
+
+        result = await self.client.embeddings.create(
+            input=input_list, model=self.config.embedding_model
+        )
+        return result.data[0].embedding[: self.config.embedding_dim]
+
+    async def create_batch(self, input_data_list: list[str]) -> list[list[float]]:
+        """
+        Create embeddings for multiple inputs.
+
+        Args:
+            input_data_list: List of texts to embed.
+
+        Returns:
+            List of embedding vectors.
+        """
+        result = await self.client.embeddings.create(
+            input=input_data_list, model=self.config.embedding_model
+        )
+        return [embedding.embedding[: self.config.embedding_dim] for embedding in result.data]

--- a/graphiti_core/llm_client/__init__.py
+++ b/graphiti_core/llm_client/__init__.py
@@ -17,13 +17,15 @@ limitations under the License.
 from .client import LLMClient
 from .config import LLMConfig
 from .errors import RateLimitError
+from .novita_client import NovitaClient
 from .openai_client import OpenAIClient
 from .token_tracker import TokenUsage, TokenUsageTracker
 
 __all__ = [
     'LLMClient',
-    'OpenAIClient',
     'LLMConfig',
+    'NovitaClient',
+    'OpenAIClient',
     'RateLimitError',
     'TokenUsage',
     'TokenUsageTracker',

--- a/graphiti_core/llm_client/client.py
+++ b/graphiti_core/llm_client/client.py
@@ -229,6 +229,8 @@ class LLMClient(ABC):
             return 'gemini'
         elif 'groq' in class_name:
             return 'groq'
+        elif 'novita' in class_name:
+            return 'novita'
         else:
             return 'unknown'
 

--- a/graphiti_core/llm_client/novita_client.py
+++ b/graphiti_core/llm_client/novita_client.py
@@ -1,0 +1,96 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+
+from .config import LLMConfig
+from .openai_generic_client import OpenAIGenericClient
+
+DEFAULT_MODEL = 'moonshotai/kimi-k2.5'
+DEFAULT_MAX_TOKENS = 16384
+DEFAULT_BASE_URL = 'https://api.novita.ai/openai'
+
+
+class NovitaClient(OpenAIGenericClient):
+    """
+    Novita AI LLM Client.
+
+    This client provides access to Novita AI's LLM models through their
+    OpenAI-compatible API endpoint. It extends OpenAIGenericClient for
+    full compatibility with structured outputs and function calling.
+
+    Novita AI offers cost-effective access to various LLM models including:
+    - moonshotai/kimi-k2.5 (default) - MoE model with function calling,
+      structured output, reasoning, and vision support
+    - zai-org/glm-5 - MoE model with function calling and structured output
+    - minimax/minimax-m2.5 - MoE model with function calling and structured output
+
+    Attributes:
+        client: The AsyncOpenAI client configured for Novita AI.
+        model: The Novita AI model name to use.
+        temperature: The temperature for response generation.
+        max_tokens: The maximum tokens for responses.
+
+    Example:
+        ```python
+        from graphiti_core.llm_client.novita_client import NovitaClient
+        from graphiti_core.llm_client.config import LLMConfig
+
+        # Using environment variable NOVITA_API_KEY
+        client = NovitaClient()
+
+        # Or with explicit API key
+        client = NovitaClient(
+            config=LLMConfig(
+                api_key='your-novita-api-key',
+                model='moonshotai/kimi-k2.5',
+            )
+        )
+        ```
+    """
+
+    def __init__(
+        self,
+        config: LLMConfig | None = None,
+        cache: bool = False,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ):
+        """
+        Initialize the Novita AI LLM client.
+
+        Args:
+            config: LLM configuration including api_key, model, etc.
+                    If not provided, defaults are used.
+            cache: Whether to enable response caching. Defaults to False.
+            max_tokens: Maximum tokens for responses. Defaults to 16384.
+        """
+        if config is None:
+            config = LLMConfig()
+
+        # Set Novita-specific defaults if not provided
+        if config.api_key is None:
+            config.api_key = os.environ.get('NOVITA_API_KEY')
+
+        if config.model is None:
+            config.model = DEFAULT_MODEL
+
+        if config.base_url is None:
+            config.base_url = DEFAULT_BASE_URL
+
+        if config.max_tokens is None:
+            config.max_tokens = max_tokens
+
+        super().__init__(config=config, cache=cache, max_tokens=max_tokens)

--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -125,6 +125,13 @@ class GroqProviderConfig(BaseModel):
     api_url: str = 'https://api.groq.com/openai/v1'
 
 
+class NovitaProviderConfig(BaseModel):
+    """Novita AI provider configuration."""
+
+    api_key: str | None = None
+    api_url: str = 'https://api.novita.ai/openai'
+
+
 class VoyageProviderConfig(BaseModel):
     """Voyage AI provider configuration."""
 
@@ -141,6 +148,7 @@ class LLMProvidersConfig(BaseModel):
     anthropic: AnthropicProviderConfig | None = None
     gemini: GeminiProviderConfig | None = None
     groq: GroqProviderConfig | None = None
+    novita: NovitaProviderConfig | None = None
 
 
 class LLMConfig(BaseModel):
@@ -162,6 +170,7 @@ class EmbedderProvidersConfig(BaseModel):
     azure_openai: AzureOpenAIProviderConfig | None = None
     gemini: GeminiProviderConfig | None = None
     voyage: VoyageProviderConfig | None = None
+    novita: NovitaProviderConfig | None = None
 
 
 class EmbedderConfig(BaseModel):

--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -42,6 +42,13 @@ except ImportError:
     HAS_VOYAGE_EMBEDDER = False
 
 try:
+    from graphiti_core.embedder.novita import NovitaEmbedder
+
+    HAS_NOVITA_EMBEDDER = True
+except ImportError:
+    HAS_NOVITA_EMBEDDER = False
+
+try:
     from graphiti_core.llm_client.azure_openai_client import AzureOpenAILLMClient
 
     HAS_AZURE_LLM = True
@@ -68,6 +75,13 @@ try:
     HAS_GROQ = True
 except ImportError:
     HAS_GROQ = False
+
+try:
+    from graphiti_core.llm_client.novita_client import NovitaClient
+
+    HAS_NOVITA = True
+except ImportError:
+    HAS_NOVITA = False
 
 
 def _validate_api_key(provider_name: str, api_key: str | None, logger) -> str:
@@ -242,6 +256,24 @@ class LLMClientFactory:
                 )
                 return GroqClient(config=llm_config)
 
+            case 'novita':
+                if not HAS_NOVITA:
+                    raise ValueError('Novita client not available in current graphiti-core version')
+                if not config.providers.novita:
+                    raise ValueError('Novita provider configuration not found')
+
+                api_key = config.providers.novita.api_key
+                _validate_api_key('Novita', api_key, logger)
+
+                llm_config = GraphitiLLMConfig(
+                    api_key=api_key,
+                    base_url=config.providers.novita.api_url,
+                    model=config.model,
+                    temperature=config.temperature,
+                    max_tokens=config.max_tokens,
+                )
+                return NovitaClient(config=llm_config)
+
             case _:
                 raise ValueError(f'Unsupported LLM provider: {provider}')
 
@@ -353,6 +385,27 @@ class EmbedderFactory:
                     embedding_dim=config.dimensions or 1024,
                 )
                 return VoyageAIEmbedder(config=voyage_config)
+
+            case 'novita':
+                if not HAS_NOVITA_EMBEDDER:
+                    raise ValueError(
+                        'Novita embedder not available in current graphiti-core version'
+                    )
+                if not config.providers.novita:
+                    raise ValueError('Novita provider configuration not found')
+
+                api_key = config.providers.novita.api_key
+                _validate_api_key('Novita Embedder', api_key, logger)
+
+                from graphiti_core.embedder.novita import NovitaEmbedderConfig
+
+                novita_config = NovitaEmbedderConfig(
+                    api_key=api_key,
+                    base_url=config.providers.novita.api_url,
+                    embedding_model=config.model or 'qwen/qwen3-embedding-0.6b',
+                    embedding_dim=config.dimensions or 1024,
+                )
+                return NovitaEmbedder(config=novita_config)
 
             case _:
                 raise ValueError(f'Unsupported Embedder provider: {provider}')

--- a/tests/llm_client/test_novita_client.py
+++ b/tests/llm_client/test_novita_client.py
@@ -1,0 +1,93 @@
+"""
+Tests for NovitaClient.
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from graphiti_core.llm_client.config import LLMConfig
+from graphiti_core.llm_client.novita_client import DEFAULT_BASE_URL, DEFAULT_MODEL, NovitaClient
+
+
+class DummyChatCompletions:
+    def __init__(self):
+        self.create_calls: list[dict] = []
+
+    async def create(self, **kwargs):
+        self.create_calls.append(kwargs)
+        message = SimpleNamespace(content='{"result": "success"}')
+        choice = SimpleNamespace(message=message)
+        return SimpleNamespace(choices=[choice])
+
+
+class DummyChat:
+    def __init__(self):
+        self.completions = DummyChatCompletions()
+
+
+class DummyOpenAIClient:
+    def __init__(self):
+        self.chat = DummyChat()
+
+
+@pytest.mark.asyncio
+async def test_novita_client_uses_default_config():
+    """Test that NovitaClient uses default base URL and model when not specified."""
+    with patch.dict(os.environ, {'NOVITA_API_KEY': 'test-key'}):
+        client = NovitaClient()
+
+        assert client.config.base_url == DEFAULT_BASE_URL
+        assert client.config.model == DEFAULT_MODEL
+        assert client.config.api_key == 'test-key'
+
+
+@pytest.mark.asyncio
+async def test_novita_client_uses_custom_config():
+    """Test that NovitaClient respects custom configuration."""
+    custom_config = LLMConfig(
+        api_key='custom-key',
+        model='zai-org/glm-5',
+        base_url='https://custom.novita.api/openai',
+    )
+    client = NovitaClient(config=custom_config)
+
+    assert client.config.base_url == 'https://custom.novita.api/openai'
+    assert client.config.model == 'zai-org/glm-5'
+    assert client.config.api_key == 'custom-key'
+
+
+@pytest.mark.asyncio
+async def test_novita_client_generate_response():
+    """Test that NovitaClient can generate responses via OpenAI-compatible API."""
+    dummy_client = DummyOpenAIClient()
+
+    with patch.dict(os.environ, {'NOVITA_API_KEY': 'test-key'}):
+        client = NovitaClient()
+        client.client = dummy_client
+
+        from graphiti_core.prompts.models import Message
+
+        messages = [
+            Message(role='system', content='You are a helpful assistant.'),
+            Message(role='user', content='Hello!'),
+        ]
+
+        result = await client._generate_response(messages=messages)
+
+        assert result == {'result': 'success'}
+        assert len(dummy_client.chat.completions.create_calls) == 1
+
+        call_args = dummy_client.chat.completions.create_calls[0]
+        assert call_args['model'] == DEFAULT_MODEL
+        assert 'response_format' in call_args
+
+
+@pytest.mark.asyncio
+async def test_novita_client_provider_type():
+    """Test that _get_provider_type returns 'novita'."""
+    with patch.dict(os.environ, {'NOVITA_API_KEY': 'test-key'}):
+        client = NovitaClient()
+        assert client._get_provider_type() == 'novita'


### PR DESCRIPTION
## Summary
- Add NovitaClient for LLM inference via Novita AI's OpenAI-compatible API endpoint
- Add NovitaEmbedder for embeddings via Novita AI's OpenAI-compatible API endpoint  
- Wire Novita provider into MCP server configuration and factories
- Add unit tests for NovitaClient

## Details
This PR adds support for [Novita AI](https://novita.ai) as an LLM and embedding provider.

### Core Library Changes
- `graphiti_core/llm_client/novita_client.py`: New NovitaClient extending OpenAIGenericClient with defaults for Novita's OpenAI-compatible endpoint (`https://api.novita.ai/openai`) and model (`moonshotai/kimi-k2.5`)
- `graphiti_core/embedder/novita.py`: New NovitaEmbedder with defaults for Novita's embedding model (`qwen/qwen3-embedding-0.6b`, 1024 dimensions)
- Updated `__init__.py` files to export the new clients
- Updated `_get_provider_type()` in client.py to recognize 'novita'

### MCP Server Changes
- Added `NovitaProviderConfig` to `mcp_server/src/config/schema.py`
- Added Novita cases to `LLMClientFactory` and `EmbedderFactory` in `mcp_server/src/services/factories.py`

### Configuration
Set `NOVITA_API_KEY` environment variable to use Novita provider.

### Available Models
- **Chat**: `moonshotai/kimi-k2.5` (default), `zai-org/glm-5`, `minimax/minimax-m2.5`
- **Embedding**: `qwen/qwen3-embedding-0.6b`