### PR TITLE
fix(mcp): coerce neo4j.time.DateTime in fact formatter

### DIFF
--- a/mcp_server/src/utils/formatting.py
+++ b/mcp_server/src/utils/formatting.py
@@ -19,22 +19,37 @@ except ImportError:  # neo4j isn't always available in non-bolt deployments
     _Neo4jDateTime = None  # type: ignore
 
 
+def _to_native_dt(v: Any) -> Any:
+    """Convert a neo4j.time.{DateTime,Date} to a native datetime; pass
+    through anything else."""
+    if _Neo4jDateTime is not None and isinstance(v, _Neo4jDateTime):
+        return v.to_native()
+    if _Neo4jDate is not None and isinstance(v, _Neo4jDate):
+        native = v.to_native()
+        return datetime(native.year, native.month, native.day)
+    return v
+
+
 def _coerce_edge_datetimes(edge: EntityEdge) -> None:
     """In-place: convert any neo4j.time.{DateTime,Date} on an edge to
-    native datetime / date so Pydantic can serialize them."""
+    native datetime / date so Pydantic can serialize them. Covers all
+    typed temporal fields on EntityEdge (incl. parent Edge.created_at
+    and reference_time) plus any datetimes nested in the free-form
+    `attributes` dict."""
     if _Neo4jDateTime is None:
         return
-    for field in ('created_at', 'valid_at', 'invalid_at', 'expired_at'):
+    for field in ('created_at', 'valid_at', 'invalid_at',
+                  'expired_at', 'reference_time'):
         v = getattr(edge, field, None)
         if v is None:
             continue
-        if isinstance(v, _Neo4jDateTime):
-            setattr(edge, field, v.to_native())
-        elif _Neo4jDate is not None and isinstance(v, _Neo4jDate):
-            # Date → datetime at midnight UTC; consistent with Pydantic
-            # field types which expect datetime, not date.
-            native = v.to_native()
-            setattr(edge, field, datetime(native.year, native.month, native.day))
+        coerced = _to_native_dt(v)
+        if coerced is not v:
+            setattr(edge, field, coerced)
+    attrs = getattr(edge, 'attributes', None)
+    if isinstance(attrs, dict):
+        for k, v in list(attrs.items()):
+            attrs[k] = _to_native_dt(v)
 
 
 def format_node_result(node: EntityNode) -> dict[str, Any]:

--- a/mcp_server/src/utils/formatting.py
+++ b/mcp_server/src/utils/formatting.py
@@ -1,9 +1,40 @@
 """Formatting utilities for Graphiti MCP Server."""
 
+from datetime import datetime
 from typing import Any
 
 from graphiti_core.edges import EntityEdge
 from graphiti_core.nodes import EntityNode
+
+try:
+    # neo4j.time.DateTime / Date / Time are returned untyped by the driver
+    # for some load paths (notably the fact/edge search). Pydantic's
+    # `model_dump(mode='json')` doesn't know how to serialize them, which
+    # surfaces in MCP as: "Unable to serialize unknown type:
+    # <class 'neo4j.time.DateTime'>".
+    from neo4j.time import Date as _Neo4jDate
+    from neo4j.time import DateTime as _Neo4jDateTime
+except ImportError:  # neo4j isn't always available in non-bolt deployments
+    _Neo4jDate = None  # type: ignore
+    _Neo4jDateTime = None  # type: ignore
+
+
+def _coerce_edge_datetimes(edge: EntityEdge) -> None:
+    """In-place: convert any neo4j.time.{DateTime,Date} on an edge to
+    native datetime / date so Pydantic can serialize them."""
+    if _Neo4jDateTime is None:
+        return
+    for field in ('created_at', 'valid_at', 'invalid_at', 'expired_at'):
+        v = getattr(edge, field, None)
+        if v is None:
+            continue
+        if isinstance(v, _Neo4jDateTime):
+            setattr(edge, field, v.to_native())
+        elif _Neo4jDate is not None and isinstance(v, _Neo4jDate):
+            # Date → datetime at midnight UTC; consistent with Pydantic
+            # field types which expect datetime, not date.
+            native = v.to_native()
+            setattr(edge, field, datetime(native.year, native.month, native.day))
 
 
 def format_node_result(node: EntityNode) -> dict[str, Any]:
@@ -40,6 +71,7 @@ def format_fact_result(edge: EntityEdge) -> dict[str, Any]:
     Returns:
         A dictionary representation of the edge with serialized dates and excluded embeddings
     """
+    _coerce_edge_datetimes(edge)
     result = edge.model_dump(
         mode='json',
         exclude={


### PR DESCRIPTION
## Summary

Defensive coercion in `format_fact_result` so `search_memory_facts` stops failing with `Unable to serialize unknown type: <class 'neo4j.time.DateTime'>` against a Neo4j-backed graph.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective

`format_fact_result` calls `edge.model_dump(mode='json')`. Pydantic's JSON mode handles `datetime.datetime` correctly but not `neo4j.time.DateTime`. When a search path produces an `EntityEdge` whose temporal fields still hold raw driver datetimes — i.e., the `EntityEdge` wasn't constructed through `graphiti_core.edges.get_entity_edge_from_record`, which routes datetimes through `parse_db_date` — the dump explodes.

`search_nodes` works on the same graph because the corresponding `format_node_result` happens to receive an `EntityNode` whose load path consistently calls `parse_db_date`. `search_memory_facts` is the only MCP tool that consistently fails.

This PR coerces the four temporal fields (`created_at`, `valid_at`, `invalid_at`, `expired_at`) to native `datetime.datetime` immediately before `model_dump`. Lazy import of `neo4j.time` so the patch is a no-op for non-Neo4j drivers (Kuzu/FalkorDB/Neptune).

**This is defensive, not the root-cause fix.** The proper upstream fix is to ensure every `EntityEdge` constructor in `graphiti_core/search/` funnels through `get_entity_edge_from_record` (or equivalently calls `parse_db_date` on temporal fields). I didn't isolate the missing call site in this PR — the symptom-side fix at the API boundary is independent value, and a maintainer with more context on the search reranker pipeline can chase the root cause separately.

## Testing

Verified locally against:
- `graphiti` HEAD = `9cdcc93`
- Neo4j community 5.x via Apple containers
- `gcc_deals` group with ~5,000 RELATES_TO edges populated by `add_episode_bulk` runs

Before: `search_memory_facts(query=\"…\", group_ids=[\"gcc_deals\"])` returns the serialization error.
After: returns clean `FactSearchResponse` with ISO 8601 datetimes on every fact.

- [ ] Unit tests added/updated — *not added; the bug requires a Neo4j-backed integration test fixture and the existing MCP test suite uses a different load path. Happy to add one if the maintainers prefer; flagging it explicitly so it's not missed in review.*
- [ ] Integration tests added/updated
- [x] All existing tests pass (`mcp_server/tests/` unaffected — no public signature changes)

## Breaking Changes
- [x] No breaking changes. `format_fact_result` returns the same shape; only the values for the four temporal fields are now guaranteed to be ISO strings instead of crashing.

## Checklist
- [x] Code follows project style guidelines (`make lint` passes — single-quote strings, 100-char lines, snake_case)
- [x] Self-review completed
- [ ] Documentation updated where necessary — no docs touched; pure bug fix
- [x] No secrets or sensitive information committed

## Related Issues
Closes #1438