### PR TITLE
fix: sort episode_mentions_reranker descending (most mentions first)

### DIFF
--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -1872,7 +1872,7 @@ async def episode_mentions_reranker(
     sorted_uuids, _ = rrf(node_uuids)
     scores: dict[str, float] = {}
 
-    # Find the shortest path to center node
+    # Count episode mentions for each node
     results, _, _ = await driver.execute_query(
         """
         UNWIND $node_uuids AS node_uuid
@@ -1888,10 +1888,9 @@ async def episode_mentions_reranker(
 
     for uuid in sorted_uuids:
         if uuid not in scores:
-            scores[uuid] = float('inf')
+            scores[uuid] = 0
 
-    # rerank on shortest distance
-    sorted_uuids.sort(key=lambda cur_uuid: scores[cur_uuid])
+    sorted_uuids.sort(key=lambda cur_uuid: scores[cur_uuid], reverse=True)
 
     return [uuid for uuid in sorted_uuids if scores[uuid] >= min_score], [
         scores[uuid] for uuid in sorted_uuids if scores[uuid] >= min_score

--- a/tests/test_graphiti_mock.py
+++ b/tests/test_graphiti_mock.py
@@ -1982,7 +1982,41 @@ async def test_episode_mentions_reranker(graph_driver, mock_embedder):
     uuid_to_name = {entity_node_1.uuid: entity_node_1.name, entity_node_2.uuid: entity_node_2.name}
     names = [uuid_to_name[uuid] for uuid in reranked_uuids]
     assert names == [entity_node_1.name, entity_node_2.name]
-    assert np.allclose(reranked_scores, [1.0, float('inf')])
+    assert np.allclose(reranked_scores, [1.0, 0])
+
+    # Add a second episodic node mentioning entity_node_1 so it has 2 mentions vs 1 for entity_node_2
+    episodic_node_2 = EpisodicNode(
+        name='test_episodic_2',
+        content='test_content_2',
+        created_at=datetime.now(),
+        valid_at=datetime.now(),
+        group_id=group_id,
+        source=EpisodeType.message,
+        source_description='Description about Bob',
+    )
+    episodic_edge_2 = EpisodicEdge(
+        source_node_uuid=episodic_node_2.uuid,
+        target_node_uuid=entity_node_1.uuid,
+        created_at=datetime.now(),
+        group_id=group_id,
+    )
+    episodic_edge_3 = EpisodicEdge(
+        source_node_uuid=episodic_node_2.uuid,
+        target_node_uuid=entity_node_2.uuid,
+        created_at=datetime.now(),
+        group_id=group_id,
+    )
+    await episodic_node_2.save(graph_driver)
+    await episodic_edge_2.save(graph_driver)
+    await episodic_edge_3.save(graph_driver)
+
+    reranked_uuids, reranked_scores = await episode_mentions_reranker(
+        graph_driver,
+        [[entity_node_1.uuid, entity_node_2.uuid]],
+    )
+    names = [uuid_to_name[uuid] for uuid in reranked_uuids]
+    assert names == [entity_node_1.name, entity_node_2.name]
+    assert np.allclose(reranked_scores, [2.0, 1.0])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Fixes #1342

`episode_mentions_reranker` was sorting nodes ascending, so nodes with the fewest episode mentions ranked first. This was a copy-paste leftover from `node_distance_reranker` which sorts by shortest distance (ascending makes sense there, not here).

Three changes in `search_utils.py`:
- Fixed comment to say "Count episode mentions" instead of "Find the shortest path"
- Changed the default score from `float('inf')` to `0` so zero-mention nodes sort to the bottom
- Added `reverse=True` to the sort so most-mentioned nodes rank first

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

Extended `test_episode_mentions_reranker` to cover the case where two nodes both have positive mention counts, verifying the higher-mention node ranks first. This is the test case that would have caught the original bug.

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Closes #1342