### PR TITLE
fix: terminate label_propagation on bipartite / weight-symmetric graphs

### DIFF
--- a/graphiti_core/driver/operations/graph_utils.py
+++ b/graphiti_core/driver/operations/graph_utils.py
@@ -24,39 +24,50 @@ class Neighbor(BaseModel):
     edge_count: int
 
 
-def label_propagation(projection: dict[str, list[Neighbor]]) -> list[list[str]]:
-    community_map = {uuid: i for i, uuid in enumerate(projection.keys())}
+def label_propagation(
+    projection: dict[str, list[Neighbor]], max_iterations: int = 100
+) -> list[list[str]]:
+    """Cluster nodes via the asynchronous label propagation algorithm.
 
-    while True:
+    Each node iteratively adopts the most-weighted community label among
+    its neighbours. Updates are applied in place (asynchronous LPA), so
+    later nodes within the same iteration see earlier nodes' fresh
+    labels. This avoids the oscillation that synchronous LPA exhibits on
+    bipartite or weight-symmetric graphs, where reading from a snapshot
+    and writing to a parallel map can flip-flop between two states
+    indefinitely. ``max_iterations`` is a defensive upper bound that
+    guarantees termination on any input.
+
+    Ties between candidate communities of equal total weight are broken
+    deterministically by the smallest community ID, so two runs over the
+    same input produce the same clustering.
+    """
+    community_map: dict[str, int] = {uuid: i for i, uuid in enumerate(projection.keys())}
+
+    for _ in range(max_iterations):
         no_change = True
-        new_community_map: dict[str, int] = {}
 
         for uuid, neighbors in projection.items():
-            curr_community = community_map[uuid]
-
             community_candidates: dict[int, int] = defaultdict(int)
             for neighbor in neighbors:
                 community_candidates[community_map[neighbor.node_uuid]] += neighbor.edge_count
-            community_lst = [
-                (count, community) for community, count in community_candidates.items()
-            ]
 
-            community_lst.sort(reverse=True)
-            candidate_rank, community_candidate = community_lst[0] if community_lst else (0, -1)
-            if community_candidate != -1 and candidate_rank > 1:
-                new_community = community_candidate
-            else:
-                new_community = max(community_candidate, curr_community)
+            if not community_candidates:
+                # A node with no neighbours has no candidate community to
+                # adopt; leave it in its initial singleton community.
+                continue
 
-            new_community_map[uuid] = new_community
+            new_community = min(
+                community_candidates.items(),
+                key=lambda item: (-item[1], item[0]),
+            )[0]
 
-            if new_community != curr_community:
+            if new_community != community_map[uuid]:
+                community_map[uuid] = new_community
                 no_change = False
 
         if no_change:
             break
-
-        community_map = new_community_map
 
     community_cluster_map: dict[int, list[str]] = defaultdict(list)
     for uuid, community in community_map.items():

