### PR TITLE
fix: apply --host and --port CLI flags in apply_cli_overrides

### DIFF
--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -301,6 +301,10 @@ class GraphitiConfig(BaseSettings):
         # Override server settings
         if hasattr(args, 'transport') and args.transport:
             self.server.transport = args.transport
+        if hasattr(args, 'host') and args.host:
+            self.server.host = args.host
+        if hasattr(args, 'port') and args.port is not None:
+            self.server.port = args.port
 
         # Override LLM settings
         if hasattr(args, 'llm_provider') and args.llm_provider:

--- a/mcp_server/tests/test_configuration.py
+++ b/mcp_server/tests/test_configuration.py
@@ -153,6 +153,8 @@ def test_cli_override():
     class Args:
         config = Path('config.yaml')
         transport = 'stdio'
+        host = '127.0.0.1'
+        port = 9999
         llm_provider = 'anthropic'
         model = 'claude-3-sonnet'
         temperature = 0.5
@@ -165,8 +167,13 @@ def test_cli_override():
     config = GraphitiConfig()
     config.apply_cli_overrides(Args())
 
+    assert config.server.host == '127.0.0.1', f'Expected host 127.0.0.1, got {config.server.host}'
+    assert config.server.port == 9999, f'Expected port 9999, got {config.server.port}'
+
     print('✓ CLI overrides applied successfully')
     print(f'  - Transport: {config.server.transport}')
+    print(f'  - Host: {config.server.host}')
+    print(f'  - Port: {config.server.port}')
     print(f'  - LLM provider: {config.llm.provider}')
     print(f'  - LLM model: {config.llm.model}')
     print(f'  - Temperature: {config.llm.temperature}')
@@ -174,6 +181,28 @@ def test_cli_override():
     print(f'  - Database provider: {config.database.provider}')
     print(f'  - Group ID: {config.graphiti.group_id}')
     print(f'  - User ID: {config.graphiti.user_id}')
+
+    # Test that defaults are preserved when CLI flags are omitted
+    class MinimalArgs:
+        config = Path('config.yaml')
+        transport = None
+        host = None
+        port = None
+        llm_provider = None
+        model = None
+        temperature = None
+        embedder_provider = None
+        embedder_model = None
+        database_provider = None
+        group_id = None
+        user_id = None
+
+    default_config = GraphitiConfig()
+    default_config.apply_cli_overrides(MinimalArgs())
+
+    assert default_config.server.host == '0.0.0.0', 'Default host should be preserved'
+    assert default_config.server.port == 8000, 'Default port should be preserved'
+    print('✓ Defaults preserved when CLI flags are omitted')
 
 
 async def main():


### PR DESCRIPTION
Fixes #1333

## Summary

The `--host` and `--port` CLI flags for `graphiti-mcp-server` were parsed by argparse but never applied to the `ServerConfig`, causing the server to always bind to `0.0.0.0:8000` regardless of what was passed.

## Root Cause

`apply_cli_overrides()` in `mcp_server/src/config/schema.py` handled `transport`, LLM, embedder, database, and graphiti overrides but skipped `host` and `port`.

## Changes

- **`mcp_server/src/config/schema.py`**: Added `host` and `port` overrides in `apply_cli_overrides()`, placed right after the existing `transport` override since they're all `ServerConfig` fields
  - Used `args.port is not None` (not `args.port`) to correctly handle port `0` as a valid value
- **`mcp_server/tests/test_configuration.py`**: Added assertions for `host` and `port` override, plus a separate test case verifying defaults are preserved when CLI flags are omitted

## Verification

```bash
# Before: always binds to 0.0.0.0:8000
graphiti-mcp-server --transport sse --host 127.0.0.1 --port 9999

# After: correctly binds to 127.0.0.1:9999
```

## Test plan

- [x] Existing CLI override test updated with `host`/`port` assertions
- [x] Added `MinimalArgs` test to verify defaults are preserved when flags are `None`
- [x] Verified `port=0` edge case is handled correctly (`is not None` vs truthy check)