### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     environment: development


### PR DESCRIPTION
Potential fix for [https://github.com/getzep/graphiti/security/code-scanning/26](https://github.com/getzep/graphiti/security/code-scanning/26)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted to the minimum required scope.  
Best fix here: add workflow-level permissions directly under `on` (or before `jobs`) with:

- `contents: read`

This preserves existing behavior (checkout and linting still work) while preventing unintended write access if repository/org defaults are permissive or change later. Only `.github/workflows/lint.yml` needs editing; no imports, methods, or extra definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
