### PR TITLE
fix: scope make test to core tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ lint:
 
 # Run tests
 test:
-	DISABLE_FALKORDB=1 DISABLE_KUZU=1 DISABLE_NEPTUNE=1 $(PYTEST) -m "not integration"
+	DISABLE_FALKORDB=1 DISABLE_KUZU=1 DISABLE_NEPTUNE=1 $(PYTEST) tests/ -m "not integration"
 
 # Run format, lint, and test
 check: format lint test


### PR DESCRIPTION
## Summary
- limit the Makefile test target to the repository core tests directory
- avoid collecting mcp_server/tests from the root pytest run
- keep the existing non-integration marker and backend disable flags unchanged

Closes #1180

## Test plan
- make -n test
- DISABLE_FALKORDB=1 DISABLE_KUZU=1 DISABLE_NEPTUNE=1 uv run pytest tests/ -m "not integration" --collect-only -q

The collect-only run no longer reaches the reported mcp_server/tests import error. It stops later in this local environment on optional dependency setup for sentence_transformers/torch and voyageai.