### PR TITLE
fix: prevent infinite loop in label_propagation when edge_count >= 2

### DIFF
--- a/graphiti_core/utils/maintenance/community_operations.py
+++ b/graphiti_core/utils/maintenance/community_operations.py
@@ -98,7 +98,13 @@ def label_propagation(projection: dict[str, list[Neighbor]]) -> list[list[str]]:
 
     community_map = {uuid: i for i, uuid in enumerate(projection.keys())}
 
-    while True:
+    # FIX START: replace `while True` with a bounded loop to prevent infinite
+    # oscillation when candidate_rank > 1 causes IDs to decrease while the
+    # max() fallback in the else-branch causes them to increase, creating a
+    # cycle that never satisfies no_change == True.
+    max_iterations = len(projection) * 10 + 10
+    for _ in range(max_iterations):
+    # FIX END
         no_change = True
         new_community_map: dict[str, int] = {}
 
@@ -124,10 +130,15 @@ def label_propagation(projection: dict[str, list[Neighbor]]) -> list[list[str]]:
             if new_community != curr_community:
                 no_change = False
 
+        # FIX START: must update community_map before the break check so that
+        # the last iteration's result is preserved when the loop exits at
+        # max_iterations. In the original while-loop the update came after the
+        # break, which was safe; in a for-loop it must come before.
+        community_map = new_community_map
+
         if no_change:
             break
-
-        community_map = new_community_map
+        # FIX END
 
     community_cluster_map = defaultdict(list)
     for uuid, community in community_map.items():

--- a/tests/utils/maintenance/test_community_operations.py
+++ b/tests/utils/maintenance/test_community_operations.py
@@ -1,0 +1,113 @@
+"""
+Tests for label_propagation in community_operations.py.
+
+Covers the infinite loop bug where entity pairs with edge_count >= 2 caused
+the original while True loop to oscillate forever and never converge.
+"""
+
+import pytest
+
+from graphiti_core.utils.maintenance.community_operations import Neighbor, label_propagation
+
+
+class TestLabelPropagationTermination:
+    """label_propagation must always terminate regardless of edge_count."""
+
+    def test_two_nodes_edge_count_2_terminates(self):
+        """Minimal trigger for the infinite loop bug: 2 nodes, edge_count=2.
+
+        Before the fix, this oscillated between {A:0,B:1} and {A:1,B:0} forever.
+        After the fix, the bounded loop exits within max_iterations.
+        """
+        projection = {
+            'A': [Neighbor(node_uuid='B', edge_count=2)],
+            'B': [Neighbor(node_uuid='A', edge_count=2)],
+        }
+        clusters = label_propagation(projection)
+        assert clusters is not None
+        assert isinstance(clusters, list)
+
+    def test_two_nodes_edge_count_2_all_nodes_assigned(self):
+        """Every node must appear in exactly one cluster."""
+        projection = {
+            'A': [Neighbor(node_uuid='B', edge_count=2)],
+            'B': [Neighbor(node_uuid='A', edge_count=2)],
+        }
+        clusters = label_propagation(projection)
+        all_nodes = [node for cluster in clusters for node in cluster]
+        assert sorted(all_nodes) == ['A', 'B']
+
+    def test_chain_with_high_edge_count_terminates(self):
+        """Larger graph with edge_count=5 must also terminate."""
+        projection = {
+            'A': [Neighbor(node_uuid='B', edge_count=5)],
+            'B': [Neighbor(node_uuid='A', edge_count=5), Neighbor(node_uuid='C', edge_count=5)],
+            'C': [Neighbor(node_uuid='B', edge_count=5), Neighbor(node_uuid='D', edge_count=5)],
+            'D': [Neighbor(node_uuid='C', edge_count=5)],
+        }
+        clusters = label_propagation(projection)
+        all_nodes = [node for cluster in clusters for node in cluster]
+        assert sorted(all_nodes) == ['A', 'B', 'C', 'D']
+
+
+class TestLabelPropagationCorrectness:
+    """label_propagation should produce sensible community assignments."""
+
+    def test_empty_projection_returns_empty(self):
+        clusters = label_propagation({})
+        assert clusters == []
+
+    def test_single_node_no_neighbors(self):
+        projection = {'A': []}
+        clusters = label_propagation(projection)
+        all_nodes = [node for cluster in clusters for node in cluster]
+        assert all_nodes == ['A']
+
+    def test_two_isolated_nodes_form_separate_clusters(self):
+        """Nodes with no edges between them should not be merged."""
+        projection = {
+            'A': [],
+            'B': [],
+        }
+        clusters = label_propagation(projection)
+        assert len(clusters) == 2
+        all_nodes = sorted(node for cluster in clusters for node in cluster)
+        assert all_nodes == ['A', 'B']
+
+    def test_fully_connected_triangle_edge_count_1(self):
+        """Three nodes all connected with edge_count=1 should converge."""
+        projection = {
+            'A': [Neighbor(node_uuid='B', edge_count=1), Neighbor(node_uuid='C', edge_count=1)],
+            'B': [Neighbor(node_uuid='A', edge_count=1), Neighbor(node_uuid='C', edge_count=1)],
+            'C': [Neighbor(node_uuid='A', edge_count=1), Neighbor(node_uuid='B', edge_count=1)],
+        }
+        clusters = label_propagation(projection)
+        all_nodes = sorted(node for cluster in clusters for node in cluster)
+        assert all_nodes == ['A', 'B', 'C']
+
+    def test_two_dense_cliques_stay_separate(self):
+        """Two tightly connected groups with a weak bridge should not fully merge."""
+        # Clique 1: A-B-C with edge_count=3
+        # Clique 2: D-E-F with edge_count=3
+        # Bridge: C-D with edge_count=1
+        projection = {
+            'A': [Neighbor(node_uuid='B', edge_count=3), Neighbor(node_uuid='C', edge_count=3)],
+            'B': [Neighbor(node_uuid='A', edge_count=3), Neighbor(node_uuid='C', edge_count=3)],
+            'C': [
+                Neighbor(node_uuid='A', edge_count=3),
+                Neighbor(node_uuid='B', edge_count=3),
+                Neighbor(node_uuid='D', edge_count=1),
+            ],
+            'D': [
+                Neighbor(node_uuid='C', edge_count=1),
+                Neighbor(node_uuid='E', edge_count=3),
+                Neighbor(node_uuid='F', edge_count=3),
+            ],
+            'E': [Neighbor(node_uuid='D', edge_count=3), Neighbor(node_uuid='F', edge_count=3)],
+            'F': [Neighbor(node_uuid='D', edge_count=3), Neighbor(node_uuid='E', edge_count=3)],
+        }
+        clusters = label_propagation(projection)
+        all_nodes = sorted(node for cluster in clusters for node in cluster)
+        assert all_nodes == ['A', 'B', 'C', 'D', 'E', 'F']
+        # All nodes accounted for; exact cluster boundaries are algorithm-dependent
+        # but must not loop forever and must not lose any node


