### PR TITLE
Fix async ingest client lifetime and missing timestamps

### DIFF
--- a/server/graph_service/routers/ingest.py
+++ b/server/graph_service/routers/ingest.py
@@ -1,13 +1,19 @@
 import asyncio
+import logging
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from functools import partial
 
 from fastapi import APIRouter, FastAPI, status
 from graphiti_core.nodes import EpisodeType  # type: ignore
 from graphiti_core.utils.maintenance.graph_data_operations import clear_data  # type: ignore
 
+from graph_service.config import get_settings
 from graph_service.dto import AddEntityNodeRequest, AddMessagesRequest, Message, Result
-from graph_service.zep_graphiti import ZepGraphitiDep
+from graph_service.zep_graphiti import ZepGraphiti, ZepGraphitiDep
+
+
+logger = logging.getLogger(__name__)
 
 
 class AsyncWorker:
@@ -23,6 +29,8 @@ class AsyncWorker:
                 await job()
             except asyncio.CancelledError:
                 break
+            except Exception:
+                logger.exception('Graphiti async worker job failed')
 
     async def start(self):
         self.task = asyncio.create_task(self.worker())
@@ -48,21 +56,43 @@ async def lifespan(_: FastAPI):
 router = APIRouter(lifespan=lifespan)
 
 
+def _build_graphiti_client() -> ZepGraphiti:
+    settings = get_settings()
+    client = ZepGraphiti(
+        uri=settings.neo4j_uri,
+        user=settings.neo4j_user,
+        password=settings.neo4j_password,
+    )
+    if settings.openai_base_url is not None:
+        client.llm_client.config.base_url = settings.openai_base_url
+    if settings.openai_api_key is not None:
+        client.llm_client.config.api_key = settings.openai_api_key
+    if settings.model_name is not None:
+        client.llm_client.model = settings.model_name
+    return client
+
+
 @router.post('/messages', status_code=status.HTTP_202_ACCEPTED)
 async def add_messages(
     request: AddMessagesRequest,
-    graphiti: ZepGraphitiDep,
 ):
     async def add_messages_task(m: Message):
-        await graphiti.add_episode(
-            uuid=m.uuid,
-            group_id=request.group_id,
-            name=m.name,
-            episode_body=f'{m.role or ""}({m.role_type}): {m.content}',
-            reference_time=m.timestamp,
-            source=EpisodeType.message,
-            source_description=m.source_description,
-        )
+        client = _build_graphiti_client()
+        try:
+            reference_time = m.timestamp
+            if reference_time is None:
+                reference_time = datetime.now(timezone.utc)
+            await client.add_episode(
+                uuid=m.uuid,
+                group_id=request.group_id,
+                name=m.name,
+                episode_body=f'{m.role or ""}({m.role_type}): {m.content}',
+                reference_time=reference_time,
+                source=EpisodeType.message,
+                source_description=m.source_description,
+            )
+        finally:
+            await client.close()
 
     for m in request.messages:
         await async_worker.queue.put(partial(add_messages_task, m))

