### PR TITLE
fix: unpack community results from semaphore_gather in add_episode

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -1182,13 +1182,15 @@ class Graphiti:
                 communities = []
                 community_edges = []
                 if update_communities:
-                    communities, community_edges = await semaphore_gather(
+                    community_results = await semaphore_gather(
                         *[
                             update_community(self.driver, self.llm_client, self.embedder, node)
                             for node in nodes
                         ],
                         max_coroutines=self.max_coroutines,
                     )
+                    communities = [c for r in community_results for c in r[0]]
+                    community_edges = [e for r in community_results for e in r[1]]
 
                 end = time()
 

--- a/tests/test_community_update_unpack.py
+++ b/tests/test_community_update_unpack.py
@@ -1,0 +1,92 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""
+Regression test for: semaphore_gather unpack bug in add_episode with update_communities=True.
+
+Previously, `semaphore_gather` returned a list of (communities, edges) tuples — one per
+extracted node — but the code tried to unpack the whole list as two variables:
+
+    communities, community_edges = await semaphore_gather(...)
+
+This raised ValueError for any episode that extracted at least one node.
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graphiti_core.edges import CommunityEdge
+from graphiti_core.helpers import semaphore_gather
+from graphiti_core.nodes import CommunityNode, EntityNode
+
+pytest_plugins = ('pytest_asyncio',)
+
+
+@pytest.mark.asyncio
+async def test_semaphore_gather_community_results_flatten():
+    """semaphore_gather returns a list of tuples; verify the flatten logic is correct."""
+    community_node = CommunityNode(
+        name='test_community',
+        labels=[],
+        created_at=datetime.now(),
+        group_id='test',
+        summary='test summary',
+    )
+    community_edge = MagicMock(spec=CommunityEdge)
+
+    async def mock_update_community(*args, **kwargs):
+        return ([community_node], [community_edge])
+
+    entity_nodes = [
+        EntityNode(name='node_1', labels=[], created_at=datetime.now(), group_id='test'),
+        EntityNode(name='node_2', labels=[], created_at=datetime.now(), group_id='test'),
+    ]
+
+    # This is the fixed pattern — previously the code tried:
+    #   communities, community_edges = await semaphore_gather(...)
+    # which raises ValueError because semaphore_gather returns a list of N tuples.
+    results = await semaphore_gather(
+        *[mock_update_community(node) for node in entity_nodes],
+    )
+
+    # Verify semaphore_gather returns a list of tuples (one per coroutine)
+    assert len(results) == 2
+    assert isinstance(results[0], tuple)
+
+    # Verify the flatten produces the correct lists
+    communities = [c for r in results for c in r[0]]
+    community_edges_out = [e for r in results for e in r[1]]
+
+    assert len(communities) == 2
+    assert all(c is community_node for c in communities)
+    assert len(community_edges_out) == 2
+    assert all(e is community_edge for e in community_edges_out)
+
+
+@pytest.mark.asyncio
+async def test_semaphore_gather_unpack_raises_without_fix():
+    """Demonstrate that the old unpack pattern fails — confirms the bug existed."""
+    async def mock_update_community(*args):
+        return ([MagicMock(spec=CommunityNode)], [MagicMock(spec=CommunityEdge)])
+
+    results = await semaphore_gather(mock_update_community('node'))
+
+    # Old code: `communities, community_edges = results` would raise ValueError
+    # because results is a list of 1 tuple, not 2 items.
+    with pytest.raises(ValueError, match='not enough values to unpack'):
+        communities, community_edges = results

--- a/tests/test_community_update_unpack.py
+++ b/tests/test_community_update_unpack.py
@@ -12,9 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-"""
 
-"""
 Regression test for: semaphore_gather unpack bug in add_episode with update_communities=True.
 
 Previously, `semaphore_gather` returned a list of (communities, edges) tuples — one per
@@ -26,7 +24,7 @@ This raised ValueError for any episode that extracted at least one node.
 """
 
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -81,6 +79,7 @@ async def test_semaphore_gather_community_results_flatten():
 @pytest.mark.asyncio
 async def test_semaphore_gather_unpack_raises_without_fix():
     """Demonstrate that the old unpack pattern fails — confirms the bug existed."""
+
     async def mock_update_community(*args):
         return ([MagicMock(spec=CommunityNode)], [MagicMock(spec=CommunityEdge)])
 


### PR DESCRIPTION
## Summary

Fixes a `ValueError: not enough values to unpack (expected 2, got N)` crash in `add_episode` when `update_communities=True`.

## Type of Change
- [x] Bug fix

## Objective

`semaphore_gather` returns a **list** of results — one `(communities, edges)` tuple per coroutine (one per extracted node). The previous code tried to unpack that list directly as two variables:

```python
communities, community_edges = await semaphore_gather(
    *[update_community(...) for node in nodes],
    max_coroutines=self.max_coroutines,
)
```

This raises `ValueError: not enough values to unpack (expected 2, got N)` for any episode that extracts at least one node, making `add_episode` with `update_communities=True` entirely broken.

**Fix:** collect into a results list, then flatten:

```python
community_results = await semaphore_gather(...)
communities = [c for r in community_results for c in r[0]]
community_edges = [e for r in community_results for e in r[1]]
```

## Testing
- [x] Unit tests added/updated (`tests/test_community_update_unpack.py`)
- [ ] Integration tests added/updated
- [x] All existing tests pass

Two unit tests:
1. `test_semaphore_gather_community_results_flatten` — verifies the fixed flatten logic correctly collects communities and edges across multiple nodes
2. `test_semaphore_gather_unpack_raises_without_fix` — demonstrates the old pattern raises `ValueError`, confirming the bug existed

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] No secrets or sensitive information committed

## Related Issues

Reproduces on `graphiti-core==0.29.0`. Verified fix locally.