--- a/graphiti_core/utils/maintenance/community_operations.py
+++ b/graphiti_core/utils/maintenance/community_operations.py
@@ -90,52 +90,56 @@ async def get_community_clusters(
     return community_clusters
 
 
-def label_propagation(projection: dict[str, list[Neighbor]]) -> list[list[str]]:
-    # Implement the label propagation community detection algorithm.
-    # 1. Start with each node being assigned its own community
-    # 2. Each node will take on the community of the plurality of its neighbors
-    # 3. Ties are broken by going to the largest community
-    # 4. Continue until no communities change during propagation
+def label_propagation(
+    projection: dict[str, list[Neighbor]], max_iterations: int = 100
+) -> list[list[str]]:
+    """Cluster nodes via the asynchronous label propagation algorithm.
 
-    community_map = {uuid: i for i, uuid in enumerate(projection.keys())}
+    Each node iteratively adopts the most-weighted community label among
+    its neighbours. Updates are applied in place (asynchronous LPA), so
+    later nodes within the same iteration see earlier nodes' fresh
+    labels. This avoids the oscillation that synchronous LPA exhibits on
+    bipartite or weight-symmetric graphs, where reading from a snapshot
+    and writing to a parallel map can flip-flop between two states
+    indefinitely. ``max_iterations`` is a defensive upper bound that
+    guarantees termination on any input.
 
-    while True:
+    Ties between candidate communities of equal total weight are broken
+    deterministically by the smallest community ID, so two runs over the
+    same input produce the same clustering.
+    """
+    community_map: dict[str, int] = {uuid: i for i, uuid in enumerate(projection.keys())}
+
+    for _ in range(max_iterations):
         no_change = True
-        new_community_map: dict[str, int] = {}
 
         for uuid, neighbors in projection.items():
-            curr_community = community_map[uuid]
-
             community_candidates: dict[int, int] = defaultdict(int)
             for neighbor in neighbors:
                 community_candidates[community_map[neighbor.node_uuid]] += neighbor.edge_count
-            community_lst = [
-                (count, community) for community, count in community_candidates.items()
-            ]
 
-            community_lst.sort(reverse=True)
-            candidate_rank, community_candidate = community_lst[0] if community_lst else (0, -1)
-            if community_candidate != -1 and candidate_rank > 1:
-                new_community = community_candidate
-            else:
-                new_community = max(community_candidate, curr_community)
+            if not community_candidates:
+                # A node with no neighbours has no candidate community to
+                # adopt; leave it in its initial singleton community.
+                continue
 
-            new_community_map[uuid] = new_community
+            new_community = min(
+                community_candidates.items(),
+                key=lambda item: (-item[1], item[0]),
+            )[0]
 
-            if new_community != curr_community:
+            if new_community != community_map[uuid]:
+                community_map[uuid] = new_community
                 no_change = False
 
         if no_change:
             break
 
-        community_map = new_community_map
-
-    community_cluster_map = defaultdict(list)
+    community_cluster_map: dict[int, list[str]] = defaultdict(list)
     for uuid, community in community_map.items():
         community_cluster_map[community].append(uuid)
 
-    clusters = [cluster for cluster in community_cluster_map.values()]
-    return clusters
+    return list(community_cluster_map.values())
 
 
 async def summarize_pair(llm_client: LLMClient, summary_pair: tuple[str, str]) -> str:

--- a/tests/utils/maintenance/test_community_operations.py
+++ b/tests/utils/maintenance/test_community_operations.py
@@ -1,0 +1,198 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+
+from graphiti_core.driver.operations.graph_utils import (
+    Neighbor as DriverNeighbor,
+)
+from graphiti_core.driver.operations.graph_utils import (
+    label_propagation as driver_label_propagation,
+)
+from graphiti_core.utils.maintenance.community_operations import (
+    Neighbor as MaintenanceNeighbor,
+)
+from graphiti_core.utils.maintenance.community_operations import (
+    label_propagation as maintenance_label_propagation,
+)
+
+# Two duplicate copies of label_propagation exist in the codebase: one in
+# graphiti_core.driver.operations.graph_utils (used by every database driver
+# via graph_operations_interface) and one in
+# graphiti_core.utils.maintenance.community_operations (used as the legacy
+# fallback). Run every test against both so any fix lands in lockstep and
+# does not silently regress one site.
+LABEL_PROPAGATION_IMPLS = [
+    pytest.param(driver_label_propagation, DriverNeighbor, id='driver'),
+    pytest.param(maintenance_label_propagation, MaintenanceNeighbor, id='maintenance'),
+]
+
+
+def _undirected(
+    cls,
+    edges: list[tuple[str, str, int]],
+    isolated: list[str] | None = None,
+) -> dict[str, list]:
+    """Build a symmetric `projection` dict from undirected weighted edges.
+
+    The Cypher in get_community_clusters matches RELATES_TO undirected, so
+    a real projection contains both (u -> v) and (v -> u) entries. Tests
+    that omit one direction would not exercise the shape of input the
+    function actually receives in production.
+    """
+    projection: dict[str, list] = {}
+    for u, v, w in edges:
+        projection.setdefault(u, []).append(cls(node_uuid=v, edge_count=w))
+        projection.setdefault(v, []).append(cls(node_uuid=u, edge_count=w))
+    for n in isolated or []:
+        projection.setdefault(n, [])
+    return projection
+
+
+@pytest.mark.parametrize('impl, neighbor_cls', LABEL_PROPAGATION_IMPLS)
+def test_label_propagation_terminates_on_oscillation_inducing_graph(impl, neighbor_cls):
+    """Regression test for non-convergence under synchronous label
+    propagation. The original implementation reads from a snapshot and
+    writes to a parallel map (synchronous LPA), then swaps. Synchronous
+    LPA is known to oscillate on graphs with ties between weighted
+    candidate communities and a tiebreak that pulls labels in different
+    directions on alternating rounds. This 5-node graph exhibits exactly
+    that pathology with the original tiebreak (max(candidate, current)
+    when candidate_rank <= 1, raw candidate when > 1) — labels for the
+    central X / Y / Z triangle alternate between two states forever.
+
+    The fix must guarantee termination on this input. Output correctness
+    is checked separately; this test only asserts the function returns.
+    """
+    projection = _undirected(
+        neighbor_cls,
+        edges=[
+            ('X', 'Y', 2),
+            ('X', 'Z', 2),
+            ('Y', 'A', 1),
+            ('Z', 'B', 1),
+        ],
+    )
+
+    clusters = impl(projection)
+
+    flat = sorted([uuid for cluster in clusters for uuid in cluster])
+    assert flat == ['A', 'B', 'X', 'Y', 'Z']
+
+
+@pytest.mark.parametrize('impl, neighbor_cls', LABEL_PROPAGATION_IMPLS)
+def test_label_propagation_assigns_every_node_exactly_once(impl, neighbor_cls):
+    """Output invariant: every input UUID appears in exactly one cluster.
+    No node is dropped, no node is duplicated across clusters.
+    """
+    projection = _undirected(
+        neighbor_cls,
+        edges=[
+            ('a', 'b', 1),
+            ('b', 'c', 1),
+            ('c', 'd', 1),
+            ('d', 'e', 1),
+            ('e', 'a', 1),
+        ],
+    )
+
+    clusters = impl(projection)
+
+    flat = [uuid for cluster in clusters for uuid in cluster]
+    assert sorted(flat) == ['a', 'b', 'c', 'd', 'e']
+    assert len(flat) == len(set(flat))
+
+
+@pytest.mark.parametrize('impl, neighbor_cls', LABEL_PROPAGATION_IMPLS)
+def test_label_propagation_disconnected_graph_yields_singletons(impl, neighbor_cls):
+    """Three nodes with no edges between them must produce three
+    singleton clusters. A node with an empty neighbour list has no
+    candidate community to adopt and must keep its initial assignment.
+    """
+    projection = _undirected(neighbor_cls, edges=[], isolated=['a', 'b', 'c'])
+
+    clusters = impl(projection)
+
+    sizes = sorted(len(c) for c in clusters)
+    assert sizes == [1, 1, 1]
+    flat = sorted([uuid for cluster in clusters for uuid in cluster])
+    assert flat == ['a', 'b', 'c']
+
+
+@pytest.mark.parametrize('impl, neighbor_cls', LABEL_PROPAGATION_IMPLS)
+def test_label_propagation_complete_graph_collapses_to_one_cluster(impl, neighbor_cls):
+    """A fully-connected graph of 4 nodes must converge to a single
+    cluster: every node sees every other node voting for the same shared
+    plurality, so all nodes adopt the same community.
+    """
+    nodes = ['a', 'b', 'c', 'd']
+    edges = [(u, v, 1) for i, u in enumerate(nodes) for v in nodes[i + 1 :]]
+    projection = _undirected(neighbor_cls, edges=edges)
+
+    clusters = impl(projection)
+
+    assert len(clusters) == 1
+    assert sorted(clusters[0]) == sorted(nodes)
+
+
+@pytest.mark.parametrize('impl, neighbor_cls', LABEL_PROPAGATION_IMPLS)
+def test_label_propagation_two_disjoint_components_yield_two_clusters(impl, neighbor_cls):
+    """Two disjoint complete subgraphs of size 3 must produce two
+    clusters of 3 each — the algorithm must not bridge components.
+    """
+    projection = _undirected(
+        neighbor_cls,
+        edges=[
+            ('a', 'b', 1),
+            ('b', 'c', 1),
+            ('a', 'c', 1),
+            ('x', 'y', 1),
+            ('y', 'z', 1),
+            ('x', 'z', 1),
+        ],
+    )
+
+    clusters = impl(projection)
+
+    cluster_sets = [frozenset(c) for c in clusters]
+    assert frozenset({'a', 'b', 'c'}) in cluster_sets
+    assert frozenset({'x', 'y', 'z'}) in cluster_sets
+    assert len(clusters) == 2
+
+
+@pytest.mark.parametrize('impl, neighbor_cls', LABEL_PROPAGATION_IMPLS)
+def test_label_propagation_is_deterministic(impl, neighbor_cls):
+    """Same input, same output across repeated calls. Reproducibility
+    matters for downstream community-summary caching and for tests that
+    depend on cluster identity.
+    """
+    projection = _undirected(
+        neighbor_cls,
+        edges=[
+            ('a', 'b', 2),
+            ('b', 'c', 1),
+            ('c', 'd', 2),
+            ('d', 'e', 1),
+            ('e', 'a', 1),
+        ],
+    )
+
+    first = impl(projection)
+    second = impl(projection)
+
+    canonical_first = sorted(sorted(c) for c in first)
+    canonical_second = sorted(sorted(c) for c in second)
+    assert canonical_first == canonical_second


### PR DESCRIPTION
## Problem

`graphiti_core.utils.maintenance.community_operations.label_propagation` (and its duplicate at `graphiti_core.driver.operations.graph_utils.label_propagation`) implements **synchronous** label propagation: it reads labels from a snapshot `community_map`, writes to a parallel `new_community_map`, and swaps at the end of each iteration. The loop has no iteration cap.

Synchronous LPA is mathematically prone to **oscillation** on bipartite or weight-symmetric graphs — two label assignments can flip-flop between consecutive iterations because no node ever sees a neighbour's updated label within the same pass. Combined with the tiebreak rule `new_community = max(community_candidate, curr_community)` in the singleton-vote case versus raw `community_candidate` in the plurality case, the algorithm has no monotonic convergence guarantee. On the right input shape it never terminates.

## Reproduction

A small 5-node graph triggers it:

```python
projection = {
    'X': [Neighbor('Y', 2), Neighbor('Z', 2)],
    'Y': [Neighbor('X', 2), Neighbor('A', 1)],
    'Z': [Neighbor('X', 2), Neighbor('B', 1)],
    'A': [Neighbor('Y', 1)],
    'B': [Neighbor('Z', 1)],
}
clusters = label_propagation(projection)  # never returns
```

This shape arises naturally from `add_episode` over rich prose with a hub entity (e.g. an organisation) and several competing role claims (multiple CEOs / CFOs across different valid intervals). I encountered it while building a bitemporal-correctness benchmark for agentic memory systems: 5 dated documents about a single fictional company drove `client.build_communities()` into a CPU-bound hang. `py-spy dump` of a one-hour run shows the main thread spending 100% CPU in `label_propagation` with no forward progress; all 14 asyncio worker threads idle.

## Fix

Three changes, applied identically to both copies of `label_propagation`:

1. **Switch to asynchronous LPA.** Read and write to `community_map` in place so later nodes within the same iteration see earlier nodes' fresh labels. This is the standard form and generally converges within O(log N) iterations on graphs that arise in practice.
2. **Add a `max_iterations=100` safety cap.** Even async LPA can stall on adversarial inputs; the cap guarantees termination in bounded time rather than hanging the entire community-build pipeline.
3. **Replace the asymmetric tiebreak with a deterministic smallest-community-ID rule.** Among candidate communities of equal total weight, pick the one with the smallest ID. Removes the oscillation-amplifying asymmetry and makes output reproducible across runs.

Both copies of the function get the same patch in lockstep — the test suite parametrizes every assertion over both implementations so they cannot diverge.

## Tests

New file `tests/utils/maintenance/test_community_operations.py`:

- `test_label_propagation_terminates_on_oscillation_inducing_graph` — the regression test. Hangs forever on the previous code (verified manually with a wall-clock timeout); passes in 0.01 s on the fix.
- `test_label_propagation_assigns_every_node_exactly_once` — output invariant.
- `test_label_propagation_disconnected_graph_yields_singletons` — edge case for nodes with no neighbours.
- `test_label_propagation_complete_graph_collapses_to_one_cluster` — sanity check on dense connectivity.
- `test_label_propagation_two_disjoint_components_yield_two_clusters` — the algorithm must not bridge components.
- `test_label_propagation_is_deterministic` — two runs over the same input produce the same clustering.

All twelve test cases (six tests × two implementations) pass:

```
tests/utils/maintenance/test_community_operations.py::test_label_propagation_terminates_on_oscillation_inducing_graph[driver] PASSED
tests/utils/maintenance/test_community_operations.py::test_label_propagation_terminates_on_oscillation_inducing_graph[maintenance] PASSED
... (10 more)
======================== 12 passed in 0.01s =========================
```

`make format`, `make lint`, and `pyright` are all clean on the modified files. The full unit test suite (`make test`) shows no new failures attributable to this change — the only errors I see are Neo4j authentication failures from tests that need a live Neo4j instance, present with or without this patch.

## Compatibility

- `label_propagation` gains a new keyword-only parameter `max_iterations: int = 100`. All existing callers (the four database drivers under `graphiti_core/driver/{neo4j,falkordb,kuzu,neptune}/operations/graph_ops.py` and the legacy fallback in `community_operations.get_community_clusters`) call it positionally with a single argument, so the default kicks in and behaviour is unchanged for them.
- The fix changes which clusters are produced on graphs where the previous code happened to converge — output is now deterministic where the previous tiebreak could pick different IDs depending on dict iteration order in older Pythons. I expect this to be desirable for downstream community-summary caching, but flagging in case it surprises any callers that depend on the prior behaviour.

## How to verify locally

```bash
git checkout fix/label-propagation-non-convergence
make install
uv run pytest tests/utils/maintenance/test_community_operations.py -v
```

Without the fix, the regression test hangs. With the fix, the suite finishes in well under a second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)