--- a/tests/test_ingest_router.py
+++ b/tests/test_ingest_router.py
@@ -1,0 +1,118 @@
+"""
+Patches are applied before TestClient starts its event loop so the lifespan
+also sees the fake settings.
+"""
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from server.graph_service.main import app
+from server.graph_service.config import Settings
+
+
+@pytest.fixture
+def mock_settings():
+    return Settings(
+        openai_api_key='test-key',
+        openai_base_url='http://localhost:11434/v1',
+        model_name='gemma4:26b',
+        embedding_model_name='nomic-embed-text',
+        neo4j_uri='bolt://localhost:7687',
+        neo4j_user='neo4j',
+        neo4j_password='test',
+    )
+
+
+@pytest.fixture
+def mock_zep_client():
+    mock = AsyncMock()
+    mock.add_episode = AsyncMock(return_value=None)
+    mock.close = AsyncMock(return_value=None)
+    return mock
+
+
+@pytest.fixture
+def client(mock_settings, mock_zep_client):
+    with patch('server.graph_service.main.get_settings', return_value=mock_settings):
+        with patch('server.graph_service.main.initialize_graphiti', new_callable=AsyncMock):
+            with patch('server.graph_service.routers.ingest._build_graphiti_client', return_value=mock_zep_client):
+                with patch('server.graph_service.routers.ingest.asyncio.create_task', side_effect=lambda t, **kw: t):
+                    with TestClient(app) as c:
+                        yield c, mock_zep_client
+
+
+class TestAddMessagesTimestampDefault:
+    def test_add_messages_defaults_timestamp_to_real_datetime(self, client):
+        c, mock = client
+        response = c.post(
+            '/messages',
+            json={
+                'group_id': 'test-group',
+                'messages': [
+                    {'content': 'hello world', 'role': 'henry', 'role_type': 'user'},
+                ],
+            },
+        )
+        assert response.status_code == 202
+        mock.add_episode.assert_called_once()
+        call_kwargs = mock.add_episode.call_args.kwargs
+        assert call_kwargs['reference_time'] is not None
+        assert isinstance(call_kwargs['reference_time'], datetime)
+
+    def test_add_messages_preserves_explicit_timestamp(self, client):
+        c, mock = client
+        explicit_ts = datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        response = c.post(
+            '/messages',
+            json={
+                'group_id': 'test-group',
+                'messages': [
+                    {
+                        'content': 'hello world',
+                        'role': 'henry',
+                        'role_type': 'user',
+                        'timestamp': explicit_ts.isoformat(),
+                    },
+                ],
+            },
+        )
+        assert response.status_code == 202
+        mock.add_episode.assert_called_once()
+        assert mock.add_episode.call_args.kwargs['reference_time'] == explicit_ts
+
+
+class TestAsyncWorkerClientLifetime:
+    def test_worker_builds_fresh_client_per_job(self, client):
+        c, mock = client
+        with patch('server.graph_service.routers.ingest._build_graphiti_client', return_value=mock) as mock_build:
+            response = c.post(
+                '/messages',
+                json={
+                    'group_id': 'test-group',
+                    'messages': [
+                        {'content': 'hello', 'role': 'henry', 'role_type': 'user'},
+                        {'content': 'world', 'role': 'henry', 'role_type': 'user'},
+                    ],
+                },
+            )
+        assert response.status_code == 202
+        assert mock_build.call_count == 2
+        assert mock.close.call_count == 2
+
+    def test_worker_exception_caught_not_propagated(self, client):
+        c, mock = client
+        mock.add_episode.side_effect = RuntimeError('boom')
+        with patch('server.graph_service.routers.ingest._build_graphiti_client', return_value=mock):
+            response = c.post(
+                '/messages',
+                json={
+                    'group_id': 'test-group',
+                    'messages': [
+                        {'content': 'hello', 'role': 'henry', 'role_type': 'user'},
+                    ],
+                },
+            )
+        assert response.status_code == 202
+        mock.add_episode.assert_called_once()


### PR DESCRIPTION
## Summary

Fix two bugs in server/graph_service/routers/ingest.py:

1. /messages queues a closure that captures a dependency-scoped graphiti client, but that dependency is cleaned up when the request finishes. The async worker may then run with a closed client.
2. reference_time=m.timestamp can be None, which causes add_episode() to fail later when EpisodicNode.valid_at requires a real datetime.

## Changes

- build a fresh ZepGraphiti client inside each background worker job
- close that client in a finally block
- default missing message timestamps to datetime.now(timezone.utc) before calling add_episode()
- add worker exception logging so failures surface in service logs

## Reproduction

Observed against a local Graphiti deployment using the service endpoint:

- curl -sS -X POST http://127.0.0.1:8001/messages -H 'Content-Type: application/json' -d ... -D - returned HTTP/1.1 202 Accepted
- direct ingest reproduced the underlying validation failure when reference_time=None:
  - docker exec -i graphiti /app/.venv/bin/python /tmp/direct_ingest.py 2>&1
  - result: 1 validation error for EpisodicNode, valid_at, Input should be a valid datetime

## Verification

- python3 -m py_compile server/graph_service/routers/ingest.py
- after applying the equivalent service fix locally:
  - /messages returned HTTP/1.1 202 Accepted
  - Neo4j counts changed from zero to non-zero:
    - count(e)=1, count(n)=5, count(r)=3
  - /search returned extracted facts

## Scope

This PR intentionally stays narrow. It does not include wrapper-specific provider or model-override logic from a separate integration repo.
