### PR TITLE
fix: mount FalkorDB volume to correct data path

### DIFF
--- a/mcp_server/docker/docker-compose-falkordb.yml
+++ b/mcp_server/docker/docker-compose-falkordb.yml
@@ -8,7 +8,7 @@ services:
       - FALKORDB_PASSWORD=${FALKORDB_PASSWORD:-}
       - BROWSER=${BROWSER:-1}  # Enable FalkorDB Browser UI (set to 0 to disable)
     volumes:
-      - falkordb_data:/data
+      - falkordb_data:/var/lib/falkordb/data
     healthcheck:
       test: ["CMD", "redis-cli", "-p", "6379", "ping"]
       interval: 10s


### PR DESCRIPTION
## Summary
Fix incorrect Docker volume mount path in `mcp_server/docker/docker-compose-falkordb.yml`. 
The volume was mounted to `/data` (a symlink into the container's writable layer) instead 
of `/var/lib/falkordb/data` (where FalkorDB actually writes `dump.rdb`). Data appeared to 
persist across restarts but was silently lost on `docker compose down`, `--force-recreate`, 
or image rebuilds.

## Type of Change
- [x] Bug fix

## Objective
N/A

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

Verified on a running stack:
- `docker exec docker-falkordb-1 ls /var/lib/falkordb/data/` → `dump.rdb` present
- `docker run --rm -v docker_falkordb_data:/check alpine ls /check/` → `dump.rdb` in the named volume

`make check` passes (format, lint, pyright, unit tests).

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed


