### PR TITLE
fix: force batch_size=1 for gemini-embedding-2 models

### DIFF
--- a/graphiti_core/embedder/gemini.py
+++ b/graphiti_core/embedder/gemini.py
@@ -76,8 +76,13 @@ class GeminiEmbedder(EmbedderClient):
         else:
             self.client = client
 
-        if batch_size is None and self.config.embedding_model == 'gemini-embedding-001':
-            # Gemini API has a limit on the number of instances per request
+        if batch_size is None and self.config.embedding_model in (
+            'gemini-embedding-001',
+            'gemini-embedding-2-preview',
+            'gemini-embedding-2',
+        ):
+            # These models do not support batching via embed_content(contents=[...]).
+            # They treat the list as parts of a single document and return one embedding.
             # https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api
             self.batch_size = 1
         elif batch_size is None:
@@ -145,6 +150,12 @@ class GeminiEmbedder(EmbedderClient):
 
                 if not result.embeddings or len(result.embeddings) == 0:
                     raise Exception('No embeddings returned')
+
+                if len(result.embeddings) != len(batch):
+                    raise Exception(
+                        f'Batch embedding returned {len(result.embeddings)} vectors '
+                        f'for {len(batch)} inputs; model may not support batching'
+                    )
 
                 # Process embeddings from this batch
                 for embedding in result.embeddings:

--- a/tests/embedder/test_gemini.py
+++ b/tests/embedder/test_gemini.py
@@ -390,6 +390,82 @@ class TestGeminiEmbedderCreateBatch:
         assert len(result) == 2
         assert all(len(embedding) == 512 for embedding in result)
 
+    @pytest.mark.asyncio
+    @patch('google.genai.Client')
+    async def test_create_batch_length_mismatch_falls_back_to_individual(
+        self, mock_client_class, mock_gemini_client: Any
+    ) -> None:
+        """Test that create_batch falls back to individual processing when batch returns wrong count."""
+        config = GeminiEmbedderConfig(api_key='test_api_key', embedding_model='future-model')
+        embedder = GeminiEmbedder(config=config, batch_size=100)
+        embedder.client = mock_gemini_client
+
+        # Batch call returns only 1 embedding for 3 inputs (simulates gemini-embedding-2 behavior)
+        mock_batch_response = MagicMock()
+        mock_batch_response.embeddings = [create_gemini_embedding(0.1)]
+
+        # Individual calls each return 1 embedding
+        mock_individual_responses = [
+            MagicMock(embeddings=[create_gemini_embedding(0.1)]),
+            MagicMock(embeddings=[create_gemini_embedding(0.2)]),
+            MagicMock(embeddings=[create_gemini_embedding(0.3)]),
+        ]
+
+        mock_gemini_client.aio.models.embed_content.side_effect = [
+            mock_batch_response,
+            *mock_individual_responses,
+        ]
+
+        result = await embedder.create_batch(['Input 1', 'Input 2', 'Input 3'])
+
+        # Should fall back and produce 3 embeddings
+        assert len(result) == 3
+        # First call is the batch, next 3 are individual
+        assert mock_gemini_client.aio.models.embed_content.call_count == 4
+
+
+class TestGeminiEmbedderBatchSizeConfig:
+    """Tests for GeminiEmbedder batch_size configuration for different models."""
+
+    @patch('google.genai.Client')
+    def test_gemini_embedding_001_forces_batch_size_1(self, mock_client):
+        """Test that gemini-embedding-001 defaults to batch_size=1."""
+        config = GeminiEmbedderConfig(
+            api_key='test_api_key', embedding_model='gemini-embedding-001'
+        )
+        embedder = GeminiEmbedder(config=config)
+        assert embedder.batch_size == 1
+
+    @patch('google.genai.Client')
+    def test_gemini_embedding_2_preview_forces_batch_size_1(self, mock_client):
+        """Test that gemini-embedding-2-preview defaults to batch_size=1."""
+        config = GeminiEmbedderConfig(
+            api_key='test_api_key', embedding_model='gemini-embedding-2-preview'
+        )
+        embedder = GeminiEmbedder(config=config)
+        assert embedder.batch_size == 1
+
+    @patch('google.genai.Client')
+    def test_gemini_embedding_2_forces_batch_size_1(self, mock_client):
+        """Test that gemini-embedding-2 defaults to batch_size=1."""
+        config = GeminiEmbedderConfig(api_key='test_api_key', embedding_model='gemini-embedding-2')
+        embedder = GeminiEmbedder(config=config)
+        assert embedder.batch_size == 1
+
+    @patch('google.genai.Client')
+    def test_other_model_uses_default_batch_size(self, mock_client):
+        """Test that other models use the default batch size."""
+        config = GeminiEmbedderConfig(api_key='test_api_key', embedding_model='text-embedding-005')
+        embedder = GeminiEmbedder(config=config)
+        assert embedder.batch_size == 100
+
+    @patch('google.genai.Client')
+    def test_explicit_batch_size_overrides_model_default(self, mock_client):
+        """Test that explicitly passing batch_size overrides the model-specific default."""
+        config = GeminiEmbedderConfig(api_key='test_api_key', embedding_model='gemini-embedding-2')
+        embedder = GeminiEmbedder(config=config, batch_size=50)
+        assert embedder.batch_size == 50
+
 
 if __name__ == '__main__':
     pytest.main(['-xvs', __file__])


### PR DESCRIPTION
## Summary

Fix `GeminiEmbedder.create_batch()` silently returning fewer vectors than inputs when using `gemini-embedding-2-preview` or `gemini-embedding-2` models.

Closes #1467

## Problem

The `gemini-embedding-2*` models do not support batching via `embed_content(contents=[...])`. They treat the list as parts of a single document and return only **one** embedding vector regardless of how many strings are passed.

This caused `create_batch()` to silently return fewer vectors than inputs, leading to `ValueError` in downstream `zip(..., strict=True)` calls during entity deduplication (e.g. in `_semantic_candidate_search`).

## Fix

1. **Extend the `batch_size=1` special case** — the same defense already applied to `gemini-embedding-001` is now applied to the `-2` and `-2-preview` models. This ensures each input is sent individually, matching the API's actual behavior.

2. **Add a defensive length-mismatch check** — if a future model (or misconfiguration) causes the API to return fewer embeddings than requested, `create_batch()` now detects this and triggers the existing per-item fallback path instead of silently returning partial results.

## Tests

Added 6 new tests covering:
- `gemini-embedding-2-preview` defaults to `batch_size=1`
- `gemini-embedding-2` defaults to `batch_size=1`
- `gemini-embedding-001` still defaults to `batch_size=1` (existing behavior)
- Other models use default batch size (100)
- Explicit `batch_size` overrides model-specific default
- Length-mismatch triggers fallback to individual processing
