### PR TITLE
fix: escape hyphens in group_id values for FalkorDB fulltext queries

### DIFF
--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -403,9 +403,10 @@ class FalkorDriver(GraphDriver):
         if group_ids is None or len(group_ids) == 0:
             group_filter = ''
         else:
-            # Escape group_ids with quotes to prevent RediSearch syntax errors
-            # with reserved words like "main" or special characters like hyphens
-            escaped_group_ids = [f'"{gid}"' for gid in group_ids]
+            # Escape special RediSearch characters in group_id values.
+            # Hyphens must be escaped with backslash to avoid query syntax errors
+            # (e.g. "jira-summary" becomes "jira\-summary").
+            escaped_group_ids = [f'"{gid.replace("-", r"\-")}"' for gid in group_ids]
             group_values = '|'.join(escaped_group_ids)
             group_filter = f'(@group_id:{group_values})'
 


### PR DESCRIPTION
Fixes #1425

## Problem

Group IDs containing hyphens (e.g. `jira-summary`, `user-profile`) cause a RediSearch syntax error when used as filters in FalkorDB fulltext queries:

```
(@group_id:"jira-summary") (Samuel | Wycliffe)
→ RediSearch: Syntax error at offset 16 near jira
```

The episode is silently dropped — the MCP call succeeds but nodes are never stored in FalkorDB. Users only discover the problem by digging through logs.

## Root cause

In RediSearch, hyphens have special meaning (they act as word separators) and must be escaped with a backslash (`\-`) even inside double-quoted strings. The current code wraps group IDs in double quotes but does not escape the hyphen character.

Group IDs are validated to match `[a-zA-Z0-9_-]+`, so hyphens are an expected and common character (e.g. `user-profile`, `jira-summary`, `chat-history`).

## Solution

Escape hyphens in group_id values before embedding them in the RediSearch query:

```python
# Before: "jira-summary" → syntax error
escaped_group_ids = [f'"{gid}"' for gid in group_ids]

# After: "jira\-summary" → works correctly
escaped_group_ids = [f'"{gid.replace("-", r"\-")}"' for gid in group_ids]
```

## Testing

The fix is targeted at the one character class that `validate_group_id` allows that requires escaping in RediSearch queries. Existing group IDs without hyphens are unaffected (the replace is a no-op). Group IDs with hyphens that previously silently dropped episodes will now be correctly filtered.