### PR TITLE
fix(falkordb): strip backticks and guard empty token list in fulltext query builder

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -83,6 +83,7 @@ _SEPARATOR_MAP = str.maketrans(
         '|': ' ',
         '/': ' ',
         '\\': ' ',
+        '`': ' ',
     }
 )
 
@@ -111,6 +112,12 @@ def _build_falkor_fulltext_query(
     # Remove stopwords and empty tokens
     query_words = sanitized_query.split()
     filtered_words = [word for word in query_words if word and word.lower() not in STOPWORDS]
+
+    # If all tokens were stopwords or the query was empty/punctuation-only, return ''
+    # so callers skip the search rather than issue a malformed "(@group_id:…) ()" query.
+    if not filtered_words:
+        return ''
+
     sanitized_query = ' | '.join(filtered_words)
 
     if len(sanitized_query.split(' ')) + len(group_ids or '') >= max_query_length:

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -379,6 +379,7 @@ class FalkorDriver(GraphDriver):
                 '|': ' ',
                 '/': ' ',
                 '\\': ' ',
+                '`': ' ',
             }
         )
         sanitized = query.translate(separator_map)
@@ -414,6 +415,12 @@ class FalkorDriver(GraphDriver):
         # Remove stopwords and empty tokens from the sanitized query
         query_words = sanitized_query.split()
         filtered_words = [word for word in query_words if word and word.lower() not in STOPWORDS]
+
+        # If all tokens were stopwords or the query was empty/punctuation-only, return ''
+        # so callers skip the search rather than issue a malformed "(@group_id:…) ()" query.
+        if not filtered_words:
+            return ''
+
         sanitized_query = ' | '.join(filtered_words)
 
         # If the query is too long return no query

--- a/tests/driver/test_falkordb_driver.py
+++ b/tests/driver/test_falkordb_driver.py
@@ -362,6 +362,55 @@ class TestDatetimeConversion:
         assert convert_datetimes_to_strings(True) is True
 
 
+class TestFalkorDriverFulltextQuery:
+    """Tests for FalkorDriver.build_fulltext_query and _build_falkor_fulltext_query."""
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def setup_method(self):
+        with patch('graphiti_core.driver.falkordb_driver.FalkorDB'):
+            self.driver = FalkorDriver()
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def test_backtick_tokens_are_stripped(self):
+        """Backtick-quoted tokens (e.g. `add_episode`) must not reach RediSearch."""
+        result = self.driver.build_fulltext_query('`add_episode`')
+        # backtick stripped → token is "add_episode" → underscore survives, no raw backtick
+        assert '`' not in result
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def test_stopword_only_query_returns_empty(self):
+        """A query whose every token is a stopword must return '' to prevent malformed queries."""
+        # "the" and "a" are common stopwords in the FalkorDB STOPWORDS list
+        result = self.driver.build_fulltext_query('the a')
+        assert result == ''
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def test_punctuation_only_query_returns_empty(self):
+        """A query consisting entirely of separator characters must return ''."""
+        result = self.driver.build_fulltext_query('---')
+        assert result == ''
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def test_backtick_only_query_returns_empty(self):
+        """A query that is only backticks must return '' after sanitization."""
+        result = self.driver.build_fulltext_query('``')
+        assert result == ''
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def test_normal_query_unchanged(self):
+        """A regular query should still produce a valid non-empty result."""
+        result = self.driver.build_fulltext_query('graphiti knowledge graph')
+        assert result != ''
+        assert '(' in result and ')' in result
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def test_backtick_mixed_with_normal_tokens(self):
+        """Backticks around a token should be stripped but the token itself kept."""
+        result = self.driver.build_fulltext_query('`add_episode` function')
+        assert result != ''
+        assert '`' not in result
+
+
 # Simple integration test
 class TestFalkorDriverIntegration:
     """Simple integration test for FalkorDB driver."""


### PR DESCRIPTION
Fixes #1440

## Problem

`_build_falkor_fulltext_query` (and `FalkorDriver.build_fulltext_query`) had two bugs that caused RediSearch `Syntax error` failures during dedup-search:

1. **Backtick tokens leak through to RediSearch.** The separator translation map omitted the backtick character `` ` ``, so entity names from code-fenced text (e.g. `` `add_episode` ``) survived sanitization and broke RediSearch parsing.

2. **Empty parenthesis on stopword-only or punctuation-only queries.** When every token was filtered out as a stopword (or the input was all separators/backticks), `filtered_words` became empty but the builder still constructed `(@group_id:"…") ()`, which RediSearch rejects with a syntax error.

Both failure modes existed in two upstream copies of the function:
- `graphiti_core/driver/falkordb/operations/search_ops.py` — `_build_falkor_fulltext_query`
- `graphiti_core/driver/falkordb_driver.py` — `FalkorDriver.sanitize` / `build_fulltext_query`

## Solution

Two surgical changes applied to both copies:

1. Add `` ` `` to the separator translation map so backticks are replaced with whitespace before tokenization.
2. Return `''` early when `filtered_words` is empty after stopword filtering, so callers skip the RediSearch query rather than issuing a malformed one.

## Testing

Added unit tests in `tests/driver/test_falkordb_driver.py` covering:
- Backtick tokens are stripped from the query string
- Stopword-only queries return `''`
- Punctuation-only queries return `''`
- Backtick-only queries return `''`
- Normal queries still produce valid non-empty results
- Backtick mixed with normal tokens strips backticks but keeps the tokens

All 6 new tests pass. No existing tests were broken.