### PR TITLE
fix: avoid FalkorDB edge rematch scans

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -302,8 +302,8 @@ class FalkorSearchOperations(SearchOperations):
                 'edge_name_and_fact', limit=limit, provider=GraphProvider.FALKORDB
             )
             + """
-            YIELD relationship AS rel, score
-            MATCH (n:Entity)-[e:RELATES_TO {uuid: rel.uuid}]->(m:Entity)
+            YIELD relationship AS e, score
+            WITH e, score, startNode(e) AS n, endNode(e) AS m
             """
             + filter_query
             + """
@@ -415,7 +415,9 @@ class FalkorSearchOperations(SearchOperations):
             UNWIND $bfs_origin_node_uuids AS origin_uuid
             MATCH path = (origin {{uuid: origin_uuid}})-[:RELATES_TO|MENTIONS*1..{max_depth}]->(:Entity)
             UNWIND relationships(path) AS rel
-            MATCH (n:Entity)-[e:RELATES_TO {{uuid: rel.uuid}}]-(m:Entity)
+            WITH rel
+            WHERE type(rel) = 'RELATES_TO'
+            WITH rel AS e, startNode(rel) AS n, endNode(rel) AS m
             """
             + filter_query
             + """

--- a/tests/driver/test_falkordb_search_ops.py
+++ b/tests/driver/test_falkordb_search_ops.py
@@ -1,0 +1,52 @@
+from typing import Any
+
+import pytest
+
+from graphiti_core.driver.falkordb.operations.search_ops import FalkorSearchOperations
+from graphiti_core.search.search_filters import SearchFilters
+
+
+class RecordingExecutor:
+    def __init__(self):
+        self.cypher_query = ''
+        self.params: dict[str, Any] = {}
+
+    async def execute_query(self, cypher_query_: str, **kwargs: Any):
+        self.cypher_query = cypher_query_
+        self.params = kwargs
+        return [], None, None
+
+
+@pytest.mark.asyncio
+async def test_edge_fulltext_search_uses_returned_relationship_endpoints():
+    executor = RecordingExecutor()
+    operations = FalkorSearchOperations()
+
+    await operations.edge_fulltext_search(
+        executor,
+        'api test system',
+        SearchFilters(),
+        group_ids=['group-a'],
+    )
+
+    assert 'YIELD relationship AS e, score' in executor.cypher_query
+    assert 'WITH e, score, startNode(e) AS n, endNode(e) AS m' in executor.cypher_query
+    assert 'uuid: rel.uuid' not in executor.cypher_query
+
+
+@pytest.mark.asyncio
+async def test_edge_bfs_search_uses_path_relationship_endpoints():
+    executor = RecordingExecutor()
+    operations = FalkorSearchOperations()
+
+    await operations.edge_bfs_search(
+        executor,
+        ['origin-uuid'],
+        2,
+        SearchFilters(),
+        group_ids=['group-a'],
+    )
+
+    assert "WHERE type(rel) = 'RELATES_TO'" in executor.cypher_query
+    assert 'WITH rel AS e, startNode(rel) AS n, endNode(rel) AS m' in executor.cypher_query
+    assert 'uuid: rel.uuid' not in executor.cypher_query


### PR DESCRIPTION
## Summary
Avoids the FalkorDB edge search re-MATCH pattern that scans `RELATES_TO` edges by `uuid` after the full-text procedure or BFS path traversal has already produced the relationship.

The full-text path now uses the returned relationship directly, and the BFS path filters path relationships to `RELATES_TO` before deriving source/target nodes with `startNode` / `endNode`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation/Tests

## Objective
Fix the FalkorDB edge search query shape described in #1272 so edge endpoint lookup is linear in the returned relationships instead of forcing a relationship re-scan by UUID.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

Validation run:
- `DISABLE_FALKORDB=1 DISABLE_KUZU=1 DISABLE_NEPTUNE=1 uv run pytest tests/driver/test_falkordb_search_ops.py`
- `uv run ruff format graphiti_core/driver/falkordb/operations/search_ops.py tests/driver/test_falkordb_search_ops.py --check`
- `uv run ruff check graphiti_core/driver/falkordb/operations/search_ops.py tests/driver/test_falkordb_search_ops.py`
- `git diff --check`

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Closes #1272
