### PR TITLE
fix: group bm25 filters for multiple group ids

### DIFF
--- a/graphiti_core/driver/neo4j/operations/search_ops.py
+++ b/graphiti_core/driver/neo4j/operations/search_ops.py
@@ -59,11 +59,9 @@ def _build_neo4j_fulltext_query(
     validate_group_ids(group_ids)
 
     group_ids_filter_list = [f'group_id:"{g}"' for g in group_ids] if group_ids is not None else []
-    group_ids_filter = ''
-    for f in group_ids_filter_list:
-        group_ids_filter += f if not group_ids_filter else f' OR {f}'
-
-    group_ids_filter += ' AND ' if group_ids_filter else ''
+    group_ids_filter = (
+        f'({" OR ".join(group_ids_filter_list)}) AND ' if group_ids_filter_list else ''
+    )
 
     lucene_query = lucene_sanitize(query)
     if len(lucene_query.split(' ')) + len(group_ids or '') >= max_query_length:

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -97,11 +97,9 @@ def fulltext_query(query: str, group_ids: list[str] | None, driver: GraphDriver)
         if group_ids is not None
         else []
     )
-    group_ids_filter = ''
-    for f in group_ids_filter_list:
-        group_ids_filter += f if not group_ids_filter else f' OR {f}'
-
-    group_ids_filter += ' AND ' if group_ids_filter else ''
+    group_ids_filter = (
+        f'({" OR ".join(group_ids_filter_list)}) AND ' if group_ids_filter_list else ''
+    )
 
     lucene_query = lucene_sanitize(query)
     # If the lucene query is too long return no query

--- a/tests/utils/search/test_search_security.py
+++ b/tests/utils/search/test_search_security.py
@@ -58,9 +58,23 @@ def test_fulltext_query_rejects_invalid_group_ids():
         fulltext_query('test', ['bad"group'], driver)
 
 
+def test_fulltext_query_groups_multiple_group_ids():
+    driver = SimpleNamespace(provider=GraphProvider.NEO4J, fulltext_syntax='')
+
+    query = fulltext_query('alice bob', ['group-a', 'group-b'], driver)
+
+    assert query == '(group_id:"group-a" OR group_id:"group-b") AND (alice bob)'
+
+
 def test_build_neo4j_fulltext_query_rejects_invalid_group_ids():
     with pytest.raises(GroupIdValidationError, match='must contain only alphanumeric'):
         _build_neo4j_fulltext_query('test', ['bad"group'])
+
+
+def test_build_neo4j_fulltext_query_groups_multiple_group_ids():
+    query = _build_neo4j_fulltext_query('alice bob', ['group-a', 'group-b'])
+
+    assert query == '(group_id:"group-a" OR group_id:"group-b") AND (alice bob)'
 
 
 def test_falkordb_fulltext_query_rejects_invalid_group_ids():


### PR DESCRIPTION
## Summary
Groups multiple Neo4j BM25 `group_id` filters before appending the full-text query, so searches with more than one group constrain results to any requested group instead of letting Lucene precedence bind the search terms only to the last group.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
Fix multi-group BM25 search filtering for both the shared search utility path and the Neo4j search operations helper.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

Validation run:
- `DISABLE_FALKORDB=1 DISABLE_KUZU=1 DISABLE_NEPTUNE=1 uv run pytest tests/utils/search/test_search_security.py::test_fulltext_query_rejects_invalid_group_ids tests/utils/search/test_search_security.py::test_fulltext_query_groups_multiple_group_ids tests/utils/search/test_search_security.py::test_build_neo4j_fulltext_query_rejects_invalid_group_ids tests/utils/search/test_search_security.py::test_build_neo4j_fulltext_query_groups_multiple_group_ids`
- `uv run ruff format graphiti_core/search/search_utils.py graphiti_core/driver/neo4j/operations/search_ops.py tests/utils/search/test_search_security.py --check`
- `uv run ruff check graphiti_core/search/search_utils.py graphiti_core/driver/neo4j/operations/search_ops.py tests/utils/search/test_search_security.py`
- `git diff --check`

Note: the full `tests/utils/search/test_search_security.py` file was not run in this local environment because the existing FalkorDB-specific test imports optional FalkorDB extras that are not installed here.

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Closes #1249
