### PR TITLE
fix(falkordb): handle empty sanitized query in build_fulltext_query

### DIFF
--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -420,6 +420,15 @@ class FalkorDriver(GraphDriver):
         if len(sanitized_query.split(' ')) + len(group_ids or '') >= max_query_length:
             return ''
 
+        # If every token was a stopword (or input was empty), the sanitized
+        # query is now the empty string. Emitting "(@group_id:...) ()" causes
+        # RediSearch to return a syntax error, which breaks any search whose
+        # subject happens to be an all-stopword phrase (e.g. an entity named
+        # "will send the" or a fact like "the one"). Return either an empty
+        # string (no filter at all) or just the group filter on its own.
+        if not sanitized_query:
+            return group_filter
+
         full_query = group_filter + ' (' + sanitized_query + ')'
 
         return full_query


### PR DESCRIPTION
## Summary

`FalkorDriver.build_fulltext_query` crashes RediSearch when every token of the input reduces to a stopword.

After line 417 filters stopwords, `sanitized_query` can become the empty string. The function then emits:

```
(@group_id:"...") ()
```

RediSearch rejects this with a syntax error, which surfaces as a 500 from any `Graphiti.search_()` call whose subject happens to be an all-stopword phrase. Real-world triggers we hit in production:

- Entity names produced by the LLM extractor like `"will send the"`, `"the one"`, `"it is"`.
- Any fact text that reduces to stopwords after sanitization.

## Repro

Against any running FalkorDB instance:

```python
from graphiti_core.driver.falkordb_driver import FalkorDriver

d = FalkorDriver(host="localhost", port=6379)
q = d.build_fulltext_query("will the it", group_ids=["my_group"])
# before this patch: '(@group_id:"my_group") ()'   <-- RediSearch syntax error
# after  this patch: '(@group_id:"my_group")'
assert "()" not in q
```

End-to-end, `graphiti.search_(query="will send the", group_ids=["x"])` returns an empty result set instead of raising.

## Fix

When the sanitized query is empty after stopword filtering, return either the empty string (no group filter) or just the group filter on its own, so RediSearch receives a valid query. Keeps the upstream behaviour for every non-empty case identical.

## Test plan

- [x] Manual repro above passes with the patch
- [x] Normal queries (`"shopify migration"`) unchanged
- [x] Searches against a FalkorDB-backed Graphiti no longer 500 on all-stopword entity names