### PR TITLE
feat(mcp_server): forward OpenAI api_url + add chat-completions LLM path

### DIFF
--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -90,6 +90,12 @@ class OpenAIProviderConfig(BaseModel):
     api_key: str | None = None
     api_url: str = 'https://api.openai.com/v1'
     organization_id: str | None = None
+    # When True, route through `OpenAIGenericClient` (chat.completions + json_object)
+    # instead of `OpenAIClient` (responses.parse / structured outputs API). Required
+    # for OpenAI-compatible endpoints that don't implement the Responses API — e.g.
+    # llama.cpp, Ollama, LiteLLM, vLLM-without-structured-outputs. Default False
+    # preserves the existing real-OpenAI behaviour.
+    use_chat_completions: bool = False
 
 
 class AzureOpenAIProviderConfig(BaseModel):

--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -17,6 +17,7 @@ except ImportError:
 # Kuzu support removed - FalkorDB is now the default
 from graphiti_core.embedder import EmbedderClient, OpenAIEmbedder
 from graphiti_core.llm_client import LLMClient, OpenAIClient
+from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
 from graphiti_core.llm_client.config import LLMConfig as GraphitiLLMConfig
 
 # Try to import additional providers if available
@@ -119,13 +120,27 @@ class LLMClientFactory:
                 # Use the same model for both main and small model slots
                 small_model = config.model
 
+                # Forward `api_url` so non-OpenAI endpoints (LiteLLM, vLLM, Azure-via-
+                # generic-shim, etc.) reach the configured server. Without this the
+                # underlying AsyncOpenAI client falls back to https://api.openai.com/v1
+                # and any non-OpenAI api_key produces a 401.
                 llm_config = CoreLLMConfig(
                     api_key=api_key,
+                    base_url=config.providers.openai.api_url,
                     model=config.model,
                     small_model=small_model,
                     temperature=config.temperature,
                     max_tokens=config.max_tokens,
                 )
+
+                # `OpenAIGenericClient` uses chat.completions + response_format json_object,
+                # which OpenAI-compatible servers (llama.cpp, Ollama, vLLM without
+                # structured-outputs, LiteLLM) actually implement. The default
+                # `OpenAIClient` calls responses.parse / structured outputs, which only
+                # real OpenAI + a small handful of providers implement. Opt in via the
+                # `use_chat_completions` provider flag.
+                if config.providers.openai.use_chat_completions:
+                    return OpenAIGenericClient(config=llm_config)
 
                 # Check if this is a reasoning model (o1, o3, gpt-5 family)
                 reasoning_prefixes = ('o1', 'o3', 'gpt-5')


### PR DESCRIPTION
## Summary

Two fixes that together unblock the MCP server when its `openai` provider points at a self-hosted endpoint (LiteLLM, vLLM, llama.cpp, Ollama). Both are surface-level patches in `mcp_server/src/services/factories.py` + a new flag on `OpenAIProviderConfig`. Default behaviour against real OpenAI is unchanged.

## Bug 1 — `api_url` is silently dropped on the LLM path

`OpenAIProviderConfig.api_url` defaults to `https://api.openai.com/v1` and is overridable via env in every shipped config example. The embedder branch of the factory already forwards it correctly (line 274 today: `base_url=config.providers.openai.api_url, # Support custom endpoints like Ollama`). The LLM branch does not — `CoreLLMConfig` is built without `base_url`, so the underlying `AsyncOpenAI` client falls back to `https://api.openai.com/v1` regardless of what the user configured. With a non-OpenAI api_key, the very first request returns 401.

Symptom in the running server:
```
services.queue_service - ERROR - Error processing queued episode for group_id <X>:
Error code: 401 - {'error': {'message': 'Incorrect API key provided: sk-58662*****...'}}
```

Fix: pass `base_url=config.providers.openai.api_url` into `CoreLLMConfig`, matching the embedder branch.

## Bug 2 — only the structured-outputs API path is wired

Once base_url forwarding is fixed, calls reach the configured server but the next failure surfaces:

```
graphiti_core.llm_client.openai_base_client - ERROR - Max retries (2) exceeded.
Last error: 1 validation error for ExtractedEntities
```

The factory always builds an `OpenAIClient`, which talks to `responses.parse` (the structured outputs API). llama.cpp, Ollama, vLLM-without-structured-outputs, and LiteLLM serve `/v1/chat/completions` cleanly but their `responses.parse` implementations are partial or absent — schema constraints aren't honoured and `ExtractedEntities` pydantic validation fails on every episode.

graphiti-core already ships an `OpenAIGenericClient` (chat.completions + `response_format: {"type": "json_object"}`) explicitly intended for this case — its docstring even mentions "16K for better compatibility with local models". The MCP factory just doesn't expose it.

Fix: add a `use_chat_completions: bool = False` field to `OpenAIProviderConfig`. When set, the factory returns `OpenAIGenericClient`. Default keeps the existing path so real-OpenAI / o1 / o3 / gpt-5 reasoning routing is untouched.

## What lands

`mcp_server/src/config/schema.py`:

```python
class OpenAIProviderConfig(BaseModel):
    api_key: str | None = None
    api_url: str = 'https://api.openai.com/v1'
    organization_id: str | None = None
    use_chat_completions: bool = False  # new
```

`mcp_server/src/services/factories.py`:

```python
from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
...
llm_config = CoreLLMConfig(
    api_key=api_key,
    base_url=config.providers.openai.api_url,  # ← was missing
    model=config.model,
    small_model=small_model,
    temperature=config.temperature,
    max_tokens=config.max_tokens,
)

if config.providers.openai.use_chat_completions:
    return OpenAIGenericClient(config=llm_config)

# existing OpenAIClient path unchanged
```

## Verification

Tested on a homelab Graphiti MCP server (zepai/knowledge-graph-mcp:latest, version 1.0.2) routed through LiteLLM → llama-server (Qwen3.5-9B Q4) → Neo4j 5.

Config:
```yaml
llm:
  provider: openai
  model: agent
  providers:
    openai:
      api_key: <litellm-master-key>
      api_url: http://192.168.0.125:4000/v1
      use_chat_completions: true
```

Result: three test episodes ingested cleanly. `Successfully processed episode` for all three. Neo4j ended with 223 `Entity` nodes and 197 `RELATES_TO` edges, all populated with extracted fields ("RHR 51 bpm", "Recovery Score 73/100", "Sleep Debt 1559 min", "ACWR 1.39", etc.). HTTP traffic confirmed in container logs hitting `192.168.0.125:4000/v1/chat/completions` (and `/v1/embeddings`) returning 200.

Without patch 1 (revert base_url forwarding): 401 from `api.openai.com` on every episode.

Without patch 2 (force `OpenAIClient`): `1 validation error for ExtractedEntities` followed by max retries.

## Test plan

- [ ] CI passes
- [ ] Real-OpenAI smoke (`api_key=<real>`, `use_chat_completions: false`, `model=gpt-4o-mini`) — should be byte-identical to pre-patch behaviour
- [ ] Ollama or LiteLLM smoke (`api_key=<local>`, `use_chat_completions: true`) — episodes ingest without 401 / pydantic errors
- [ ] o1 / o3 / gpt-5 routing unchanged (factory still hits the `is_reasoning_model` branch when `use_chat_completions: false`)