### PR TITLE
 mcp_server: fix passing throught OpenAI base_url

### DIFF
--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -121,6 +121,7 @@ class LLMClientFactory:
 
                 llm_config = CoreLLMConfig(
                     api_key=api_key,
+                    base_url=config.providers.openai.api_url,
                     model=config.model,
                     small_model=small_model,
                     temperature=config.temperature,


### PR DESCRIPTION
## Summary
The OpenAI API base URL was not being passed from the config to the LLM client. This MR fixes it.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests