### PR TITLE
fix: apply host and port CLI overrides in config

### DIFF
--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -265,6 +265,10 @@ class GraphitiConfig(BaseSettings):
         # Override server settings
         if hasattr(args, 'transport') and args.transport:
             self.server.transport = args.transport
+        if hasattr(args, 'host') and args.host:
+            self.server.host = args.host
+        if hasattr(args, 'port') and args.port:
+            self.server.port = args.port
 
         # Override LLM settings
         if hasattr(args, 'llm_provider') and args.llm_provider:

--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -267,7 +267,7 @@ class GraphitiConfig(BaseSettings):
             self.server.transport = args.transport
         if hasattr(args, 'host') and args.host:
             self.server.host = args.host
-        if hasattr(args, 'port') and args.port:
+        if hasattr(args, 'port') and args.port is not None:
             self.server.port = args.port
 
         # Override LLM settings

--- a/mcp_server/tests/test_configuration.py
+++ b/mcp_server/tests/test_configuration.py
@@ -153,6 +153,8 @@ def test_cli_override():
     class Args:
         config = Path('config.yaml')
         transport = 'stdio'
+        host = '127.0.0.1'
+        port = 9999
         llm_provider = 'anthropic'
         model = 'claude-3-sonnet'
         temperature = 0.5
@@ -167,6 +169,8 @@ def test_cli_override():
 
     print('✓ CLI overrides applied successfully')
     print(f'  - Transport: {config.server.transport}')
+    print(f'  - Host: {config.server.host}')
+    print(f'  - Port: {config.server.port}')
     print(f'  - LLM provider: {config.llm.provider}')
     print(f'  - LLM model: {config.llm.model}')
     print(f'  - Temperature: {config.llm.temperature}')
@@ -174,6 +178,9 @@ def test_cli_override():
     print(f'  - Database provider: {config.database.provider}')
     print(f'  - Group ID: {config.graphiti.group_id}')
     print(f'  - User ID: {config.graphiti.user_id}')
+
+    assert config.server.host == '127.0.0.1', f'Expected host 127.0.0.1, got {config.server.host}'
+    assert config.server.port == 9999, f'Expected port 9999, got {config.server.port}'
 
 
 async def main():

--- a/mcp_server/tests/test_configuration.py
+++ b/mcp_server/tests/test_configuration.py
@@ -183,6 +183,32 @@ def test_cli_override():
     assert config.server.port == 9999, f'Expected port 9999, got {config.server.port}'
 
 
+def test_cli_override_port_zero():
+    """Test that --port 0 (OS-assigned ephemeral port) is not silently ignored."""
+    print('\nTesting CLI argument override with port=0...')
+
+    class Args:
+        config = Path('config.yaml')
+        transport = None
+        host = None
+        port = 0
+        llm_provider = None
+        model = None
+        temperature = None
+        embedder_provider = None
+        embedder_model = None
+        database_provider = None
+        group_id = None
+        user_id = None
+
+    config = GraphitiConfig()
+    config.apply_cli_overrides(Args())
+
+    print(f'  - Port: {config.server.port}')
+    assert config.server.port == 0, f'Expected port 0, got {config.server.port}'
+    print('✓ port=0 override applied correctly')
+
+
 async def main():
     """Run all tests."""
     print('=' * 60)
@@ -200,6 +226,7 @@ async def main():
 
         # Test CLI overrides
         test_cli_override()
+        test_cli_override_port_zero()
 
         print('\n' + '=' * 60)
         print('✓ All tests completed successfully!')


### PR DESCRIPTION
## Summary
`apply_cli_overrides()` in `schema.py` was missing the host and port overrides — only transport was being written back. Added two if-blocks after the transport check, using `is not None` for port so that port 0 is accepted.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

Added `test_cli_override_port_zero` to cover the port=0 edge case. Existing `test_cli_override` now also checks host and port.

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Closes #1333