### PR TITLE
fix(mcp): reasoning.effort 'minimal' incompatible with gpt-5.4-mini

### DIFF
--- a/mcp_server/docker/Dockerfile.standalone
+++ b/mcp_server/docker/Dockerfile.standalone
@@ -46,6 +46,14 @@ RUN sed -i '/\[tool\.uv\.sources\]/,/graphiti-core/d' pyproject.toml && \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --no-group dev
 
+# Patch graphiti-core: reasoning.effort 'minimal' is not supported by newer
+# OpenAI models (gpt-5.4-mini etc). Change default to 'low'.
+# See: https://github.com/getzep/graphiti/issues/902
+RUN sed -i "s/DEFAULT_REASONING = 'minimal'/DEFAULT_REASONING = 'low'/" \
+    .venv/lib/python*/site-packages/graphiti_core/llm_client/openai_base_client.py && \
+    find .venv/lib/python*/site-packages/graphiti_core/ -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null; \
+    python -m compileall .venv/lib/python*/site-packages/graphiti_core/ -q || true
+
 # Store graphiti-core version
 RUN echo "${GRAPHITI_CORE_VERSION}" > /app/mcp/.graphiti-core-version
 

--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -133,7 +133,7 @@ class LLMClientFactory:
 
                 # Only pass reasoning/verbosity parameters for reasoning models (gpt-5 family)
                 if is_reasoning_model:
-                    return OpenAIClient(config=llm_config, reasoning='minimal', verbosity='low')
+                    return OpenAIClient(config=llm_config, reasoning='low', verbosity='low')
                 else:
                     # For non-reasoning models, explicitly pass None to disable these parameters
                     return OpenAIClient(config=llm_config, reasoning=None, verbosity=None)


### PR DESCRIPTION
## Summary

The MCP server factory (`factories.py:136`) hardcodes `reasoning='minimal'` when creating `OpenAIClient` for reasoning models. However, newer OpenAI models (gpt-5.4-mini, gpt-5.4, etc.) reject `'minimal'` — they only accept `'none'`, `'low'`, `'medium'`, `'high'`, and `'xhigh'`.

This causes all entity extraction to fail with a 400 error when using any gpt-5.4 series model:

```
Error code: 400 - {'error': {'message': "Unsupported value: 'minimal' is not supported 
with the 'gpt-5.4-mini' model.", 'param': 'reasoning.effort'}}
```

Related: #902

### Changes

- `mcp_server/src/services/factories.py` — change `reasoning='minimal'` to `reasoning='low'`
- `mcp_server/docker/Dockerfile.standalone` — patch `graphiti-core`'s `DEFAULT_REASONING` constant from `'minimal'` to `'low'` (defense in depth for the same value in the pip package), recompile bytecode after patching

### Test plan

- [ ] Verify gpt-5.4-mini entity extraction works without 400 errors
- [ ] Verify gpt-5-mini (default model) still works with `reasoning='low'`
- [ ] Verify non-reasoning models (gpt-4o-mini etc.) still pass `reasoning=None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)