### PR TITLE
fix: validate LLM responses in OpenAIGenericClient to prevent Pydantic errors

### DIFF
--- a/graphiti_core/llm_client/openai_generic_client.py
+++ b/graphiti_core/llm_client/openai_generic_client.py
@@ -22,7 +22,7 @@ from typing import Any, ClassVar
 import openai
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletionMessageParam
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from ..prompts.models import Message
 from .client import LLMClient, get_extraction_language_instruction
@@ -107,25 +107,17 @@ class OpenAIGenericClient(LLMClient):
             elif m.role == 'system':
                 openai_messages.append({'role': 'system', 'content': m.content})
         try:
-            # Prepare response format
-            response_format: dict[str, Any] = {'type': 'json_object'}
-            if response_model is not None:
-                schema_name = getattr(response_model, '__name__', 'structured_response')
-                json_schema = response_model.model_json_schema()
-                response_format = {
-                    'type': 'json_schema',
-                    'json_schema': {
-                        'name': schema_name,
-                        'schema': json_schema,
-                    },
-                }
-
+            # Use json_object format for maximum compatibility with local/generic LLMs.
+            # Many local models (Ollama, vLLM, etc.) do not support the json_schema
+            # response_format and may return the schema definition itself instead of
+            # actual data. The schema is already embedded in the prompt by the base
+            # class, so json_object is sufficient to guide the output format.
             response = await self.client.chat.completions.create(
                 model=self.model or DEFAULT_MODEL,
                 messages=openai_messages,
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
-                response_format=response_format,  # type: ignore[arg-type]
+                response_format={'type': 'json_object'},
             )
             result = response.choices[0].message.content or ''
             return json.loads(result)
@@ -169,6 +161,15 @@ class OpenAIGenericClient(LLMClient):
                     response = await self._generate_response(
                         messages, response_model, max_tokens=max_tokens, model_size=model_size
                     )
+
+                    # Validate the response against the response_model if provided.
+                    # This catches cases where the LLM returns valid JSON but with
+                    # wrong structure (e.g., returning the schema definition itself
+                    # instead of actual data — common with local/generic LLMs).
+                    if response_model is not None:
+                        model_instance = response_model(**response)
+                        return model_instance.model_dump()
+
                     return response
                 except (RateLimitError, RefusalError):
                     # These errors should not trigger retries
@@ -187,21 +188,34 @@ class OpenAIGenericClient(LLMClient):
 
                     # Don't retry if we've hit the max retries
                     if retry_count >= self.MAX_RETRIES:
-                        logger.error(f'Max retries ({self.MAX_RETRIES}) exceeded. Last error: {e}')
+                        if isinstance(e, ValidationError):
+                            logger.error(
+                                f'Validation error after {retry_count}/{self.MAX_RETRIES} attempts: {e}'
+                            )
+                        else:
+                            logger.error(f'Max retries ({self.MAX_RETRIES}) exceeded. Last error: {e}')
                         span.set_status('error', str(e))
                         span.record_exception(e)
                         raise
 
                     retry_count += 1
 
-                    # Construct a detailed error message for the LLM
-                    error_context = (
-                        f'The previous response attempt was invalid. '
-                        f'Error type: {e.__class__.__name__}. '
-                        f'Error details: {str(e)}. '
-                        f'Please try again with a valid response, ensuring the output matches '
-                        f'the expected format and constraints.'
-                    )
+                    # Provide a specific error message for validation errors so the
+                    # LLM knows exactly what schema to follow on retry.
+                    if isinstance(e, ValidationError) and response_model is not None:
+                        error_context = (
+                            f'The previous response was invalid. '
+                            f'Please provide a valid {response_model.__name__} object. '
+                            f'Error: {e}'
+                        )
+                    else:
+                        error_context = (
+                            f'The previous response attempt was invalid. '
+                            f'Error type: {e.__class__.__name__}. '
+                            f'Error details: {str(e)}. '
+                            f'Please try again with a valid response, ensuring the output matches '
+                            f'the expected format and constraints.'
+                        )
 
                     error_message = Message(role='user', content=error_context)
                     messages.append(error_message)

