### PR TITLE
feat: add custom edge type support to combined extraction prompt

### DIFF
--- a/graphiti_core/prompts/extract_nodes_and_edges.py
+++ b/graphiti_core/prompts/extract_nodes_and_edges.py
@@ -73,6 +73,21 @@ class Versions(TypedDict):
     extract_message: PromptFunction
 
 
+def _build_edge_types_section(edge_types: list[dict] | None) -> str:
+    """Build the optional FACT TYPES section for the combined prompt."""
+    if not edge_types:
+        return ''
+    return f"""
+<FACT TYPES>
+{to_prompt_json(edge_types)}
+</FACT TYPES>
+RELATION TYPE RULES:
+- When a relationship matches a FACT TYPE, use that fact_type_name as the relation_type.
+- If no FACT TYPE fits, derive a relation_type in SCREAMING_SNAKE_CASE
+  (e.g., WORKS_AT, LIVES_IN, IS_FRIENDS_WITH).
+"""
+
+
 def extract_message(context: dict[str, Any]) -> list[Message]:
     sys_prompt = (
         'You are an expert knowledge graph extraction specialist for an AI agent memory system. '
@@ -131,7 +146,7 @@ FACT RULES:
 <ENTITY TYPES>
 {context['entity_types']}
 </ENTITY TYPES>
-
+{_build_edge_types_section(context.get('edge_types'))}
 <PREVIOUS MESSAGES>
 {to_prompt_json([ep for ep in context['previous_episodes']])}
 </PREVIOUS MESSAGES>

--- a/graphiti_core/utils/maintenance/combined_extraction.py
+++ b/graphiti_core/utils/maintenance/combined_extraction.py
@@ -67,9 +67,9 @@ async def extract_nodes_and_edges(
     excluded_entity_types : list[str] | None
         Entity types to exclude from extraction.
     edge_type_map : dict | None
-        Mapping of edge type signatures (unused in combined prompt but kept for API compat).
+        Mapping of (source_type, target_type) tuples to lists of edge type names.
     edge_types : dict | None
-        Custom edge type definitions (unused in combined prompt but kept for API compat).
+        Custom edge type definitions (Pydantic models keyed by type name).
     custom_extraction_instructions : str | None
         Additional extraction instructions.
 
@@ -82,22 +82,32 @@ async def extract_nodes_and_edges(
     episodes = episode if isinstance(episode, list) else [episode]
     primary_episode = episodes[0]
 
-    if edge_types:
-        logger.debug(
-            'Combined extraction does not use custom edge types; %d edge type(s) will be ignored',
-            len(edge_types),
-        )
-    if edge_type_map:
-        logger.debug(
-            'Combined extraction does not use edge_type_map; %d mapping(s) will be ignored',
-            len(edge_type_map),
-        )
-
     start = time()
     llm_client = clients.llm_client
 
     # Build entity types context
     entity_types_context = _build_entity_types_context(entity_types)
+
+    # Build edge types context (same format as separate extraction path)
+    edge_types_context: list[dict] = []
+    if edge_types and edge_type_map:
+        edge_type_signatures_map: dict[str, list] = {}
+        for signature, type_names in edge_type_map.items():
+            for type_name in type_names:
+                if type_name not in edge_type_signatures_map:
+                    edge_type_signatures_map[type_name] = []
+                edge_type_signatures_map[type_name].append(signature)
+
+        edge_types_context = [
+            {
+                'fact_type_name': type_name,
+                'fact_type_signatures': edge_type_signatures_map.get(
+                    type_name, [('Entity', 'Entity')]
+                ),
+                'fact_type_description': type_model.__doc__,
+            }
+            for type_name, type_model in edge_types.items()
+        ]
 
     # Build context for the combined prompt
     context = {
@@ -111,6 +121,7 @@ async def extract_nodes_and_edges(
         ],
         'custom_extraction_instructions': custom_extraction_instructions or '',
         'entity_types': entity_types_context,
+        'edge_types': edge_types_context,
     }
 
     # Single LLM call for combined extraction


### PR DESCRIPTION
## Summary

Forward-port from getzep/zep-proprietary PRs #4199 and #4212.

The combined extraction prompt was missing custom edge types (`FACT TYPES`) that the separate extraction path includes. When a customer sets a custom edge ontology (e.g., `VISITED_RESTAURANT`, `OWNS_PET`), the combined prompt didn't know about them — the model invented its own `relation_type` names instead of using the ontology types.

**Changes:**
- Build `edge_types_context` in `combined_extraction.py` from the `edge_types` and `edge_type_map` parameters (same format as the separate extraction path)
- Add `_build_edge_types_section()` helper to `extract_nodes_and_edges.py` that conditionally injects a `<FACT TYPES>` section and relation type matching rules
- Both entity types and edge types now appear above the episode content in the prompt
- Remove the "unused" debug logs since edge types are now actively used

## Test plan

- [ ] Verify combined extraction uses custom edge types when ontology is set
- [ ] Verify non-ontology graphs still work (empty FACT TYPES section is omitted)
- [ ] Run existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)