### PR TITLE
fix: guard empty FalkorDB fulltext queries

### DIFF
--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -416,6 +416,9 @@ class FalkorDriver(GraphDriver):
         filtered_words = [word for word in query_words if word and word.lower() not in STOPWORDS]
         sanitized_query = ' | '.join(filtered_words)
 
+        if not sanitized_query:
+            return ''
+
         # If the query is too long return no query
         if len(sanitized_query.split(' ')) + len(group_ids or '') >= max_query_length:
             return ''

--- a/tests/utils/search/test_search_security.py
+++ b/tests/utils/search/test_search_security.py
@@ -74,6 +74,18 @@ def test_falkordb_fulltext_query_rejects_invalid_group_ids():
         FalkorDriver.build_fulltext_query(driver, 'test', ['bad"group'])
 
 
+def test_falkordb_fulltext_query_returns_empty_string_for_stopword_only_query():
+    # Import inside the test so collection still works when FalkorDB extras are unavailable.
+    from graphiti_core.driver.falkordb_driver import FalkorDriver
+
+    driver = MagicMock(spec=FalkorDriver)
+    driver.sanitize.return_value = 'the and'
+
+    result = FalkorDriver.build_fulltext_query(driver, 'the and', ['standups'])
+
+    assert result == ''
+
+
 @pytest.mark.asyncio
 async def test_shared_search_rejects_invalid_group_ids():
     clients = SimpleNamespace(


### PR DESCRIPTION
## Summary
  Fixes an issue in `FalkorDriver.build_fulltext_query()` where a stopword-only query could produce invalid RediSearch
  syntax such as `(@group_id:"standups") ()`. This PR returns an empty string when the filtered query is empty and adds
  a regression test covering that case.

  ## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Performance improvement
  - [x] Documentation/Tests

  ## Objective
  This is a bug fix, so no new feature or performance objective applies.

  ## Testing
  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [ ] All existing tests pass

  Locally verified with:
  - `uv run pytest tests/utils/search/test_search_security.py -k stopword_only -v`
  - `uv run pytest tests/utils/search/test_search_security.py -v`
  - `uv run ruff check graphiti_core/driver/falkordb_driver.py tests/utils/search/test_search_security.py`

  ## Breaking Changes
  - [ ] This PR contains breaking changes

  If this is a breaking change, describe:
  - Not applicable

  ## Checklist
  - [ ] Code follows project style guidelines (`make lint` passes)
  - [x] Self-review completed
  - [x] Documentation updated where necessary
  - [x] No secrets or sensitive information committed

  ## Related Issues
  Closes #1337
