### PR TITLE
fix: correctly flatten update_community results in add_episode

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -1114,16 +1114,19 @@ class Graphiti:
                 )
 
                 # Update communities if requested
-                communities = []
-                community_edges = []
+                communities: list[CommunityNode] = []
+                community_edges: list[CommunityEdge] = []
                 if update_communities:
-                    communities, community_edges = await semaphore_gather(
+                    per_node_results = await semaphore_gather(
                         *[
                             update_community(self.driver, self.llm_client, self.embedder, node)
                             for node in nodes
                         ],
                         max_coroutines=self.max_coroutines,
                     )
+                    for node_communities, node_community_edges in per_node_results:
+                        communities.extend(node_communities)
+                        community_edges.extend(node_community_edges)
 
                 end = time()
 


### PR DESCRIPTION
Fixes #1396

## Problem

`add_episode` crashes with `ValueError: too many / not enough values to unpack` when the number of extracted entity nodes is anything other than exactly 2.

The root cause: `semaphore_gather` returns a **list of N tuples** (one per coroutine), where each tuple is `(list[CommunityNode], list[CommunityEdge])`. The previous code did:

```python
communities, community_edges = await semaphore_gather(...)
```

This Python unpacking treats the returned list as if it has exactly 2 items, so it only worked by accident when `N == 2`. For `N == 1` it raises `ValueError: not enough values to unpack`; for `N >= 3` it raises `ValueError: too many values to unpack`.

## Solution

Replace the tuple unpack with an explicit accumulation loop:

```python
per_node_results = await semaphore_gather(...)
for node_communities, node_community_edges in per_node_results:
    communities.extend(node_communities)
    community_edges.extend(node_community_edges)
```

This correctly aggregates results across all nodes regardless of how many entity nodes were extracted from the episode. Also adds explicit type annotations to `communities` and `community_edges` since they were previously inferred as `list[Any]`.

## Testing

The fix is a straightforward logic correction with no behaviour change for callers — the returned `communities` and `community_edges` lists now have the correct types and values for all N. No external dependencies are required to verify the logic.