### PR TITLE
fix(graphiti_core): default list fields in response models to prevent ValidationError on empty LLM output

### DIFF
--- a/graphiti_core/prompts/dedupe_edges.py
+++ b/graphiti_core/prompts/dedupe_edges.py
@@ -23,11 +23,11 @@ from .models import Message, PromptFunction, PromptVersion
 
 class EdgeDuplicate(BaseModel):
     duplicate_facts: list[int] = Field(
-        ...,
+        default_factory=list,
         description='List of idx values of duplicate facts (only from EXISTING FACTS range). Empty list if none.',
     )
     contradicted_facts: list[int] = Field(
-        ...,
+        default_factory=list,
         description='List of idx values of contradicted facts (from full idx range). Empty list if none.',
     )
 

--- a/graphiti_core/prompts/dedupe_nodes.py
+++ b/graphiti_core/prompts/dedupe_nodes.py
@@ -35,7 +35,9 @@ class NodeDuplicate(BaseModel):
 
 
 class NodeResolutions(BaseModel):
-    entity_resolutions: list[NodeDuplicate] = Field(..., description='List of resolved nodes')
+    entity_resolutions: list[NodeDuplicate] = Field(
+        default_factory=list, description='List of resolved nodes'
+    )
 
 
 class Prompt(Protocol):

--- a/graphiti_core/prompts/extract_edges.py
+++ b/graphiti_core/prompts/extract_edges.py
@@ -48,7 +48,7 @@ class Edge(BaseModel):
 
 
 class ExtractedEdges(BaseModel):
-    edges: list[Edge]
+    edges: list[Edge] = Field(default_factory=list)
 
 
 class Prompt(Protocol):

--- a/graphiti_core/prompts/extract_nodes.py
+++ b/graphiti_core/prompts/extract_nodes.py
@@ -34,7 +34,9 @@ class ExtractedEntity(BaseModel):
 
 
 class ExtractedEntities(BaseModel):
-    extracted_entities: list[ExtractedEntity] = Field(..., description='List of extracted entities')
+    extracted_entities: list[ExtractedEntity] = Field(
+        default_factory=list, description='List of extracted entities'
+    )
 
 
 class EntitySummary(BaseModel):
@@ -48,7 +50,7 @@ class SummarizedEntity(BaseModel):
 
 class SummarizedEntities(BaseModel):
     summaries: list[SummarizedEntity] = Field(
-        ...,
+        default_factory=list,
         description='List of entity summaries. Only include entities that need summary updates.',
     )
 

--- a/tests/prompts/test_response_models.py
+++ b/tests/prompts/test_response_models.py
@@ -1,0 +1,100 @@
+"""Regression tests for response model defaults.
+
+When LLM providers (Anthropic, Gemini) return empty tool input ``{}``,
+response models with required list fields crash with ``ValidationError``.
+These tests verify that all list-based response models accept empty input
+and produce valid instances with empty lists.
+"""
+
+from graphiti_core.prompts.dedupe_edges import EdgeDuplicate
+from graphiti_core.prompts.dedupe_nodes import NodeDuplicate, NodeResolutions
+from graphiti_core.prompts.extract_edges import Edge, ExtractedEdges
+from graphiti_core.prompts.extract_nodes import (
+    ExtractedEntities,
+    ExtractedEntity,
+    SummarizedEntities,
+    SummarizedEntity,
+)
+
+
+class TestResponseModelsAcceptEmptyInput:
+    """Verify that response models handle empty LLM output without crashing.
+
+    This simulates the exact code path in anthropic_client.py (line 403):
+        model_instance = response_model(**response)
+    where response is {} (empty dict from tool_use input).
+    """
+
+    def test_extracted_entities_empty_input(self):
+        result = ExtractedEntities(**{})
+        assert result.extracted_entities == []
+
+    def test_extracted_edges_empty_input(self):
+        result = ExtractedEdges(**{})
+        assert result.edges == []
+
+    def test_edge_duplicate_empty_input(self):
+        result = EdgeDuplicate(**{})
+        assert result.duplicate_facts == []
+        assert result.contradicted_facts == []
+
+    def test_node_resolutions_empty_input(self):
+        result = NodeResolutions(**{})
+        assert result.entity_resolutions == []
+
+    def test_summarized_entities_empty_input(self):
+        result = SummarizedEntities(**{})
+        assert result.summaries == []
+
+
+class TestResponseModelsPopulatedInput:
+    """Verify that response models still work correctly with populated input."""
+
+    def test_extracted_entities_with_data(self):
+        result = ExtractedEntities(
+            extracted_entities=[
+                ExtractedEntity(name='Alice', entity_type_id=1),
+                ExtractedEntity(name='Bob', entity_type_id=2),
+            ]
+        )
+        assert len(result.extracted_entities) == 2
+        assert result.extracted_entities[0].name == 'Alice'
+
+    def test_extracted_edges_with_data(self):
+        result = ExtractedEdges(
+            edges=[
+                Edge(
+                    source_entity_name='Alice',
+                    target_entity_name='Bob',
+                    relation_type='KNOWS',
+                    fact='Alice knows Bob',
+                    valid_at=None,
+                    invalid_at=None,
+                )
+            ]
+        )
+        assert len(result.edges) == 1
+        assert result.edges[0].relation_type == 'KNOWS'
+
+    def test_edge_duplicate_with_data(self):
+        result = EdgeDuplicate(duplicate_facts=[1, 2], contradicted_facts=[3])
+        assert result.duplicate_facts == [1, 2]
+        assert result.contradicted_facts == [3]
+
+    def test_node_resolutions_with_data(self):
+        result = NodeResolutions(
+            entity_resolutions=[
+                NodeDuplicate(id=1, name='Alice', duplicate_candidate_id=-1),
+            ]
+        )
+        assert len(result.entity_resolutions) == 1
+        assert result.entity_resolutions[0].duplicate_candidate_id == -1
+
+    def test_summarized_entities_with_data(self):
+        result = SummarizedEntities(
+            summaries=[
+                SummarizedEntity(name='Alice', summary='A person named Alice'),
+            ]
+        )
+        assert len(result.summaries) == 1
+        assert result.summaries[0].name == 'Alice'


