### PR TITLE
fix(pydantic): use ConfigDict instead of class-based Config in SearchInterface

### DIFF
--- a/graphiti_core/driver/search_interface/search_interface.py
+++ b/graphiti_core/driver/search_interface/search_interface.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class SearchInterface(BaseModel):
@@ -32,6 +32,8 @@ class SearchInterface(BaseModel):
         - EntityNode, EpisodicNode, CommunityNode from graphiti_core.nodes
         - EntityEdge from graphiti_core.edges
     """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     async def edge_fulltext_search(
         self,
@@ -347,5 +349,3 @@ class SearchInterface(BaseModel):
         """
         raise NotImplementedError
 
-    class Config:
-        arbitrary_types_allowed = True


### PR DESCRIPTION
## Summary

Resolves #1477. `SearchInterface` declares a Pydantic v1-style `class Config:` which Pydantic v2 deprecated and v3 will reject as a hard error. This PR swaps to the v2 idiom — one-line behavior preserved.

## Diff

```diff
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict


 class SearchInterface(BaseModel):
     """..."""

+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     async def edge_fulltext_search(...): ...

-    class Config:
-        arbitrary_types_allowed = True
```

## Verification

- `from graphiti_core.driver.search_interface.search_interface import SearchInterface; SearchInterface.model_config` returns `{'arbitrary_types_allowed': True}` — same configuration as before, no semantic change.
- `python -W error::DeprecationWarning -c "import graphiti_core"` no longer raises.

## Test plan

- [x] No behavior change (`arbitrary_types_allowed=True` preserved).
- [ ] CI run by maintainers; happy to address feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)