### PR TITLE
fix(docker): mount FalkorDB volume to actual data path

### DIFF
--- a/mcp_server/docker/docker-compose-falkordb.yml
+++ b/mcp_server/docker/docker-compose-falkordb.yml
@@ -8,7 +8,7 @@ services:
       - FALKORDB_PASSWORD=${FALKORDB_PASSWORD:-}
       - BROWSER=${BROWSER:-1}  # Enable FalkorDB Browser UI (set to 0 to disable)
     volumes:
-      - falkordb_data:/data
+      - falkordb_data:/var/lib/falkordb/data
     healthcheck:
       test: ["CMD", "redis-cli", "-p", "6379", "ping"]
       interval: 10s


### PR DESCRIPTION
## Summary
- fix mcp_server/docker/docker-compose-falkordb.yml to mount alkordb_data at /var/lib/falkordb/data
- align FalkorDB compose variant with the existing default compose data-path mount

## Why
Issue #1452 reports that mounting to /data persists only a symlink while dump.rdb is written under /var/lib/falkordb/data, causing data loss on container recreation.

## Testing
- verified diff only changes the FalkorDB volume mount target in docker-compose-falkordb.yml

Closes #1452