### PR DESCRIPTION
## Summary

Several Pydantic response models crash with `ValidationError` when the LLM returns an empty dict `{}` as structured output. This happens because list fields are defined as required (`Field(...)`) with no default value.

LLM providers that don't enforce `required` fields server-side (Anthropic, Gemini) can return `{}` when there's nothing to extract. This causes `response_model(**{})` to fail, and retries don't help since the model makes the same decision.

This PR changes the affected list fields from `Field(...)` to `Field(default_factory=list)` so that empty LLM output is treated as "nothing found" instead of crashing.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Bug Details

**Error logs:**

```
graphiti_core.llm_client.anthropic_client - WARNING - Retrying after error (attempt 1/2):
1 validation error for ExtractedEntities
extracted_entities
  Field required [type=missing, input_value={}, input_type=dict]
```

```
graphiti_core.llm_client.anthropic_client - WARNING - Retrying after error (attempt 1/2):
1 validation error for ExtractedEdges
edges
  Field required [type=missing, input_value={}, input_type=dict]
```

After 2 retries, the error propagates and the episode fails to process.

**Call path (Anthropic):**

```
add_episode()
  -> llm_client.generate_response(response_model=ExtractedEntities)
    -> _generate_response() returns tool_args = {}        # content_item.input is {}
    -> generate_response() calls response_model(**{})     # ExtractedEntities(**{}) -> ValidationError
    -> retry appends error to messages -> model returns {} again -> same error
    -> after max_retries, episode fails
```

**Affected clients:**

| Client | Validates with Pydantic? | Affected? |
|---|---|---|
| **Anthropic** (`anthropic_client.py`) | Yes — `response_model(**response)` at line 403 | **Yes** |
| **Gemini** (`gemini_client.py`) | Yes — `response_model.model_validate(...)` at line 329 | **Yes** |
| **OpenAI** (`openai_base_client.py`) | No — trusts structured output (constrained decoding) | No |
| **Groq** (inherits OpenAI base) | No | No |

OpenAI's structured output feature enforces the schema via constrained decoding, guaranteeing valid output. Anthropic and Gemini do not enforce `required` fields server-side.

## Changes

6 fields across 4 files, all `Field(...)` -> `Field(default_factory=list)`:

| File | Model | Field |
|---|---|---|
| `prompts/extract_nodes.py` | `ExtractedEntities` | `extracted_entities` |
| `prompts/extract_nodes.py` | `SummarizedEntities` | `summaries` |
| `prompts/extract_edges.py` | `ExtractedEdges` | `edges` |
| `prompts/dedupe_edges.py` | `EdgeDuplicate` | `duplicate_facts` |
| `prompts/dedupe_edges.py` | `EdgeDuplicate` | `contradicted_facts` |
| `prompts/dedupe_nodes.py` | `NodeResolutions` | `entity_resolutions` |

**Before / After:**

```python
# Before (crashes on empty input)
class ExtractedEntities(BaseModel):
    extracted_entities: list[ExtractedEntity] = Field(..., description='List of extracted entities')

# After (gracefully handles empty input)
class ExtractedEntities(BaseModel):
    extracted_entities: list[ExtractedEntity] = Field(default_factory=list, description='List of extracted entities')
```

**Why this is safe:**

- An empty list is the correct semantic for "nothing found" - downstream code already handles empty lists (no nodes/edges/duplicates created).
- The tool schema still includes the field with its description, so the model is guided to populate it when it has results.
- Behavior is identical when the model returns populated fields like `{"extracted_entities": [...]}`.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

Added `tests/prompts/test_response_models.py` with 10 tests covering all 5 affected models:
- **5 empty-input tests** — verify `Model(**{})` produces valid instances with empty lists (the regression scenario)
- **5 populated-input tests** — verify normal operation is unchanged

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Environment

- graphiti-core: 0.28.2
- LLM providers confirmed affected: Anthropic (Claude), Gemini
- pydantic: 2.12+
