### PR TITLE
Fix FalkorDB fulltext search performance

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import logging
+import os
 from typing import Any
 
 from graphiti_core.driver.driver import GraphProvider
@@ -108,9 +109,16 @@ def _build_falkor_fulltext_query(
 
     sanitized_query = _sanitize(query)
 
-    # Remove stopwords and empty tokens
+    # Remove stopwords, one-character noise tokens, and cap OR-term count.
+    # Long RedisSearch OR queries can become pathological on FalkorDB during
+    # dedup/search, even before graph traversal work begins.
     query_words = sanitized_query.split()
-    filtered_words = [word for word in query_words if word and word.lower() not in STOPWORDS]
+    filtered_words = [
+        word for word in query_words if word and len(word) > 1 and word.lower() not in STOPWORDS
+    ]
+    max_terms = int(os.environ.get('FALKORDB_FULLTEXT_MAX_TERMS', '6'))
+    if max_terms > 0:
+        filtered_words = filtered_words[:max_terms]
     sanitized_query = ' | '.join(filtered_words)
 
     if len(sanitized_query.split(' ')) + len(group_ids or '') >= max_query_length:
@@ -293,29 +301,74 @@ class FalkorSearchOperations(SearchOperations):
             filter_queries.append('e.group_id IN $group_ids')
             filter_params['group_ids'] = group_ids
 
-        filter_query = ''
-        if filter_queries:
-            filter_query = ' WHERE ' + (' AND '.join(filter_queries))
+        endpoint_filter_queries = [
+            filter_query
+            for filter_query in filter_queries
+            if filter_query.startswith('n:') or ' m:' in filter_query
+        ]
+        edge_filter_queries = [
+            filter_query
+            for filter_query in filter_queries
+            if filter_query not in endpoint_filter_queries
+        ]
 
-        cypher = (
-            get_relationships_query(
-                'edge_name_and_fact', limit=limit, provider=GraphProvider.FALKORDB
+        edge_filter_query = ''
+        if edge_filter_queries:
+            edge_filter_query = ' WHERE ' + (' AND '.join(edge_filter_queries))
+
+        endpoint_filter_query = ''
+        if endpoint_filter_queries:
+            endpoint_filter_query = ' WHERE ' + (' AND '.join(endpoint_filter_queries))
+
+        if search_filter.node_labels is None:
+            cypher = (
+                get_relationships_query(
+                    'edge_name_and_fact', limit=limit, provider=GraphProvider.FALKORDB
+                )
+                + """
+                YIELD relationship AS e, score
+                """
+                + edge_filter_query
+                + """
+                WITH e, score
+                ORDER BY score DESC
+                LIMIT $limit
+                RETURN
+                    e.uuid AS uuid,
+                    e.source_node_uuid AS source_node_uuid,
+                    e.target_node_uuid AS target_node_uuid,
+                    e.group_id AS group_id,
+                    e.created_at AS created_at,
+                    e.name AS name,
+                    e.fact AS fact,
+                    e.episodes AS episodes,
+                    e.expired_at AS expired_at,
+                    e.valid_at AS valid_at,
+                    e.invalid_at AS invalid_at,
+                    properties(e) AS attributes
+                """
             )
-            + """
-            YIELD relationship AS rel, score
-            MATCH (n:Entity)-[e:RELATES_TO {uuid: rel.uuid}]->(m:Entity)
-            """
-            + filter_query
-            + """
-            WITH e, score, n, m
-            RETURN
-            """
-            + get_entity_edge_return_query(GraphProvider.FALKORDB)
-            + """
-            ORDER BY score DESC
-            LIMIT $limit
-            """
-        )
+        else:
+            cypher = (
+                get_relationships_query(
+                    'edge_name_and_fact', limit=limit, provider=GraphProvider.FALKORDB
+                )
+                + """
+                YIELD relationship AS rel, score
+                """
+                + edge_filter_query.replace('e.', 'rel.')
+                + """
+                WITH rel, score
+                ORDER BY score DESC
+                LIMIT $limit
+                MATCH (n:Entity)-[e:RELATES_TO {uuid: rel.uuid}]->(m:Entity)
+                """
+                + endpoint_filter_query
+                + """
+                RETURN
+                """
+                + get_entity_edge_return_query(GraphProvider.FALKORDB)
+            )
 
         records, _, _ = await executor.execute_query(
             cypher,
@@ -454,7 +507,7 @@ class FalkorSearchOperations(SearchOperations):
         filter_params: dict[str, Any] = {}
         group_filter_query = ''
         if group_ids is not None:
-            group_filter_query += '\nAND e.group_id IN $group_ids'
+            group_filter_query = 'WHERE e.group_id IN $group_ids'
             filter_params['group_ids'] = group_ids
 
         cypher = (
@@ -462,19 +515,16 @@ class FalkorSearchOperations(SearchOperations):
                 'episode_content', '$query', limit=limit, provider=GraphProvider.FALKORDB
             )
             + """
-            YIELD node AS episode, score
-            MATCH (e:Episodic)
-            WHERE e.uuid = episode.uuid
+            YIELD node AS e, score
             """
             + group_filter_query
             + """
+            WITH e, score
+            ORDER BY score DESC
+            LIMIT $limit
             RETURN
             """
             + EPISODIC_NODE_RETURN
-            + """
-            ORDER BY score DESC
-            LIMIT $limit
-            """
         )
 
         records, _, _ = await executor.execute_query(

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -17,7 +17,7 @@ limitations under the License.
 import asyncio
 import datetime
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from falkordb import Graph as FalkorGraph
@@ -156,6 +156,7 @@ class FalkorDriver(GraphDriver):
         self._has_episode_edge_ops = FalkorHasEpisodeEdgeOperations()
         self._next_episode_edge_ops = FalkorNextEpisodeEdgeOperations()
         self._search_ops = FalkorSearchOperations()
+        self.search_interface = cast(Any, self._search_ops)
         self._graph_ops = FalkorGraphMaintenanceOperations()
 
         # Schedule the indices and constraints to be built

--- a/tests/driver/test_falkordb_driver.py
+++ b/tests/driver/test_falkordb_driver.py
@@ -22,6 +22,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.falkordb.operations.search_ops import (
+    FalkorSearchOperations,
+    _build_falkor_fulltext_query,
+)
+from graphiti_core.search.search_filters import SearchFilters
 
 try:
     from graphiti_core.driver.falkordb_driver import FalkorDriver, FalkorDriverSession
@@ -69,6 +74,12 @@ class TestFalkorDriver:
     def test_provider(self):
         """Test driver provider identification."""
         assert self.driver.provider == GraphProvider.FALKORDB
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def test_search_interface_uses_falkor_search_operations(self):
+        """Test search_utils dispatches FalkorDB searches to provider-specific operations."""
+        assert self.driver.search_interface is self.driver.search_ops
+        assert isinstance(self.driver.search_interface, FalkorSearchOperations)
 
     @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
     def test_get_graph_with_name(self):
@@ -360,6 +371,87 @@ class TestDatetimeConversion:
         assert convert_datetimes_to_strings(123) == 123
         assert convert_datetimes_to_strings(None) is None
         assert convert_datetimes_to_strings(True) is True
+
+
+class TestFalkorSearchOperations:
+    """Test FalkorDB search query generation."""
+
+    def test_fulltext_query_caps_terms_by_default(self, monkeypatch):
+        monkeypatch.delenv('FALKORDB_FULLTEXT_MAX_TERMS', raising=False)
+
+        query = _build_falkor_fulltext_query('a alpha beta gamma delta epsilon zeta eta theta iota')
+
+        assert query == ' (alpha | beta | gamma | delta | epsilon | zeta)'
+
+    def test_fulltext_query_cap_can_be_disabled(self, monkeypatch):
+        monkeypatch.setenv('FALKORDB_FULLTEXT_MAX_TERMS', '0')
+
+        query = _build_falkor_fulltext_query('alpha beta gamma delta epsilon zeta eta')
+
+        assert query == ' (alpha | beta | gamma | delta | epsilon | zeta | eta)'
+
+    @pytest.mark.asyncio
+    async def test_edge_fulltext_search_uses_edge_properties_without_node_label_filter(self):
+        executor = MagicMock()
+        executor.execute_query = AsyncMock(return_value=([], None, None))
+
+        await FalkorSearchOperations().edge_fulltext_search(
+            executor,
+            'alpha beta',
+            SearchFilters(edge_types=['related_to']),
+            group_ids=['group'],
+            limit=5,
+        )
+
+        cypher = executor.execute_query.call_args.args[0]
+        assert 'YIELD relationship AS e, score' in cypher
+        assert 'MATCH (n:Entity)-[e:RELATES_TO {uuid: rel.uuid}]->(m:Entity)' not in cypher
+        assert 'e.source_node_uuid AS source_node_uuid' in cypher
+        assert 'e.target_node_uuid AS target_node_uuid' in cypher
+        assert cypher.index('e.name in $edge_types') < cypher.index('ORDER BY score DESC')
+        assert cypher.index('ORDER BY score DESC') < cypher.index('RETURN')
+
+    @pytest.mark.asyncio
+    async def test_edge_fulltext_search_limits_before_endpoint_match_for_node_label_filter(self):
+        executor = MagicMock()
+        executor.execute_query = AsyncMock(return_value=([], None, None))
+
+        await FalkorSearchOperations().edge_fulltext_search(
+            executor,
+            'alpha beta',
+            SearchFilters(edge_types=['related_to'], node_labels=['Person']),
+            group_ids=['group'],
+            limit=5,
+        )
+
+        cypher = executor.execute_query.call_args.args[0]
+        assert 'YIELD relationship AS rel, score' in cypher
+        assert 'rel.name in $edge_types' in cypher
+        assert 'n:Person AND m:Person' in cypher
+        assert cypher.index('rel.name in $edge_types') < cypher.index('ORDER BY score DESC')
+        assert cypher.index('LIMIT $limit') < cypher.index(
+            'MATCH (n:Entity)-[e:RELATES_TO {uuid: rel.uuid}]->(m:Entity)'
+        )
+
+    @pytest.mark.asyncio
+    async def test_episode_fulltext_search_filters_and_limits_without_rebinding_node(self):
+        executor = MagicMock()
+        executor.execute_query = AsyncMock(return_value=([], None, None))
+
+        await FalkorSearchOperations().episode_fulltext_search(
+            executor,
+            'alpha beta',
+            SearchFilters(),
+            group_ids=['group'],
+            limit=5,
+        )
+
+        cypher = executor.execute_query.call_args.args[0]
+        assert 'YIELD node AS e, score' in cypher
+        assert 'MATCH (e:Episodic)' not in cypher
+        assert 'WHERE e.group_id IN $group_ids' in cypher
+        assert cypher.index('WHERE e.group_id IN $group_ids') < cypher.index('ORDER BY score DESC')
+        assert cypher.index('ORDER BY score DESC') < cypher.index('RETURN')
 
 
 # Simple integration test


### PR DESCRIPTION
## Summary

This fixes FalkorDB fulltext search paths that can become pathological on relationship-heavy graphs.

Changes:
- route high-level `search_utils` calls through `FalkorSearchOperations` by binding `FalkorDriver.search_interface`
- cap FalkorDB/RedisSearch fulltext OR terms by default, with `FALKORDB_FULLTEXT_MAX_TERMS=0` available to disable the cap
- avoid endpoint node `MATCH` work for edge fulltext results when no node-label filter is present, returning persisted `source_node_uuid` / `target_node_uuid` relationship properties instead
- when node labels require endpoint lookup, apply edge-only filters and `ORDER BY ... LIMIT` before matching endpoint nodes
- avoid the redundant episodic node rebind in `episode_fulltext_search`
- add regression coverage for the FalkorDB query builder and query generation

## Why

On FalkorDB, long RedisSearch OR queries and fulltext edge searches that `MATCH` endpoint nodes before `LIMIT` can time out even on modest graphs. In a real graph with roughly 7k `RELATES_TO` edges, the previous edge fulltext query shape consistently hit a 15s timeout. The optimized shape limits fulltext hits before endpoint lookup, and skips endpoint lookup entirely when endpoint labels are not part of the filter.

## Validation

- `uv run --extra dev pytest tests/driver/test_falkordb_driver.py` passed: 29 passed, 1 skipped
- `uv run --extra dev pytest tests/driver/test_falkordb_driver.py tests/utils/search/test_search_security.py` passed: 37 passed, 1 skipped
- `uv run --extra dev ruff format --check graphiti_core/driver/falkordb_driver.py graphiti_core/driver/falkordb/operations/search_ops.py tests/driver/test_falkordb_driver.py` passed
- `uv run --extra dev ruff check graphiti_core/driver/falkordb_driver.py graphiti_core/driver/falkordb/operations/search_ops.py tests/driver/test_falkordb_driver.py` passed
- `uv run --extra dev pyright graphiti_core/driver/falkordb_driver.py graphiti_core/driver/falkordb/operations/search_ops.py` passed
- `make lint` passed

`make test` was attempted, but this local environment hung for several minutes on `tests/cross_encoder/test_bge_reranker_client_int.py` while running `pytest -m "not integration"`. I stopped that run and validated the changed FalkorDB/search-security scope directly.
