### PR TITLE
fix: install MCP provider extras in Docker images

### DIFF
--- a/mcp_server/docker/Dockerfile
+++ b/mcp_server/docker/Dockerfile
@@ -49,8 +49,10 @@ RUN sed -i '/\[tool\.uv\.sources\]/,/graphiti-core/d' pyproject.toml && \
     uv lock
 
 # Install Python dependencies (exclude dev dependency group)
+# Include optional provider extras so the image matches the providers
+# advertised by the MCP server configuration and docs.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --no-group dev
+    uv sync --no-group dev --extra providers --extra azure
 
 # Store graphiti-core version
 RUN echo "${GRAPHITI_CORE_VERSION}" > /app/mcp/.graphiti-core-version

--- a/mcp_server/docker/Dockerfile.standalone
+++ b/mcp_server/docker/Dockerfile.standalone
@@ -43,8 +43,10 @@ RUN sed -i '/\[tool\.uv\.sources\]/,/graphiti-core/d' pyproject.toml && \
     uv lock
 
 # Install Python dependencies (exclude dev dependency group)
+# Include optional provider extras so the image matches the providers
+# advertised by the MCP server configuration and docs.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --no-group dev
+    uv sync --no-group dev --extra providers --extra azure
 
 # Store graphiti-core version
 RUN echo "${GRAPHITI_CORE_VERSION}" > /app/mcp/.graphiti-core-version


### PR DESCRIPTION
## Summary

- install MCP server provider extras in both Docker image build paths
- include the optional provider dependencies during `uv sync`
- make the published MCP Docker images match the providers advertised in the config and docs

Closes #1394
