### PR TITLE
feat(mcp): expose custom extraction instructions in add_memory

### DIFF
--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -326,6 +326,7 @@ async def add_memory(
     source: str = 'text',
     source_description: str = '',
     uuid: str | None = None,
+    custom_extraction_instructions: str | None = None,
 ) -> SuccessResponse | ErrorResponse:
     """Add an episode to memory. This is the primary way to add information to the graph.
 
@@ -345,6 +346,8 @@ async def add_memory(
                                - 'message': For conversation-style content
         source_description (str, optional): Description of the source
         uuid (str, optional): Optional UUID for the episode
+        custom_extraction_instructions (str, optional): Optional extraction instructions passed
+            through to Graphiti for entity/edge extraction behavior.
 
     Examples:
         # Adding plain text content
@@ -393,6 +396,7 @@ async def add_memory(
             episode_type=episode_type,
             entity_types=graphiti_service.entity_types,
             uuid=uuid or None,  # Ensure None is passed if uuid is None
+            custom_extraction_instructions=custom_extraction_instructions,
         )
 
         return SuccessResponse(

--- a/mcp_server/src/services/queue_service.py
+++ b/mcp_server/src/services/queue_service.py
@@ -107,6 +107,7 @@ class QueueService:
         episode_type: Any,
         entity_types: Any,
         uuid: str | None,
+        custom_extraction_instructions: str | None = None,
     ) -> int:
         """Add an episode for processing.
 
@@ -118,6 +119,8 @@ class QueueService:
             episode_type: Type of the episode
             entity_types: Entity types for extraction
             uuid: Episode UUID
+            custom_extraction_instructions: Optional extraction instructions passed through
+                to Graphiti extraction prompts.
 
         Returns:
             The position in the queue
@@ -140,6 +143,7 @@ class QueueService:
                     reference_time=datetime.now(timezone.utc),
                     entity_types=entity_types,
                     uuid=uuid,
+                    custom_extraction_instructions=custom_extraction_instructions,
                 )
 
                 logger.info(f'Successfully processed episode {uuid} for group {group_id}')

--- a/mcp_server/tests/test_queue_service.py
+++ b/mcp_server/tests/test_queue_service.py
@@ -1,0 +1,45 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services.queue_service import QueueService
+
+
+@pytest.mark.unit
+def test_add_episode_forwards_custom_extraction_instructions():
+    async def run_test():
+        service = QueueService()
+        mock_client = AsyncMock()
+        await service.initialize(mock_client)
+
+        async def run_immediately(group_id, process_func):
+            await process_func()
+            return 1
+
+        service.add_episode_task = run_immediately
+
+        await service.add_episode(
+            group_id="group-a",
+            name="Episode Name",
+            content="Episode body",
+            source_description="desc",
+            episode_type="text",
+            entity_types=[],
+            uuid="ep-1",
+            custom_extraction_instructions="Preserve original language.",
+        )
+
+        mock_client.add_episode.assert_awaited_once_with(
+            name="Episode Name",
+            episode_body="Episode body",
+            source_description="desc",
+            source="text",
+            group_id="group-a",
+            reference_time=mock_client.add_episode.await_args.kwargs["reference_time"],
+            entity_types=[],
+            uuid="ep-1",
+            custom_extraction_instructions="Preserve original language.",
+        )
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- expose custom_extraction_instructions on the dd_memory MCP tool
- forward the field through queue_service into Graphiti.add_episode
- add a unit test covering the pass-through behavior

## Testing
- python -m pytest tests/test_queue_service.py -q

Closes #1380