### PR TITLE
fix: handle backtick tokens and empty queries in FalkorDB fulltext search

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -84,6 +84,7 @@ _SEPARATOR_MAP = str.maketrans(
         '|': ' ',
         '/': ' ',
         '\\': ' ',
+        '`': ' ',
     }
 )
 
@@ -123,6 +124,10 @@ def _build_falkor_fulltext_query(
     # Remove stopwords and empty tokens
     query_words = sanitized_query.split()
     filtered_words = [word for word in query_words if word and word.lower() not in STOPWORDS]
+
+    if not filtered_words:
+        return ''
+
     sanitized_query = ' | '.join(filtered_words)
 
     if len(sanitized_query.split(' ')) + len(group_ids or '') >= max_query_length:

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -395,6 +395,7 @@ class FalkorDriver(GraphDriver):
                 '|': ' ',
                 '/': ' ',
                 '\\': ' ',
+                '`': ' ',
             }
         )
         sanitized = query.translate(separator_map)
@@ -435,6 +436,10 @@ class FalkorDriver(GraphDriver):
         # Remove stopwords and empty tokens from the sanitized query
         query_words = sanitized_query.split()
         filtered_words = [word for word in query_words if word and word.lower() not in STOPWORDS]
+
+        if not filtered_words:
+            return ''
+
         sanitized_query = ' | '.join(filtered_words)
 
         # If the query is too long return no query

--- a/tests/utils/search/test_search_security.py
+++ b/tests/utils/search/test_search_security.py
@@ -76,6 +76,55 @@ def test_falkordb_fulltext_query_rejects_invalid_group_ids():
         FalkorDriver.build_fulltext_query(driver, 'test', ['bad"group'])
 
 
+def test_falkordb_fulltext_query_strips_backticks():
+    """Backtick characters should be sanitized to prevent RediSearch syntax errors."""
+    from graphiti_core.driver.falkordb.operations.search_ops import _build_falkor_fulltext_query
+
+    result = _build_falkor_fulltext_query('`add_episode`', ['group1'])
+    # Backticks should be removed; remaining tokens joined with OR
+    assert '`' not in result
+    assert result != ''
+
+
+def test_falkordb_fulltext_query_returns_empty_on_stopwords_only():
+    """When all tokens are stopwords, return empty string instead of malformed query."""
+    from graphiti_core.driver.falkordb.operations.search_ops import _build_falkor_fulltext_query
+
+    result = _build_falkor_fulltext_query('the and is', ['group1'])
+    assert result == ''
+
+
+def test_falkordb_fulltext_query_returns_empty_on_punctuation_only():
+    """When input is all special characters, return empty string."""
+    from graphiti_core.driver.falkordb.operations.search_ops import _build_falkor_fulltext_query
+
+    result = _build_falkor_fulltext_query('!!!...???', ['group1'])
+    assert result == ''
+
+
+def test_falkordb_driver_build_fulltext_query_strips_backticks():
+    """FalkorDriver.build_fulltext_query should also strip backticks."""
+    from graphiti_core.driver.falkordb_driver import FalkorDriver
+
+    driver = MagicMock(spec=FalkorDriver)
+    driver.sanitize = FalkorDriver.sanitize.__get__(driver, FalkorDriver)
+
+    result = FalkorDriver.build_fulltext_query(driver, '`add_episode`', ['group1'])
+    assert '`' not in result
+    assert result != ''
+
+
+def test_falkordb_driver_build_fulltext_query_returns_empty_on_stopwords_only():
+    """FalkorDriver.build_fulltext_query returns empty on stopword-only input."""
+    from graphiti_core.driver.falkordb_driver import FalkorDriver
+
+    driver = MagicMock(spec=FalkorDriver)
+    driver.sanitize = FalkorDriver.sanitize.__get__(driver, FalkorDriver)
+
+    result = FalkorDriver.build_fulltext_query(driver, 'the and is', ['group1'])
+    assert result == ''
+
+
 @pytest.mark.asyncio
 async def test_shared_search_rejects_invalid_group_ids():
     clients = SimpleNamespace(


### PR DESCRIPTION
## Summary

Fix `_build_falkor_fulltext_query` producing malformed RediSearch queries that cause `ResponseError: Syntax error` during entity dedup-search.

Closes #1440

## Problem

Two distinct failure modes in the FalkorDB fulltext query builder:

1. **Backtick tokens leak through** — When an LLM extracts entity names from code-fenced text (e.g. `` `add_episode` ``), the backtick character was not in the separator map and survived sanitization, causing RediSearch parsing errors.

2. **Empty parentheses on stopword/punctuation-only input** — When stopword filtering removes all tokens, the builder still constructed `(@group_id:"…") ()` which RediSearch rejects. There was no early-return guard for the "no usable tokens" case.

## Fix

Both copies of the query builder are fixed:
- `graphiti_core/driver/falkordb/operations/search_ops.py`
- `graphiti_core/driver/falkordb_driver.py`

Changes:
1. Added backtick (`` ` ``) to the separator character map
2. Added early return of empty string when no tokens remain after sanitization + stopword filtering

## Tests

Added 5 new tests covering:
- Backtick stripping in `_build_falkor_fulltext_query`
- Empty return on stopword-only input
- Empty return on punctuation-only input
- Backtick stripping in `FalkorDriver.build_fulltext_query`
- Empty return on stopword-only input via driver method
