### PR TITLE
fix(mcp): preserve default temperature for non-openai llms

### DIFF
--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -94,6 +94,26 @@ def _validate_api_key(provider_name: str, api_key: str | None, logger) -> str:
     return api_key
 
 
+def _build_graphiti_llm_config(
+    *,
+    api_key: str,
+    model: str,
+    max_tokens: int,
+    temperature: float | None,
+    base_url: str | None = None,
+) -> GraphitiLLMConfig:
+    kwargs = {
+        'api_key': api_key,
+        'model': model,
+        'max_tokens': max_tokens,
+    }
+    if temperature is not None:
+        kwargs['temperature'] = temperature
+    if base_url is not None:
+        kwargs['base_url'] = base_url
+    return GraphitiLLMConfig(**kwargs)
+
+
 class LLMClientFactory:
     """Factory for creating LLM clients based on configuration."""
 
@@ -199,7 +219,7 @@ class LLMClientFactory:
                 api_key = config.providers.anthropic.api_key
                 _validate_api_key('Anthropic', api_key, logger)
 
-                llm_config = GraphitiLLMConfig(
+                llm_config = _build_graphiti_llm_config(
                     api_key=api_key,
                     model=config.model,
                     temperature=config.temperature,
@@ -216,7 +236,7 @@ class LLMClientFactory:
                 api_key = config.providers.gemini.api_key
                 _validate_api_key('Gemini', api_key, logger)
 
-                llm_config = GraphitiLLMConfig(
+                llm_config = _build_graphiti_llm_config(
                     api_key=api_key,
                     model=config.model,
                     temperature=config.temperature,
@@ -233,7 +253,7 @@ class LLMClientFactory:
                 api_key = config.providers.groq.api_key
                 _validate_api_key('Groq', api_key, logger)
 
-                llm_config = GraphitiLLMConfig(
+                llm_config = _build_graphiti_llm_config(
                     api_key=api_key,
                     base_url=config.providers.groq.api_url,
                     model=config.model,

--- a/mcp_server/tests/test_factories.py
+++ b/mcp_server/tests/test_factories.py
@@ -1,0 +1,77 @@
+from config.schema import (
+    AnthropicProviderConfig,
+    GeminiProviderConfig,
+    GroqProviderConfig,
+    LLMConfig,
+    LLMProvidersConfig,
+)
+from services import factories
+
+
+class DummyClient:
+    def __init__(self, config, **kwargs):
+        self.config = config
+        self.temperature = config.temperature
+        self.kwargs = kwargs
+
+
+def _make_llm_config(provider: str, temperature: float | None) -> LLMConfig:
+    providers = LLMProvidersConfig()
+    if provider == 'anthropic':
+        providers.anthropic = AnthropicProviderConfig(api_key='test-anthropic-key')
+        model = 'claude-sonnet-4-5-20250929'
+    elif provider == 'gemini':
+        providers.gemini = GeminiProviderConfig(api_key='test-gemini-key')
+        model = 'gemini-2.5-pro'
+    elif provider == 'groq':
+        providers.groq = GroqProviderConfig(
+            api_key='test-groq-key',
+            api_url='https://api.groq.com/openai/v1',
+        )
+        model = 'llama-3.3-70b-versatile'
+    else:
+        raise ValueError(f'Unsupported provider for test: {provider}')
+
+    return LLMConfig(
+        provider=provider,
+        model=model,
+        temperature=temperature,
+        max_tokens=2048,
+        providers=providers,
+    )
+
+
+def test_anthropic_uses_core_default_temperature_when_unspecified(monkeypatch):
+    monkeypatch.setattr(factories, 'HAS_ANTHROPIC', True)
+    monkeypatch.setattr(factories, 'AnthropicClient', DummyClient, raising=False)
+
+    client = factories.LLMClientFactory.create(_make_llm_config('anthropic', temperature=None))
+
+    assert client.temperature == 1
+
+
+def test_gemini_uses_core_default_temperature_when_unspecified(monkeypatch):
+    monkeypatch.setattr(factories, 'HAS_GEMINI', True)
+    monkeypatch.setattr(factories, 'GeminiClient', DummyClient, raising=False)
+
+    client = factories.LLMClientFactory.create(_make_llm_config('gemini', temperature=None))
+
+    assert client.temperature == 1
+
+
+def test_groq_uses_core_default_temperature_when_unspecified(monkeypatch):
+    monkeypatch.setattr(factories, 'HAS_GROQ', True)
+    monkeypatch.setattr(factories, 'GroqClient', DummyClient, raising=False)
+
+    client = factories.LLMClientFactory.create(_make_llm_config('groq', temperature=None))
+
+    assert client.temperature == 1
+
+
+def test_explicit_temperature_is_preserved_for_non_openai_providers(monkeypatch):
+    monkeypatch.setattr(factories, 'HAS_ANTHROPIC', True)
+    monkeypatch.setattr(factories, 'AnthropicClient', DummyClient, raising=False)
+
+    client = factories.LLMClientFactory.create(_make_llm_config('anthropic', temperature=0.42))
+
+    assert client.temperature == 0.42


### PR DESCRIPTION
## Summary
- stop overriding Graphiti core's default temperature when MCP config leaves temperature unset for Anthropic, Gemini, and Groq providers
- keep explicit temperature overrides intact
- add focused factory regression tests for unset and explicit temperature behavior

## Testing
- .venv\\Scripts\\python.exe -m pytest mcp_server\\tests\\test_factories.py -q

Closes #1103