### PR TITLE
fix(mcp): reuse configured LLM client for cross_encoder to avoid OPENAI_API_KEY requirement

### DIFF
--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -13,6 +13,7 @@ from typing import Any, Optional
 
 from dotenv import load_dotenv
 from graphiti_core import Graphiti
+from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient
 from graphiti_core.edges import EntityEdge
 from graphiti_core.nodes import EpisodeType, EpisodicNode
 from graphiti_core.search.search_filters import SearchFilters
@@ -187,6 +188,16 @@ class GraphitiService:
             except Exception as e:
                 logger.warning(f'Failed to create embedder client: {e}')
 
+            # Create cross_encoder reusing the LLM client to avoid requiring OPENAI_API_KEY
+            cross_encoder = None
+            if llm_client is not None:
+                try:
+                    # Pass the underlying AsyncOpenAI/AsyncAzureOpenAI client directly
+                    inner_client = getattr(llm_client, 'client', None)
+                    cross_encoder = OpenAIRerankerClient(client=inner_client or llm_client)
+                except Exception as e:
+                    logger.warning(f'Failed to create cross_encoder client: {e}')
+
             # Get database configuration
             db_config = DatabaseDriverFactory.create_config(self.config.database)
 
@@ -226,6 +237,7 @@ class GraphitiService:
                         graph_driver=falkor_driver,
                         llm_client=llm_client,
                         embedder=embedder_client,
+                        cross_encoder=cross_encoder,
                         max_coroutines=self.semaphore_limit,
                     )
                 else:
@@ -236,6 +248,7 @@ class GraphitiService:
                         password=db_config['password'],
                         llm_client=llm_client,
                         embedder=embedder_client,
+                        cross_encoder=cross_encoder,
                         max_coroutines=self.semaphore_limit,
                     )
             except Exception as db_error:


### PR DESCRIPTION
## Summary

Fixes #1441

When the MCP server is configured with a non-OpenAI provider (`azure_openai`, `anthropic`, `gemini`, `groq`), the server crashes at startup because `Graphiti()` instantiates a default `OpenAIRerankerClient()` that unconditionally creates an `AsyncOpenAI(api_key=None)` client — which raises immediately if `OPENAI_API_KEY` is not set in the environment.

**Root cause:** `GraphitiService.initialize()` passes `llm_client` and `embedder_client` to `Graphiti()`, but omits `cross_encoder`. `Graphiti.__init__` then falls back to `OpenAIRerankerClient()` with no arguments.

## Changes

- Import `OpenAIRerankerClient` in `graphiti_mcp_server.py`
- Before calling `Graphiti()`, extract the underlying `AsyncOpenAI`/`AsyncAzureOpenAI` client from the already-configured `llm_client` (via `getattr(llm_client, 'client', None)`) and pass it to `OpenAIRerankerClient`
- Pass the resulting `cross_encoder` explicitly to both `Graphiti()` call sites (FalkorDB and Neo4j paths)

```python
# Create cross_encoder reusing the LLM client to avoid requiring OPENAI_API_KEY
cross_encoder = None
if llm_client is not None:
    try:
        inner_client = getattr(llm_client, 'client', None)
        cross_encoder = OpenAIRerankerClient(client=inner_client or llm_client)
    except Exception as e:
        logger.warning(f'Failed to create cross_encoder client: {e}')
```

## Test plan

- [x] Verified with `LLM__PROVIDER=azure_openai` + `EMBEDDER__PROVIDER=azure_openai` deployed on Azure Container Instance — server initialises successfully without `OPENAI_API_KEY`
- [ ] Unit test: instantiate `GraphitiService` with `azure_openai` config and no `OPENAI_API_KEY` set → should not raise
- [ ] Confirm existing OpenAI provider path still works unchanged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)