### PR TITLE
fix: sanitize FalkorDB group ids in fulltext queries

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -102,7 +102,7 @@ def _build_falkor_fulltext_query(
     if group_ids is None or len(group_ids) == 0:
         group_filter = ''
     else:
-        escaped_group_ids = [f'"{gid}"' for gid in group_ids]
+        escaped_group_ids = [f'"{_sanitize(gid)}"' for gid in group_ids]
         group_values = '|'.join(escaped_group_ids)
         group_filter = f'(@group_id:{group_values})'
 

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -405,7 +405,7 @@ class FalkorDriver(GraphDriver):
         else:
             # Escape group_ids with quotes to prevent RediSearch syntax errors
             # with reserved words like "main" or special characters like hyphens
-            escaped_group_ids = [f'"{gid}"' for gid in group_ids]
+            escaped_group_ids = [f'"{self.sanitize(gid)}"' for gid in group_ids]
             group_values = '|'.join(escaped_group_ids)
             group_filter = f'(@group_id:{group_values})'
 

--- a/tests/utils/search/test_search_security.py
+++ b/tests/utils/search/test_search_security.py
@@ -74,6 +74,19 @@ def test_falkordb_fulltext_query_rejects_invalid_group_ids():
         FalkorDriver.build_fulltext_query(driver, 'test', ['bad"group'])
 
 
+def test_falkordb_fulltext_query_sanitizes_group_ids_for_redisearch():
+    # Import inside the test so collection still works when FalkorDB extras are unavailable.
+    from graphiti_core.driver.falkordb.operations.search_ops import _build_falkor_fulltext_query
+
+    query = _build_falkor_fulltext_query(
+        'test',
+        ['00000000-0000-0000-0000-000000000001'],
+    )
+
+    assert '@group_id:"00000000 0000 0000 0000 000000000001"' in query
+    assert '00000000-0000-0000-0000-000000000001' not in query
+
+
 @pytest.mark.asyncio
 async def test_shared_search_rejects_invalid_group_ids():
     clients = SimpleNamespace(


### PR DESCRIPTION
﻿## Summary
- sanitize FalkorDB group ids before inserting them into RediSearch fulltext filters
- keep the existing validation boundary: only already-valid group ids reach query construction
- cover a hyphenated UUID-style group id in the search security tests

## To verify
- `python -m pytest tests\utils\search\test_search_security.py -q`
- `python -m ruff check graphiti_core\driver\falkordb_driver.py graphiti_core\driver\falkordb\operations\search_ops.py tests\utils\search\test_search_security.py`
- `python -m ruff format --check graphiti_core\driver\falkordb_driver.py graphiti_core\driver\falkordb\operations\search_ops.py tests\utils\search\test_search_security.py`
- `python -m py_compile graphiti_core\driver\falkordb_driver.py graphiti_core\driver\falkordb\operations\search_ops.py tests\utils\search\test_search_security.py`

Fixes #1483
