### PR TITLE
fix: pass configured Neo4j database to execute_query

### DIFF
--- a/graphiti_core/driver/neo4j_driver.py
+++ b/graphiti_core/driver/neo4j_driver.py
@@ -161,12 +161,10 @@ class Neo4jDriver(GraphDriver):
                 raise
 
     async def execute_query(self, cypher_query_: LiteralString, **kwargs: Any) -> EagerResult:
-        # Check if database_ is provided in kwargs.
-        # If not populated, set the value to retain backwards compatibility
         params = kwargs.pop('params', None)
         if params is None:
             params = {}
-        params.setdefault('database_', self._database)
+        kwargs.setdefault('database_', self._database)
 
         try:
             result = await self.client.execute_query(cypher_query_, parameters_=params, **kwargs)

--- a/tests/driver/test_neo4j_driver.py
+++ b/tests/driver/test_neo4j_driver.py
@@ -1,0 +1,78 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graphiti_core.driver.neo4j_driver import Neo4jDriver
+
+
+def build_driver(database: str = 'test_db') -> tuple[Neo4jDriver, MagicMock]:
+    mock_client = MagicMock()
+    mock_client.execute_query = AsyncMock(return_value=([], None, None))
+
+    with (
+        patch('graphiti_core.driver.neo4j_driver.AsyncGraphDatabase.driver') as mock_driver,
+        patch('asyncio.get_running_loop', side_effect=RuntimeError),
+    ):
+        mock_driver.return_value = mock_client
+        driver = Neo4jDriver('bolt://localhost:7687', 'neo4j', 'password', database=database)
+
+    return driver, mock_client
+
+
+@pytest.mark.asyncio
+async def test_execute_query_passes_configured_database_as_driver_argument():
+    driver, mock_client = build_driver(database='tenant_db')
+
+    await driver.execute_query('MATCH (n {uuid: $uuid}) RETURN n', uuid='node-uuid', routing_='r')
+
+    mock_client.execute_query.assert_awaited_once_with(
+        'MATCH (n {uuid: $uuid}) RETURN n',
+        parameters_={},
+        uuid='node-uuid',
+        routing_='r',
+        database_='tenant_db',
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_query_keeps_cypher_params_separate_from_database_argument():
+    driver, mock_client = build_driver(database='tenant_db')
+    params = {'uuid': 'node-uuid'}
+
+    await driver.execute_query('MATCH (n {uuid: $uuid}) RETURN n', params=params)
+
+    mock_client.execute_query.assert_awaited_once_with(
+        'MATCH (n {uuid: $uuid}) RETURN n',
+        parameters_=params,
+        database_='tenant_db',
+    )
+    assert 'database_' not in params
+
+
+@pytest.mark.asyncio
+async def test_execute_query_preserves_explicit_database_argument():
+    driver, mock_client = build_driver(database='tenant_db')
+
+    await driver.execute_query('RETURN 1', database_='override_db')
+
+    mock_client.execute_query.assert_awaited_once_with(
+        'RETURN 1',
+        parameters_={},
+        database_='override_db',
+    )


### PR DESCRIPTION
## Summary
Fixes `Neo4jDriver.execute_query()` so the configured database is passed to the Neo4j driver as the top-level `database_` argument instead of being inserted into Cypher `parameters_`.

This keeps query parameters separate from driver configuration and allows read/search queries to run against the configured database instead of Neo4j's default database.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation/Tests

## Objective
Bug fix for configured Neo4j databases: writes already use `session(database=self._database)`, but reads through `execute_query()` were not selecting the configured database.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

Validation run:
- `uv run --extra dev pytest tests/driver/test_neo4j_driver.py`
- `uv run --extra dev pytest tests/driver`
- `uv run --extra dev ruff format graphiti_core/driver/neo4j_driver.py tests/driver/test_neo4j_driver.py`
- `uv run --extra dev ruff check graphiti_core/driver/neo4j_driver.py tests/driver/test_neo4j_driver.py`
- `uv run --extra dev pyright ./graphiti_core`

I also started `DISABLE_FALKORDB=1 DISABLE_KUZU=1 DISABLE_NEPTUNE=1 uv run --extra dev pytest -m "not integration"`; it progressed through the driver tests but then hit repeated errors in existing graph tests outside this driver change, so I stopped it and kept the validation scoped to the touched driver path.

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Closes #1481