--- a/tests/llm_client/test_openai_generic_client.py
+++ b/tests/llm_client/test_openai_generic_client.py
@@ -1,0 +1,221 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# Running tests: pytest -xvs tests/llm_client/test_openai_generic_client.py
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from graphiti_core.llm_client.config import LLMConfig
+from graphiti_core.llm_client.errors import RateLimitError
+from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
+from graphiti_core.prompts.models import Message
+
+
+class ExtractedEntity(BaseModel):
+    name: str
+    entity_type_id: int
+
+
+class ExtractedEntities(BaseModel):
+    extracted_entities: list[ExtractedEntity]
+
+
+@pytest.fixture
+def mock_openai_client():
+    """Fixture to mock the AsyncOpenAI client."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock()
+    return mock_client
+
+
+@pytest.fixture
+def generic_client(mock_openai_client):
+    """Fixture to create an OpenAIGenericClient with a mocked AsyncOpenAI."""
+    config = LLMConfig(
+        api_key='test_api_key',
+        model='test-model',
+        base_url='http://localhost:11434/v1',
+        temperature=0.0,
+    )
+    client = OpenAIGenericClient(config=config, cache=False, client=mock_openai_client)
+    return client
+
+
+def _make_completion_response(content: str):
+    """Helper to create a mock chat completion response."""
+    mock_message = MagicMock()
+    mock_message.content = content
+
+    mock_choice = MagicMock()
+    mock_choice.message = mock_message
+
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    return mock_response
+
+
+class TestOpenAIGenericClientValidation:
+    """Tests for Pydantic validation of LLM responses."""
+
+    @pytest.mark.asyncio
+    async def test_valid_response_passes_validation(self, generic_client, mock_openai_client):
+        """Test that a valid response is validated and returned."""
+        valid_response = json.dumps({
+            'extracted_entities': [
+                {'name': 'Alice', 'entity_type_id': 1},
+                {'name': 'Bob', 'entity_type_id': 2},
+            ]
+        })
+        mock_openai_client.chat.completions.create.return_value = _make_completion_response(
+            valid_response
+        )
+
+        messages = [
+            Message(role='system', content='System message'),
+            Message(role='user', content='User message'),
+        ]
+        result = await generic_client.generate_response(
+            messages=messages, response_model=ExtractedEntities
+        )
+
+        assert isinstance(result, dict)
+        assert len(result['extracted_entities']) == 2
+        assert result['extracted_entities'][0]['name'] == 'Alice'
+
+    @pytest.mark.asyncio
+    async def test_schema_echo_triggers_retry(self, generic_client, mock_openai_client):
+        """Test that when the LLM returns the schema definition instead of data, it retries."""
+        # First response: LLM returns the schema definition (the bug from issue #912)
+        schema_echo = json.dumps({
+            '$defs': {'ExtractedEntity': {'properties': {}}},
+            'entity_type_id': 0,
+        })
+        # Second response: LLM returns valid data after retry
+        valid_response = json.dumps({
+            'extracted_entities': [{'name': 'Alice', 'entity_type_id': 1}]
+        })
+
+        mock_openai_client.chat.completions.create.side_effect = [
+            _make_completion_response(schema_echo),
+            _make_completion_response(valid_response),
+        ]
+
+        messages = [
+            Message(role='system', content='System message'),
+            Message(role='user', content='User message'),
+        ]
+        result = await generic_client.generate_response(
+            messages=messages, response_model=ExtractedEntities
+        )
+
+        # Should have retried and succeeded
+        assert mock_openai_client.chat.completions.create.call_count == 2
+        assert result['extracted_entities'][0]['name'] == 'Alice'
+
+    @pytest.mark.asyncio
+    async def test_validation_error_after_max_retries(self, generic_client, mock_openai_client):
+        """Test that persistent validation errors raise after max retries."""
+        invalid_response = json.dumps({'wrong_field': 'wrong_value'})
+
+        mock_openai_client.chat.completions.create.return_value = _make_completion_response(
+            invalid_response
+        )
+
+        messages = [
+            Message(role='system', content='System message'),
+            Message(role='user', content='User message'),
+        ]
+        with pytest.raises(ValidationError):
+            await generic_client.generate_response(
+                messages=messages, response_model=ExtractedEntities
+            )
+
+        # Should have tried 1 initial + 2 retries = 3 calls
+        assert mock_openai_client.chat.completions.create.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_no_validation_without_response_model(self, generic_client, mock_openai_client):
+        """Test that responses without response_model are returned as-is."""
+        raw_response = json.dumps({'any_key': 'any_value'})
+        mock_openai_client.chat.completions.create.return_value = _make_completion_response(
+            raw_response
+        )
+
+        messages = [
+            Message(role='system', content='System message'),
+            Message(role='user', content='User message'),
+        ]
+        result = await generic_client.generate_response(messages=messages)
+
+        assert result == {'any_key': 'any_value'}
+        assert mock_openai_client.chat.completions.create.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_uses_json_object_format(self, generic_client, mock_openai_client):
+        """Test that json_object format is used instead of json_schema for compatibility."""
+        valid_response = json.dumps({
+            'extracted_entities': [{'name': 'Alice', 'entity_type_id': 1}]
+        })
+        mock_openai_client.chat.completions.create.return_value = _make_completion_response(
+            valid_response
+        )
+
+        messages = [
+            Message(role='system', content='System message'),
+            Message(role='user', content='User message'),
+        ]
+        await generic_client.generate_response(
+            messages=messages, response_model=ExtractedEntities
+        )
+
+        # Verify json_object format was used
+        call_kwargs = mock_openai_client.chat.completions.create.call_args
+        assert call_kwargs.kwargs['response_format'] == {'type': 'json_object'}
+
+
+class TestOpenAIGenericClientInitialization:
+    """Tests for OpenAIGenericClient initialization."""
+
+    def test_init_with_config(self):
+        """Test initialization with a config object."""
+        config = LLMConfig(
+            api_key='test_api_key',
+            model='llama3',
+            base_url='http://localhost:11434/v1',
+        )
+        client = OpenAIGenericClient(config=config)
+        assert client.model == 'llama3'
+        assert client.max_tokens == 16384
+
+    def test_init_with_custom_max_tokens(self):
+        """Test initialization with custom max_tokens."""
+        config = LLMConfig(api_key='test_api_key')
+        client = OpenAIGenericClient(config=config, max_tokens=8192)
+        assert client.max_tokens == 8192
+
+    def test_cache_not_implemented(self):
+        """Test that caching raises NotImplementedError."""
+        config = LLMConfig(api_key='test_api_key')
+        with pytest.raises(NotImplementedError):
+            OpenAIGenericClient(config=config, cache=True)
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', 'test_openai_generic_client.py'])


### PR DESCRIPTION
## Summary

Fixes #912 — Pydantic `ValidationError` when using non-OpenAI LLMs (Ollama, vLLM, deepseek, etc.) with `OpenAIGenericClient`.

**Root cause:** Many local LLMs don't support the `json_schema` response format and return the schema definition itself (containing `$defs`, `$ref`, etc.) instead of actual data. This causes `ValidationError` in downstream Pydantic models like `ExtractedEntities`, `NodeResolutions`, and `EdgeDuplicate`.

**Changes:**
- Use `json_object` response format instead of `json_schema` for maximum compatibility — the schema is already embedded in the prompt text by the base `LLMClient` class
- Validate LLM responses against the `response_model` with Pydantic **before** returning, matching the existing pattern in `AnthropicClient` (lines 401-404)
- Provide specific `ValidationError` messages on retry so the LLM knows exactly what schema to follow
- Add comprehensive test suite for `OpenAIGenericClient` (8 tests)

## Test plan
- [x] All 76 existing `tests/llm_client/` tests pass (0 failures)
- [x] 8 new tests cover: valid response validation, schema-echo retry, max retry exhaustion, no-model passthrough, json_object format verification
- [ ] Manual testing with Ollama + local model (e.g., `deepseek-r1:7b`) to confirm the schema-echo scenario is handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)