### PR TITLE
perf(community): batch RELATES_TO projection into one Cypher query

### DIFF
--- a/graphiti_core/utils/maintenance/community_operations.py
+++ b/graphiti_core/utils/maintenance/community_operations.py
@@ -51,31 +51,44 @@ async def get_community_clusters(
         group_ids = group_id_values[0]['group_ids'] if group_id_values else []
 
     for group_id in group_ids:
-        projection: dict[str, list[Neighbor]] = {}
+        # Build the neighbor projection in ONE Cypher round-trip instead
+        # of one per entity. On larger graphs over a network database
+        # (e.g., Aura at ~20k entities), the per-entity loop is dominated
+        # by round-trip latency × N and becomes the wall-time bottleneck
+        # of build_communities. See issue for measured numbers.
         nodes = await EntityNode.get_by_group_ids(driver, [group_id])
-        for node in nodes:
-            match_query = """
-                MATCH (n:Entity {group_id: $group_id, uuid: $uuid})-[e:RELATES_TO]-(m: Entity {group_id: $group_id})
-            """
-            if driver.provider == GraphProvider.KUZU:
-                match_query = """
-                MATCH (n:Entity {group_id: $group_id, uuid: $uuid})-[:RELATES_TO]-(e:RelatesToNode_)-[:RELATES_TO]-(m: Entity {group_id: $group_id})
-                """
-            records, _, _ = await driver.execute_query(
-                match_query
-                + """
-                WITH count(e) AS count, m.uuid AS uuid
-                RETURN
-                    uuid,
-                    count
-                """,
-                uuid=node.uuid,
-                group_id=group_id,
-            )
 
-            projection[node.uuid] = [
-                Neighbor(node_uuid=record['uuid'], edge_count=record['count']) for record in records
-            ]
+        aggregate_query = """
+            MATCH (n:Entity {group_id: $group_id})-[e:RELATES_TO]-(m:Entity {group_id: $group_id})
+            RETURN
+                n.uuid AS src_uuid,
+                m.uuid AS tgt_uuid,
+                count(e) AS edge_count
+        """
+        if driver.provider == GraphProvider.KUZU:
+            aggregate_query = """
+                MATCH (n:Entity {group_id: $group_id})-[:RELATES_TO]-(e:RelatesToNode_)-[:RELATES_TO]-(m:Entity {group_id: $group_id})
+                RETURN
+                    n.uuid AS src_uuid,
+                    m.uuid AS tgt_uuid,
+                    count(e) AS edge_count
+            """
+
+        edge_records, _, _ = await driver.execute_query(
+            aggregate_query,
+            group_id=group_id,
+        )
+
+        # Seed every node's neighbor list so isolated nodes (no RELATES_TO
+        # edges) still appear in the projection — preserves the previous
+        # caller contract exactly.
+        projection: dict[str, list[Neighbor]] = {node.uuid: [] for node in nodes}
+        for record in edge_records:
+            src = record['src_uuid']
+            if src in projection:
+                projection[src].append(
+                    Neighbor(node_uuid=record['tgt_uuid'], edge_count=record['edge_count'])
+                )
 
         cluster_uuids = label_propagation(projection)
 


### PR DESCRIPTION
Fixes #1419.

## Summary

Replace `build_communities`' per-entity projection loop with a single aggregated Cypher query per group. Same output, ~10× faster wall time on larger graphs over a networked database — dominant cost was round-trip latency × N, not query execution.

## Before

The projection loop at `graphiti_core/utils/maintenance/community_operations.py:53–78` issues one Cypher query per entity in the group (O(N) round-trips):

```python
for node in nodes:
    records, _, _ = await driver.execute_query(
        MATCH (n:Entity {group_id: \$group_id, uuid: \$uuid})-[e:RELATES_TO]-(m:Entity {group_id: \$group_id})
        WITH count(e) AS count, m.uuid AS uuid
        RETURN uuid, count
        ...
        uuid=node.uuid,
        group_id=group_id,
    )
    projection[node.uuid] = [Neighbor(...) for record in records]
```

## After

Single aggregated query per group returning every `(src_uuid, tgt_uuid, edge_count)` triple; seed isolated nodes explicitly to preserve the `label_propagation` caller contract:

```python
edge_records, _, _ = await driver.execute_query(
    MATCH (n:Entity {group_id: \$group_id})-[e:RELATES_TO]-(m:Entity {group_id: \$group_id})
    RETURN n.uuid AS src_uuid, m.uuid AS tgt_uuid, count(e) AS edge_count
    ,
    group_id=group_id,
)

projection: dict[str, list[Neighbor]] = {node.uuid: [] for node in nodes}
for record in edge_records:
    src = record['src_uuid']
    if src in projection:
        projection[src].append(Neighbor(node_uuid=record['tgt_uuid'], edge_count=record['edge_count']))
```

Kuzu path preserved via the same aggregation shape using the `RelatesToNode_` intermediate.

## Measured impact

Single-group bonfire, 19,564 `:Entity` nodes, 35,292 undirected `:RELATES_TO` edges, Neo4j Aura (public network from a laptop):

| | projection build | end-to-end build_communities |
|---|---|---|
| before | ~10 min | ~10 min (dominated by projection) |
| after | ~5 s | ~48 s |

Round-trip latency × 19,564 was the actual cost; collapsing to one round trip recovers all of it. Query execution itself was never the bottleneck.

## Correctness

- **Isolated nodes preserved** — we explicitly seed `projection = {node.uuid: [] for node in nodes}` before ingesting edge records, so entities with no `:RELATES_TO` edges still appear in the projection with an empty neighbor list. Identical to previous behavior.
- **Edge weights preserved** — `count(e)` is aggregated per `(src, tgt)` pair in Cypher, matching the old per-node `count(e)` aggregation.
- **Kuzu path preserved** — the `RelatesToNode_` intermediate hop is used in the same place.
- `label_propagation(projection)` sees a `dict[str, list[Neighbor]]` of exactly the same shape as before.

## Scope

Single-file change (`community_operations.py`, +35/−22). No public API change. No behavior change for callers.

## Reviewer checklist

- [ ] Projection dict shape matches the old output (same keys, same `Neighbor(node_uuid, edge_count)` values)
- [ ] Isolated-node handling (verify via a group containing ≥1 entity with no RELATES_TO edges)
- [ ] Kuzu aggregation path exercised