### PR TITLE
docs(graphiti): drop stale add_episode_bulk edge-invalidation/date-extraction note

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -1240,9 +1240,10 @@ class Graphiti:
         overwhelm system resources. Consider implementing rate limiting or chunking for
         very large batches of episodes.
 
-        Important: This method does not perform edge invalidation or date extraction steps.
-        If these operations are required, use the `add_episode` method instead for each
-        individual episode.
+        Edge invalidation and date extraction (``valid_at`` / ``invalid_at``) are
+        performed in the bulk path as well: edges flow through ``extract_edges`` and
+        ``resolve_extracted_edges`` just like in ``add_episode``, and any invalidated
+        edges are persisted alongside the newly resolved ones.
         """
         with self.tracer.start_span('add_episode_bulk') as bulk_span:
             bulk_span.add_attributes({'episode.count': len(bulk_episodes)})


### PR DESCRIPTION
## Summary

The `add_episode_bulk` docstring still carries this warning:

> Important: This method does not perform edge invalidation or date extraction steps. If these operations are required, use the `add_episode` method instead for each individual episode.

That hasn't been accurate since the bulk pipeline was rewritten to share primitives with `add_episode`. Verified end-to-end in the current code:

**Edge invalidation**

- `add_episode_bulk` calls `_resolve_nodes_and_edges_bulk` (`graphiti.py:1339`).
- `_resolve_nodes_and_edges_bulk` calls `resolve_extracted_edges` for every episode (`graphiti.py:855-867`).
- `resolve_extracted_edges` returns `(resolved_edges, invalidated_edges, new_edges)` (`edge_operations.py:332-338`).
- `add_episode_bulk` persists the union with `add_nodes_and_edges_bulk(self.driver, episodes, resolved_episodic_edges, final_hydrated_nodes, resolved_edges + invalidated_edges, self.embedder)` (`graphiti.py:1353-1360`).

**Date extraction (`valid_at` / `invalid_at`)**

- The bulk extraction path goes through `extract_nodes_and_edges_bulk` → `extract_edges`.
- `extract_edges` parses LLM-returned `valid_at` / `invalid_at` strings and stores them on the `EntityEdge` (`edge_operations.py:253-307`). This is the same primitive `add_episode` uses.

## Change

Replace the stale warning with a one-paragraph note describing the shared pipeline so users aren't steered toward the slower per-episode fallback unnecessarily.

## Out of scope

This PR does **not** touch the same `add_episode_bulk` warning that lives in the Zep documentation site (`Use add_episode_bulk only for populating empty graphs or when edge invalidation is not required.`). That page should be updated separately if the maintainers want to keep the docs in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)