### PR DESCRIPTION
The original `while True` loop could oscillate forever when entity pairs have `edge_count >= 2`. In that case `candidate_rank > 1` causes branch A to lower a node's community ID, while the `max()` fallback in branch B raises it back up in the next iteration, creating a cycle that never satisfies `no_change == True`.

Fix: replace `while True` with a bounded for-loop using `max_iterations = len(projection) * 10 + 10`. The algorithm logic is unchanged -- the loop still breaks early on convergence. The `community_map` update is moved to before the break check (required by the for-loop structure to preserve the last iteration's result).

Also add `tests/utils/maintenance/test_community_operations.py` covering termination and correctness for the trigger condition (`edge_count >= 2`) and several other graph shapes.

## Summary

Fix infinite loop in `label_propagation()` that caused `build_communities()` to hang indefinitely (100% CPU, no output, no error) when any entity pair in the graph had `edge_count >= 2`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation/Tests

## Objective

N/A (bug fix)

## Testing

- [x] Unit tests added/updated (`tests/utils/maintenance/test_community_operations.py`)
- [ ] Integration tests added/updated
- [x] All existing tests pass

**Without fix** — pure Python reproduction (capped at 8 rounds):
```
round 1: {'A': 1, 'B': 0}
round 2: {'A': 0, 'B': 1}  <- back to initial state!
round 3: {'A': 1, 'B': 0}
...
❌ INFINITE LOOP: still oscillating after 8 rounds
```

**With fix** — same trigger graph:
```
Result clusters: [['A'], ['B']]
✅ Returned without infinite loop
✅ build_communities() returned successfully
✅ 4 community node(s) created in Neo4j
```

## Breaking Changes

- [ ] This PR contains breaking changes

## Checklist

- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues

Closes #1355
