### PR TITLE
Forward-port: attribute-hallucination guards, combined-extraction precision, saga episode-time watermarks

### DIFF
--- a/graphiti_core/driver/graph_operations/graph_operations.py
+++ b/graphiti_core/driver/graph_operations/graph_operations.py
@@ -383,18 +383,27 @@ class GraphOperationsInterface(BaseModel):
         saga_uuid: str,
         since: Any | None = None,
         limit: int = 200,
-    ) -> list[str]:
-        """Retrieve episode content strings from a saga for summarization.
+    ) -> list[tuple[str, Any]]:
+        """Retrieve episode content + reference timestamp from a saga for summarization.
 
         Args:
             driver: GraphDriver instance
             saga_uuid: UUID of the saga
-            since: Optional datetime. If provided, only returns episodes with
-                created_at after this timestamp. If None, returns all episodes.
+            since: Optional datetime compared against episode ``created_at``
+                (ingestion time). If provided, only returns episodes added
+                after this timestamp; if None, returns all episodes. Filtering
+                by ingestion time (not ``valid_at``) keeps backfilled episodes
+                with historical reference times reachable on subsequent runs.
             limit: Maximum number of episodes to return
 
         Returns:
-            list[str]: Episode content strings in chronological order
+            list[tuple[str, datetime | None]]: (content, valid_at) pairs in
+            chronological order by ``valid_at``. The ``valid_at`` value is the
+            originating episode's reference time and is used by the caller to
+            advance the saga's ``last_summarized_episode_valid_at`` field
+            (the public/temporal watermark, distinct from
+            ``last_summarized_at`` which is wall-clock and used as the
+            ingestion-time filter watermark).
         """
         raise NotImplementedError
 

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -1416,9 +1416,7 @@ class Graphiti:
                         # episode window rather than the time this run started.
                         valid_ats = [ep.valid_at for ep in episodes if ep.valid_at is not None]
                         saga_created_at = min(valid_ats) if valid_ats else now
-                        saga_node = await self._get_or_create_saga(
-                            saga, group_id, saga_created_at
-                        )
+                        saga_node = await self._get_or_create_saga(saga, group_id, saga_created_at)
                     else:
                         saga_node = saga
 

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -343,7 +343,9 @@ class Graphiti:
         """
         await self.driver.close()
 
-    async def _get_or_create_saga(self, saga_name: str, group_id: str, now: datetime) -> SagaNode:
+    async def _get_or_create_saga(
+        self, saga_name: str, group_id: str, created_at: datetime
+    ) -> SagaNode:
         """
         Get an existing saga by name or create a new one.
 
@@ -353,8 +355,11 @@ class Graphiti:
             The name of the saga.
         group_id : str
             The group id for the saga.
-        now : datetime
-            The current timestamp for creation.
+        created_at : datetime
+            Timestamp to stamp on a newly created saga. Callers should pass the
+            originating episode's reference time (``valid_at``) rather than the
+            current wall-clock time so the saga's ``created_at`` reflects the
+            episode it was minted from.
 
         Returns
         -------
@@ -382,7 +387,7 @@ class Graphiti:
                 created_at=parse_db_date(record['created_at']),  # type: ignore
             )
 
-        saga = SagaNode(name=saga_name, group_id=group_id, created_at=now)
+        saga = SagaNode(name=saga_name, group_id=group_id, created_at=created_at)
         await saga.save(self.driver)
         return saga
 
@@ -419,8 +424,8 @@ class Graphiti:
         saga_uuid: str,
         since: datetime | None = None,
         limit: int = 200,
-    ) -> list[str] | None:
-        """Retrieve episode contents for summarization, using IoC if available."""
+    ) -> list[tuple[str, datetime | None]] | None:
+        """Retrieve (content, valid_at) per episode for summarization, using IoC if available."""
         if self.driver.graph_operations_interface:
             try:
                 return await self.driver.graph_operations_interface.saga_get_episode_contents(
@@ -433,9 +438,24 @@ class Graphiti:
     async def summarize_saga(self, saga_id: str) -> SagaNode:
         """Incrementally summarize a saga using only new episodes since the last summary.
 
-        If the saga has been summarized before (``last_summarized_at`` is set),
-        only episodes added after that timestamp are fetched. The existing
-        summary is provided to the LLM as context so no information is lost.
+        Two watermarks are maintained on the saga node, with deliberately
+        different semantics:
+
+        - ``last_summarized_at`` is wall-clock and is the *filter* watermark:
+          the next run picks up any episode whose ``created_at`` (ingestion
+          time) is greater than this value. Wall-clock is the right semantics
+          here because episode ``created_at`` is monotonic with processing
+          time, so a backfilled episode added today with ``valid_at`` in the
+          past is still picked up next run.
+        - ``last_summarized_episode_valid_at`` is the *temporal* watermark:
+          the maximum ``valid_at`` (episode reference time) across the
+          episodes covered by the current summary. Consumers asking "how
+          recent is the content of this summary in event-time?" should use
+          this field, not ``last_summarized_at``.
+
+        If the saga has been summarized before, only episodes added after
+        ``last_summarized_at`` are fetched. The existing summary is provided
+        to the LLM as context so no information is lost.
 
         On the first call (no prior summary), all episodes are included.
 
@@ -461,16 +481,16 @@ class Graphiti:
         since = saga.last_summarized_at
 
         # Try IoC interface first, fall back to raw Cypher
-        episode_contents = await self._saga_get_episode_contents(
+        episodes_data = await self._saga_get_episode_contents(
             saga_id, since=since, limit=max_episodes
         )
-        if episode_contents is None:
+        if episodes_data is None:
             if since is not None:
                 records, _, _ = await self.driver.execute_query(
                     """
                     MATCH (s:Saga {uuid: $saga_uuid})-[:HAS_EPISODE]->(e:Episodic)
                     WHERE e.created_at > $since
-                    RETURN e.content AS content
+                    RETURN e.content AS content, e.valid_at AS valid_at
                     ORDER BY e.valid_at ASC, e.created_at ASC
                     LIMIT $limit
                     """,
@@ -483,7 +503,7 @@ class Graphiti:
                 records, _, _ = await self.driver.execute_query(
                     """
                     MATCH (s:Saga {uuid: $saga_uuid})-[:HAS_EPISODE]->(e:Episodic)
-                    RETURN e.content AS content
+                    RETURN e.content AS content, e.valid_at AS valid_at
                     ORDER BY e.valid_at DESC, e.created_at DESC
                     LIMIT $limit
                     """,
@@ -494,11 +514,20 @@ class Graphiti:
                 # Reverse to chronological order for the prompt
                 records = list(reversed(records))
 
-            episode_contents = [r['content'] for r in records if r.get('content')]
+            from graphiti_core.helpers import parse_db_date
 
-        if not episode_contents:
+            episodes_data = [
+                (r['content'], parse_db_date(r.get('valid_at')))
+                for r in records
+                if r.get('content')
+            ]
+
+        if not episodes_data:
             logger.info(f'No new episodes found for saga {saga_id}, skipping summary')
             return saga
+
+        episode_contents = [content for content, _ in episodes_data]
+        valid_ats = [valid_at for _, valid_at in episodes_data if valid_at is not None]
 
         context = {
             'saga_name': saga.name,
@@ -517,7 +546,21 @@ class Graphiti:
             summary = summary[:MAX_SUMMARY_CHARS]
 
         saga.summary = summary
+        # Wall-clock watermark for the next-run filter: keeps backfilled
+        # episodes (valid_at in the past, created_at = now) reachable on
+        # subsequent runs.
         saga.last_summarized_at = utc_now()
+        # Episode-time watermark for public/temporal consumers: advance only
+        # forward to the latest reference time we just summarized. If no
+        # episode in this batch carried a valid_at, leave the previous value
+        # unchanged so the field never regresses.
+        if valid_ats:
+            new_episode_watermark = max(valid_ats)
+            if (
+                saga.last_summarized_episode_valid_at is None
+                or new_episode_watermark > saga.last_summarized_episode_valid_at
+            ):
+                saga.last_summarized_episode_valid_at = new_episode_watermark
         await saga.save(self.driver)
 
         logger.info(f'Updated summary for saga {saga_id}')
@@ -695,7 +738,11 @@ class Graphiti:
         if saga is not None:
             # Get or create saga node based on input type
             if isinstance(saga, str):
-                saga_node = await self._get_or_create_saga(saga, group_id, now)
+                # Use the originating episode's reference time (valid_at) for a
+                # newly created saga so its created_at matches the episode that
+                # minted it, not the wall-clock time of this run.
+                saga_created_at = primary_episode.valid_at or now
+                saga_node = await self._get_or_create_saga(saga, group_id, saga_created_at)
             else:
                 saga_node = saga
 
@@ -1364,7 +1411,14 @@ class Graphiti:
                 if saga is not None:
                     # Get or create saga node based on input type
                     if isinstance(saga, str):
-                        saga_node = await self._get_or_create_saga(saga, group_id, now)
+                        # Anchor a newly minted saga to the earliest episode
+                        # reference time in the bulk, so created_at reflects the
+                        # episode window rather than the time this run started.
+                        valid_ats = [ep.valid_at for ep in episodes if ep.valid_at is not None]
+                        saga_created_at = min(valid_ats) if valid_ats else now
+                        saga_node = await self._get_or_create_saga(
+                            saga, group_id, saga_created_at
+                        )
                     else:
                         saga_node = saga
 

--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -349,6 +349,8 @@ class AnthropicClient(LLMClient):
         model_size: ModelSize = ModelSize.medium,
         group_id: str | None = None,
         prompt_name: str | None = None,
+        *,
+        attribute_extraction: bool = False,
     ) -> dict[str, typing.Any]:
         """
         Generate a response from the LLM.
@@ -357,6 +359,9 @@ class AnthropicClient(LLMClient):
             messages: List of message objects to send to the LLM.
             response_model: Optional Pydantic model to use for structured output.
             max_tokens: Maximum number of tokens to generate.
+            attribute_extraction: When True, prepends the shared attribute-extraction
+                framing to the system message so the strict "field descriptions are not
+                values" instruction reaches the model on Anthropic's native tool-use path.
 
         Returns:
             Dictionary containing the structured response from the LLM.
@@ -366,6 +371,7 @@ class AnthropicClient(LLMClient):
             RefusalError: If the LLM refuses to respond.
             Exception: If an error occurs during the generation process.
         """
+        self._apply_attribute_extraction_preamble(messages, attribute_extraction)
         if max_tokens is None:
             max_tokens = self.max_tokens
 

--- a/graphiti_core/llm_client/client.py
+++ b/graphiti_core/llm_client/client.py
@@ -152,6 +152,44 @@ class LLMClient(ABC):
         key_str = f'{self.model}:{message_str}'
         return hashlib.md5(key_str.encode()).hexdigest()
 
+    def _apply_attribute_extraction_preamble(
+        self, messages: list[Message], attribute_extraction: bool
+    ) -> None:
+        """Append a strict-framing instruction to the system message for attribute
+        extraction calls.
+
+        Customer-supplied entity-type schemas use ``Field(description=...)`` to describe
+        the FORMAT of a value (e.g. "Phone numbers, comma-separated"). Models — across
+        OpenAI, Anthropic, and Gemini — have been observed copying that description text
+        verbatim into the value when no real value exists, or dumping reasoning instead
+        of returning null. This preamble names the failure mode explicitly so the
+        instruction reaches every provider regardless of how structured output is wired
+        (schema injection in the prompt body, ``response_format``, native tool use, etc.).
+
+        Mutates ``messages`` in place. Idempotent so concrete-provider overrides can
+        safely call it without coordinating with the base class.
+        """
+        if not attribute_extraction or not messages:
+            return
+        # Unique sentinel so the idempotency check can't collide with prompt content
+        # that happens to mention "attribute extraction". Bump the suffix if the note
+        # text is meaningfully revised so older callers don't suppress the new copy.
+        sentinel = '<<graphiti.attr_extraction.preamble.v1>>'
+        note = (
+            f'\n\n{sentinel}\n'
+            'ATTRIBUTE EXTRACTION: Field descriptions in the response schema describe '
+            'what a real value LOOKS LIKE — they are NEVER themselves valid values and '
+            'must NEVER be copied into any field. If you have no value for a field, set '
+            'it to null; never explain the absence in the field itself.'
+        )
+        target = messages[0]
+        if sentinel in target.content:
+            return
+        if target.role == 'system':
+            target.content += note
+        else:
+            target.content = note.lstrip() + '\n\n' + target.content
+
     async def generate_response(
         self,
         messages: list[Message],
@@ -160,9 +198,15 @@ class LLMClient(ABC):
         model_size: ModelSize = ModelSize.medium,
         group_id: str | None = None,
         prompt_name: str | None = None,
+        *,
+        attribute_extraction: bool = False,
     ) -> dict[str, typing.Any]:
         if max_tokens is None:
             max_tokens = self.max_tokens
+
+        # The strict attribute-extraction framing belongs on the system message so it
+        # reaches every provider regardless of structured-output mechanism.
+        self._apply_attribute_extraction_preamble(messages, attribute_extraction)
 
         if response_model is not None:
             serialized_model = json.dumps(response_model.model_json_schema())

--- a/graphiti_core/llm_client/gemini_client.py
+++ b/graphiti_core/llm_client/gemini_client.py
@@ -368,6 +368,8 @@ class GeminiClient(LLMClient):
         model_size: ModelSize = ModelSize.medium,
         group_id: str | None = None,
         prompt_name: str | None = None,
+        *,
+        attribute_extraction: bool = False,
     ) -> dict[str, typing.Any]:
         """
         Generate a response from the Gemini language model with retry logic and error handling.
@@ -380,10 +382,14 @@ class GeminiClient(LLMClient):
             model_size (ModelSize): The size of the model to use (small or medium).
             group_id (str | None): Optional partition identifier for the graph.
             prompt_name (str | None): Optional name of the prompt for tracing.
+            attribute_extraction (bool): When True, prepends the shared attribute-extraction
+                framing to the system message so the strict "field descriptions are not
+                values" instruction reaches the model on Gemini's native-structured-output path.
 
         Returns:
             dict[str, typing.Any]: The response from the language model.
         """
+        self._apply_attribute_extraction_preamble(messages, attribute_extraction)
         # Add multilingual extraction instructions
         messages[0].content += get_extraction_language_instruction(group_id)
 

--- a/graphiti_core/llm_client/gliner2_client.py
+++ b/graphiti_core/llm_client/gliner2_client.py
@@ -258,8 +258,10 @@ class GLiNER2Client(LLMClient):
         model_size: ModelSize = ModelSize.medium,
         group_id: str | None = None,
         prompt_name: str | None = None,
+        *,
+        attribute_extraction: bool = False,
     ) -> dict[str, typing.Any]:
-        # Delegate non-extraction operations to the LLM client
+        # Delegate non-extraction operations to the wrapped LLM client.
         if not self._is_gliner2_operation(response_model):
             return await self.llm_client.generate_response(
                 messages,
@@ -268,6 +270,7 @@ class GLiNER2Client(LLMClient):
                 model_size=model_size,
                 group_id=group_id,
                 prompt_name=prompt_name,
+                attribute_extraction=attribute_extraction,
             )
 
         if max_tokens is None:

--- a/graphiti_core/llm_client/openai_base_client.py
+++ b/graphiti_core/llm_client/openai_base_client.py
@@ -216,8 +216,16 @@ class BaseOpenAIClient(LLMClient):
         model_size: ModelSize = ModelSize.medium,
         group_id: str | None = None,
         prompt_name: str | None = None,
+        *,
+        attribute_extraction: bool = False,
     ) -> dict[str, typing.Any]:
-        """Generate a response with retry logic and error handling."""
+        """Generate a response with retry logic and error handling.
+
+        When ``attribute_extraction`` is True, prepend the shared attribute-extraction
+        framing to the system message so the strict "field descriptions are not values"
+        instruction reaches the model on this provider's native-structured-output path.
+        """
+        self._apply_attribute_extraction_preamble(messages, attribute_extraction)
         if max_tokens is None:
             max_tokens = self.max_tokens
 

--- a/graphiti_core/llm_client/openai_generic_client.py
+++ b/graphiti_core/llm_client/openai_generic_client.py
@@ -143,7 +143,10 @@ class OpenAIGenericClient(LLMClient):
         model_size: ModelSize = ModelSize.medium,
         group_id: str | None = None,
         prompt_name: str | None = None,
+        *,
+        attribute_extraction: bool = False,
     ) -> dict[str, typing.Any]:
+        self._apply_attribute_extraction_preamble(messages, attribute_extraction)
         if max_tokens is None:
             max_tokens = self.max_tokens
 

--- a/graphiti_core/models/nodes/node_db_queries.py
+++ b/graphiti_core/models/nodes/node_db_queries.py
@@ -357,13 +357,14 @@ def get_saga_node_save_query(provider: GraphProvider) -> str:
                     n.summary = $summary,
                     n.first_episode_uuid = $first_episode_uuid,
                     n.last_episode_uuid = $last_episode_uuid,
-                    n.last_summarized_at = $last_summarized_at
+                    n.last_summarized_at = $last_summarized_at,
+                    n.last_summarized_episode_valid_at = $last_summarized_episode_valid_at
                 RETURN n.uuid AS uuid
             """
         case _:  # Neo4j, FalkorDB, Neptune
             return """
                 MERGE (n:Saga {uuid: $uuid})
-                SET n = {uuid: $uuid, name: $name, group_id: $group_id, created_at: $created_at, summary: $summary, first_episode_uuid: $first_episode_uuid, last_episode_uuid: $last_episode_uuid, last_summarized_at: $last_summarized_at}
+                SET n = {uuid: $uuid, name: $name, group_id: $group_id, created_at: $created_at, summary: $summary, first_episode_uuid: $first_episode_uuid, last_episode_uuid: $last_episode_uuid, last_summarized_at: $last_summarized_at, last_summarized_episode_valid_at: $last_summarized_episode_valid_at}
                 RETURN n.uuid AS uuid
             """
 
@@ -376,7 +377,8 @@ SAGA_NODE_RETURN = """
     s.summary AS summary,
     s.first_episode_uuid AS first_episode_uuid,
     s.last_episode_uuid AS last_episode_uuid,
-    s.last_summarized_at AS last_summarized_at
+    s.last_summarized_at AS last_summarized_at,
+    s.last_summarized_episode_valid_at AS last_summarized_episode_valid_at
 """
 
 SAGA_NODE_RETURN_NEPTUNE = """
@@ -387,5 +389,6 @@ SAGA_NODE_RETURN_NEPTUNE = """
     s.summary AS summary,
     s.first_episode_uuid AS first_episode_uuid,
     s.last_episode_uuid AS last_episode_uuid,
-    s.last_summarized_at AS last_summarized_at
+    s.last_summarized_at AS last_summarized_at,
+    s.last_summarized_episode_valid_at AS last_summarized_episode_valid_at
 """

--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -869,6 +869,11 @@ class SagaNode(Node):
     first_episode_uuid: str | None = None
     last_episode_uuid: str | None = None
     last_summarized_at: datetime | None = None
+    # Maximum ``valid_at`` (episode reference time) across all episodes covered
+    # by the most recent summary. ``last_summarized_at`` is wall-clock and is
+    # used as the watermark for the next incremental summarize run; this field
+    # carries the episode-time semantics for public/temporal consumers.
+    last_summarized_episode_valid_at: datetime | None = None
 
     async def save(self, driver: GraphDriver):
         if driver.graph_operations_interface:
@@ -887,6 +892,7 @@ class SagaNode(Node):
             first_episode_uuid=self.first_episode_uuid,
             last_episode_uuid=self.last_episode_uuid,
             last_summarized_at=self.last_summarized_at,
+            last_summarized_episode_valid_at=self.last_summarized_episode_valid_at,
         )
 
         logger.debug(f'Saved Node to Graph: {self.uuid}')
@@ -1086,6 +1092,7 @@ def get_community_node_from_record(record: Any) -> CommunityNode:
 
 def get_saga_node_from_record(record: Any) -> SagaNode:
     last_summarized_at = record.get('last_summarized_at')
+    last_summarized_episode_valid_at = record.get('last_summarized_episode_valid_at')
     return SagaNode(
         uuid=record['uuid'],
         name=record['name'],
@@ -1095,6 +1102,11 @@ def get_saga_node_from_record(record: Any) -> SagaNode:
         first_episode_uuid=record.get('first_episode_uuid'),
         last_episode_uuid=record.get('last_episode_uuid'),
         last_summarized_at=parse_db_date(last_summarized_at) if last_summarized_at else None,  # type: ignore
+        last_summarized_episode_valid_at=(
+            parse_db_date(last_summarized_episode_valid_at)  # type: ignore
+            if last_summarized_episode_valid_at
+            else None
+        ),
     )
 
 

--- a/graphiti_core/prompts/extract_edges.py
+++ b/graphiti_core/prompts/extract_edges.py
@@ -182,20 +182,46 @@ def extract_attributes(context: dict[str, Any]) -> list[Message]:
     return [
         Message(
             role='system',
-            content='You are a fact attribute extraction specialist. NEVER hallucinate or infer values not explicitly stated.',
+            content=(
+                'You are a fact attribute extraction specialist. '
+                'You ONLY emit attribute values that are explicitly stated in the FACT or '
+                'already present in EXISTING ATTRIBUTES. You output strictly the JSON specified '
+                'by the response schema — no reasoning, no explanation, no commentary in any field.'
+            ),
         ),
         Message(
             role='user',
-            content=f"""
-Given the following FACT, its REFERENCE TIME, and any EXISTING ATTRIBUTES, extract or update
-attributes based on the information explicitly stated in the fact. Use the provided attribute
-descriptions to understand how each attribute should be determined.
+            content=f"""\
+Given the following FACT, its REFERENCE TIME, and any EXISTING ATTRIBUTES, update the attributes.
 
-Guidelines:
-1. NEVER hallucinate or infer attribute values — only use values explicitly stated in the FACT.
-2. Only use information stated in the FACT to set attribute values.
-3. Use REFERENCE TIME to resolve any relative temporal expressions in the fact.
-4. Preserve existing attribute values unless the fact explicitly provides new information.
+HARD RULES — violating any of these is a failure:
+
+1. Each attribute value MUST be one of:
+   (a) a clean value copied or directly normalized from the FACT,
+   (b) the existing value already in EXISTING ATTRIBUTES (preserved unchanged), or
+   (c) null / omitted, when neither (a) nor (b) applies.
+
+2. NEVER write reasoning, justification, or commentary into any field. Specifically:
+   - NEVER include parenthetical explanations like "(implied by ...)", "(Context: ...)",
+     "(not explicitly stated ...)", "(based on ...)".
+   - NEVER include first-person or deliberative phrases like "I should...", "However...",
+     "Sticking to...", "Since no...", "the instruction is to...", "must be kept...".
+   - NEVER list alternatives or candidates inside one field ("X, or Y, or maybe Z").
+   - NEVER explain why a value is null. If unknown, set the field to null and stop.
+
+3. Each attribute schema description tells you the FORMAT a real value should take. The
+   description text is NEVER itself a value. NEVER copy schema description text into the field.
+
+4. The literal strings "null", "N/A", "Not specified", "unknown", "none", "not provided",
+   or any sentence describing absence are NOT valid values. If no value is supported by
+   the FACT, set the field to null (or omit it) — do not write a sentence.
+
+5. Each attribute value must be a short, well-formed instance of the type the field
+   describes. If you cannot produce a clean value of that type from the FACT, the field is null.
+
+6. Use REFERENCE TIME to resolve any relative temporal expressions in the fact.
+
+7. Preserve existing attribute values unless the FACT explicitly provides a new value.
 
 <FACT>
 {context['fact']}

--- a/graphiti_core/prompts/extract_nodes.py
+++ b/graphiti_core/prompts/extract_nodes.py
@@ -384,17 +384,72 @@ def extract_attributes(context: dict[str, Any]) -> list[Message]:
     return [
         Message(
             role='system',
-            content='You are an entity attribute extraction specialist. NEVER hallucinate or infer values not explicitly stated.',
+            content=(
+                'You are an entity attribute extraction specialist. '
+                'You ONLY emit attribute values that are explicitly stated in MESSAGES or '
+                'already present on the ENTITY. You output strictly the JSON specified by the '
+                'response schema — no reasoning, no explanation, no commentary in any field.'
+            ),
         ),
         Message(
             role='user',
-            content=f"""
-Given the MESSAGES and the following ENTITY, update any of its attributes based on the information provided
-in MESSAGES. Use the provided attribute descriptions to better understand how each attribute should be determined.
+            content=f"""\
+Given the MESSAGES and the following ENTITY, update its attributes.
 
-Guidelines:
-1. NEVER hallucinate or infer property values — only use values explicitly stated in the MESSAGES.
-2. Only use the provided MESSAGES and ENTITY to set attribute values.
+HARD RULES — violating any of these is a failure:
+
+1. Each attribute value MUST be one of:
+   (a) a clean value copied or directly normalized from text in MESSAGES,
+   (b) the existing value already on the ENTITY (preserved unchanged), or
+   (c) null / omitted, when neither (a) nor (b) applies.
+
+2. NEVER write reasoning, justification, or commentary into any field. Specifically:
+   - NEVER include parenthetical explanations like "(implied by ...)", "(Context: ...)",
+     "(not explicitly stated ...)", "(based on ...)".
+   - NEVER include first-person or deliberative phrases like "I should...", "However...",
+     "Sticking to...", "Since no...", "the instruction is to...", "must be kept...",
+     "if no value is present...".
+   - NEVER list alternatives or candidates inside one field ("X, or Y, or maybe Z").
+   - NEVER explain why a value is null. If unknown, set the field to null and stop.
+
+3. Each attribute schema description (e.g. an "Industry sector" field whose description
+   reads "Industry classification, single word where possible") tells you the FORMAT a
+   real value should take. The description text is NEVER itself a value. NEVER copy
+   schema description text into the field.
+
+4. The literal strings "null", "N/A", "Not specified", "unknown", "none", "not provided",
+   or any sentence describing absence are NOT valid values. If no value is supported by
+   MESSAGES, set the field to null (or omit it) — do not write a sentence.
+
+5. Each attribute value must be a short, well-formed instance of the type the field
+   describes (a phone number, an industry name, a URL, a postal address). If you cannot
+   produce a clean value of that type from MESSAGES, the field is null.
+
+6. NEVER infer attribute values from the entity's name, from related entities, from
+   generic world knowledge, or from prior summaries. Only verbatim or directly normalized
+   text from MESSAGES qualifies as a new value.
+
+7. If MESSAGES contain no information about an attribute, leave the existing entity
+   value unchanged. If the entity has no existing value, the field is null.
+
+EXAMPLES
+
+ENTITY: {{"name": "Sam Rivera", "phones": "415-555-0142"}}
+MESSAGES contain no phone information for Sam.
+GOOD → "phones": "415-555-0142"   (preserved existing value)
+BAD  → "phones": "415-555-0142 (implied by original entity, but no new information in
+        messages, retaining original value as per instruction...)"
+
+ENTITY: {{"name": "Northwind", "industry": null}}
+MESSAGES mention Northwind only as the platform some content was posted to.
+GOOD → "industry": null   (no explicit industry classification was stated)
+BAD  → "industry": "Content platform, SaaS (implied by usage context, though not stated
+        explicitly as industry classification...)"
+
+ENTITY: {{"name": "Priya"}}
+MESSAGES contain no phone for Priya, but discuss a project she contributed to.
+GOOD → "phones": null
+BAD  → "phones": "Worked with Lin and Marco on the Q3 launch..."   (off-topic content dump)
 
 <MESSAGES>
 {to_prompt_json(context['previous_episodes'])}

--- a/graphiti_core/prompts/extract_nodes_and_edges.py
+++ b/graphiti_core/prompts/extract_nodes_and_edges.py
@@ -143,6 +143,23 @@ FACT RULES:
 7. Do not emit redundant facts across episodes. But if a later episode adds new
    details (brand, count, location), extract the more detailed version as a new fact.
 
+OUTPUT DISCIPLINE:
+- Entity `name` is a literal mention from CURRENT MESSAGES, ≤5 words. NEVER use a full
+  sentence, action item, goal statement, or quoted aspiration as a name.
+  BAD: "Establish a firm training/onboarding program",
+       "Secure competitive advantage through IP",
+       "Decide whether to expand into Europe next quarter".
+  GOOD (terse-name fallback for the same source content): "training program",
+       "competitive advantage", "European expansion" — extract the topical noun
+       phrase, not the full proposition. Multi-word topic names like "watercolor
+       painting" or "VR gaming" remain valid (see ENTITY RULE 4).
+- The `fact` field is one self-contained sentence. NEVER include reasoning, hedging
+  ("appears to", "implies", "suggests"), parenthetical commentary, or schema-description text.
+- `relation_type` is SCREAMING_SNAKE_CASE letters/underscores only. NEVER spaces,
+  punctuation, or sentences.
+- Output ONLY the JSON specified by the response schema. No preamble, no trailing notes,
+  no explanation of choices.
+
 <ENTITY TYPES>
 {context['entity_types']}
 </ENTITY TYPES>

--- a/graphiti_core/prompts/extract_nodes_and_edges.py
+++ b/graphiti_core/prompts/extract_nodes_and_edges.py
@@ -109,10 +109,42 @@ ENTITY RULES:
    "video games", "watercolor painting", "VR gaming", "road cycling", "cooking"
 5. Extract named/described objects ("Gamecube", "Ford Mustang", "wool coat") and
    places ("Riverside Park", "the gym", "the beach") — not bare generics ("car", "coat").
-6. Do NOT extract: pronouns, vague abstractions (balance, growth, motivation),
-   filler nouns (day, life, stuff, time), dates as entities, full sentences as names.
+6. Entity names must be NOUN PHRASES that refer to a discrete thing in the user's
+   world. Do NOT extract any of the following — they belong inside fact text, as
+   properties of another entity, or not at all:
+   a. Pronouns, articles, and unresolved references: "the city", "this issue",
+      "that rule", "the victim", "the game". Resolve to the actual referent or skip.
+   b. Vague abstractions and filler nouns (balance, growth, motivation, day, life,
+      stuff, time). Full sentences or propositions as names are also banned.
+   c. Specific clock times and dates as entities ("5:54 am", "8:47 am",
+      "January 15"). A time/date is a property of the event — keep it in fact text.
+   d. Bare quantities, measurements, durations, prices, counts, or recipe amounts
+      ("7-8 hours", "7.5 hours of daylight", "$150/hour", "10-pound dumbbells",
+      "1 cup granulated white sugar", "4 cups water", "15-30 minutes"). Numbers
+      are properties of the thing they measure — preserve them inside the fact.
+   e. Geographic coordinates / latitudes / longitudes ("52 degrees north",
+      "66°33' north of the equator"). They are attributes of the location entity.
+   f. Multiple-choice answer labels, response-option tokens, or rubric/template
+      scaffolding the assistant is constrained to emit ("Agree",
+      "Strongly disagree", "the four answers", "the score", "scorr"). These are
+      prompt-template tokens, not entities in the user's world.
+   g. Imperative verb-phrase advice — bullet headers from how-to / tip lists
+      ("Buy in bulk", "Cook in bulk", "Plan your meals", "Follow up on leads",
+      "Personalize your outreach", "Shop sales", "Keep it simple"). Entity names
+      are noun phrases. If the topic is worth keeping, name the topical noun
+      ("bulk buying", "meal planning") and put the advice in the fact text.
+   h. Quoted slogans, idioms, definitional phrases, or loaded adjective phrases
+      from opinion statements ("from each according to his ability, to each
+      according to his need", "the enemy of my enemy", "the perpetrator of a
+      crime", "genuinely disadvantaged"). They are not retrievable referents.
 7. Each entity appears exactly ONCE. Classify using the ENTITY TYPES provided.
 8. Only extract entities from CURRENT MESSAGES — PREVIOUS MESSAGES are context only.
+9. Skip didactic / tutorial scaffolding when the assistant is teaching a topic
+   (Unix commands, astronomy, cooking technique, etc.). Tutorial example values
+   ("/path/to/source", "file.txt", "<username>") and explanatory primitives are
+   external didactic material, not facts about the user. The user's interest in
+   the topic ("user is learning Unix commands") is one fact — do not turn each
+   command, flag, or example path into its own node.
 
 FACT RULES:
 1. source_entity_name and target_entity_name must match your extracted entity names.
@@ -129,11 +161,21 @@ FACT RULES:
    - Emotions/states: "Sam feels he lacks motivation"
 3. Facts must be SELF-CONTAINED — understandable without the original episode.
    Use entity names, not pronouns. Preserve specific details where possible.
-4. Extract facts from EVERY episode — not just the first. Process each episode's
-   CURRENT_MESSAGE independently. Set `episode_indices` to the 0-based episode
-   number(s) each fact comes from (matching [Episode N] headers).
-   If the SAME fact appears across multiple episodes, extract it ONCE and list ALL
-   episode indices — do NOT emit duplicate facts with different episode numbers.
+4. Extract facts from EVERY episode — not just the meatiest one. Conversational
+   setup episodes still contain real facts that belong in the graph:
+   - Narrative announcements: "something funny happened last night",
+     "I have news to share", "you won't believe what happened"
+   - Forward commitments: "I'll keep you posted", "I'll let you know how it
+     goes", "I'll call you when I land"
+   - Plans / intentions: "I'm calling them tomorrow", "I'm planning to start
+     next week"
+   - Emotional / state setup: "I've been feeling stressed lately",
+     "I'm so excited about this"
+   Process each episode's CURRENT_MESSAGE independently. Set `episode_indices`
+   to the 0-based episode number(s) each fact comes from (matching
+   [Episode N] headers). If the SAME fact appears across multiple episodes,
+   extract it ONCE and list ALL episode indices — do NOT emit duplicate facts
+   with different episode numbers.
 5. You MAY use PREVIOUS MESSAGES to resolve what the current message refers to.
    If the current message reacts to or confirms prior context, extract the full
    contextualized fact (e.g., "all the hard work paid off" → extract what paid off).
@@ -142,6 +184,24 @@ FACT RULES:
    content-free utterances like "Hi!", "Bye!", "Thanks!".
 7. Do not emit redundant facts across episodes. But if a later episode adds new
    details (brand, count, location), extract the more detailed version as a new fact.
+8. Prefer DIRECT speaker-to-target edges over fragmenting a relationship through
+   descriptive intermediaries. When a person is/visits/wants/recommends a
+   Location, performs at/works for an Organization, owns/uses/likes an Object,
+   or feels strongly about a Topic, emit the edge directly from the person —
+   do not route the relationship through scenery nouns, observed features, or
+   ad-hoc descriptive entities.
+   GOOD: Calvin -> TOOK_PHOTO_IN -> Tokyo
+         Calvin -> PERFORMED_IN -> Tokyo
+         Dave -> WANTS_TO_VISIT -> Tokyo
+   BAD:  city lights -> LOCATED_IN -> Tokyo,
+         night skyline -> LOCATED_IN -> Tokyo,
+         insane crowd -> LOCATED_IN -> Tokyo
+         (the descriptive scenery is observation about the location, not its
+         own subject — Calvin's and Dave's actual relationships to Tokyo
+         become unretrievable. Put the scenery details inside fact text.)
+   The same applies for organizations and possessions: each speaker-relevant
+   thing should have at least one edge with the speaker (or an entity they
+   own/identify with) as source, not an observation noun.
 
 OUTPUT DISCIPLINE:
 - Entity `name` is a literal mention from CURRENT MESSAGES, ≤5 words. NEVER use a full
@@ -159,6 +219,72 @@ OUTPUT DISCIPLINE:
   punctuation, or sentences.
 - Output ONLY the JSON specified by the response schema. No preamble, no trailing notes,
   no explanation of choices.
+
+<NEGATIVE EXAMPLES>
+Each example shows the source phrasing, what NOT to extract as an entity, and
+what to keep instead. The skipped content still survives — inside fact text on
+the surviving entity.
+
+A) Multiple-choice / response-option scaffolding
+   Source (assistant): "Reply with one of: Strongly disagree, Disagree, Agree,
+   or Strongly agree."
+   SKIP entities: "Agree", "Strongly disagree", "the four answers", "responses".
+   KEEP: nothing — this is template instruction, not a fact about the user.
+
+B) Specific clock times
+   Source: "The sun rises around 8:47 am in Stockholm on the winter solstice."
+   SKIP entities: "8:47 am", "2:48 pm".
+   KEEP: "Stockholm", "winter solstice". The time stays in the fact text:
+   "The sun rises around 8:47 am in Stockholm on the winter solstice."
+
+C) Quantities / durations / prices / recipe amounts
+   Source: "Berlin and London experience approximately 7.5 hours of daylight
+   on the winter solstice."
+   SKIP entities: "7.5 hours of daylight", "7-8 hours", "6 hours of daylight".
+   KEEP: "Berlin", "London", "winter solstice". Duration stays inside the fact.
+
+   Source: "Mix 1 cup granulated white sugar into 4 cups water to make nectar."
+   SKIP entities: "1 cup granulated white sugar", "4 cups water".
+   KEEP: "sugar-water nectar" (the recipe topic). The amounts stay in the fact.
+
+D) Geographic coordinates
+   Source: "Melbourne is located approximately 37 degrees south of the equator;
+   Stockholm is around 59 degrees north."
+   SKIP entities: "37 degrees south of the equator", "59 degrees north".
+   KEEP: "Melbourne", "Stockholm", "equator". The latitude stays in the fact.
+
+E) Imperative verb-phrase advice from tip lists
+   Source (assistant): "Tips for saving money on groceries: Buy in bulk; Cook
+   in bulk; Plan your meals; Shop sales; Use cashback apps."
+   SKIP entities: "Buy in bulk", "Cook in bulk", "Plan your meals",
+   "Shop sales", "Use cashback apps".
+   KEEP: "saving money on groceries" (the topical noun phrase). Each tip lives
+   inside a fact attached to that topic, not as its own node.
+
+F) Quoted slogans / idioms / loaded phrases
+   Source (user): "I believe in 'from each according to his ability, to each
+   according to his need' — the rich are too highly taxed though."
+   SKIP entities: "from each according to his ability...", "the enemy of my
+   enemy", "the rich", "genuinely disadvantaged".
+   KEEP: the User entity. The belief and opinion go into facts in plain
+   language (e.g. user -> BELIEVES_IN -> Marxist distribution principle).
+
+G) Direct speaker-to-target edges (no fragmenting through scenery)
+   Source: Calvin: "I took that pic in Tokyo last night. The skyline was
+   stunning! [...]"  Dave: "Wow, the night skyline really pops with those
+   city lights. I gotta take a trip there soon!"  Calvin (later): "Touring
+   with Frank Ocean last week was wild. Tokyo was unreal — the crowd was
+   insane."
+   SKIP edge sources/targets: city lights -> Tokyo,
+        night skyline -> Tokyo, insane crowd -> Tokyo.
+   KEEP edges: Calvin -> TOOK_PHOTO_IN -> Tokyo
+               Calvin -> PERFORMED_IN -> Tokyo
+               Calvin -> TOURED_WITH -> Frank Ocean
+               Dave -> WANTS_TO_VISIT -> Tokyo
+   Descriptive scenery ("stunning skyline", "city lights pop", "insane
+   crowd") goes inside the fact text on these direct edges, not as its
+   own edges.
+</NEGATIVE EXAMPLES>
 
 <ENTITY TYPES>
 {context['entity_types']}

--- a/graphiti_core/utils/maintenance/attribute_utils.py
+++ b/graphiti_core/utils/maintenance/attribute_utils.py
@@ -1,0 +1,254 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+# Default cap for free-form string attribute values. Calibrated to comfortably fit
+# normal short-text fields (phones, industries, URLs, addresses, alias lists) while
+# rejecting multi-paragraph LLM meta-reasoning. Customers with legitimately longer
+# fields should set an explicit max_length on the Pydantic Field, or override the
+# default globally via the GRAPHITI_ATTRIBUTE_MAX_LENGTH env var.
+DEFAULT_ATTRIBUTE_MAX_LENGTH = 250
+
+# When a list-typed string attribute is provided, the per-item cap and an aggregate
+# multiplier together bound list-total length. The multiplier mirrors common usage
+# (≤8 short entries) without being so loose that a 50× repetition slips through.
+LIST_TOTAL_LENGTH_MULTIPLIER = 8
+
+_ENV_VAR = 'GRAPHITI_ATTRIBUTE_MAX_LENGTH'
+
+# Track invalid env values we've already warned about so a misconfigured deploy
+# emits one warning per unique bad value rather than one per cap invocation.
+_warned_invalid_env: set[str] = set()
+
+
+# Merge semantics shared by node and edge call sites:
+#
+#   merge_mode='overlay'  (node attributes)
+#       prior overlaid by kept fields. LLM-omitted fields retain prior values;
+#       cap-dropped fields also retain prior values (because they are absent
+#       from kept and overlay never overwrites with absence).
+#
+#   merge_mode='replace'  (edge attributes)
+#       kept fully replaces prior, BUT cap-dropped fields are restored from
+#       prior. LLM-omitted fields are cleared (replace semantics).
+#
+# The asymmetry exists because edge-attribute extraction historically used
+# wholesale replacement, while node attributes have always been incrementally
+# merged. The unified helper makes the choice explicit at each call site.
+
+
+def _resolve_default_max_length(default_max_length: int) -> int:
+    raw = os.environ.get(_ENV_VAR)
+    if raw is None or raw.strip() == '':
+        return default_max_length
+    try:
+        parsed = int(raw)
+        if parsed <= 0:
+            raise ValueError('non-positive')
+    except ValueError:
+        if raw not in _warned_invalid_env:
+            _warned_invalid_env.add(raw)
+            logger.warning(
+                'Ignoring invalid %s=%r; expected a positive integer. Using default=%d.',
+                _ENV_VAR,
+                raw,
+                default_max_length,
+            )
+        return default_max_length
+    return parsed
+
+
+def _field_max_length(model: type[BaseModel], field_name: str) -> int | None:
+    field_info = model.model_fields.get(field_name)
+    if field_info is None:
+        return None
+    for meta in getattr(field_info, 'metadata', []) or []:
+        explicit = getattr(meta, 'max_length', None)
+        if explicit is not None:
+            return int(explicit)
+    return None
+
+
+def _field_is_required(model: type[BaseModel], field_name: str) -> bool:
+    field_info = model.model_fields.get(field_name)
+    if field_info is None:
+        return False
+    is_required = getattr(field_info, 'is_required', None)
+    if callable(is_required):
+        return bool(is_required())
+    # Older pydantic shape; fall back conservatively.
+    return False
+
+
+def _check_value_against_cap(value: Any, max_len: int) -> tuple[bool, str, int, int]:
+    """Decide whether ``value`` exceeds the cap and on which axis.
+
+    Returns ``(exceeded, reason, observed_length, breached_cap)``:
+      * ``exceeded``       — True if the field should be dropped.
+      * ``reason``         — one of ``'per_item'``, ``'aggregate'``, ``'ok'``.
+      * ``observed_length`` — the length to log: the offending element's length for
+        per-item triggers, the aggregate string length for aggregate triggers.
+      * ``breached_cap``    — the cap that was actually breached; ``max_len`` for
+        per-item, ``max_len * LIST_TOTAL_LENGTH_MULTIPLIER`` for aggregate. Logging
+        this alongside ``observed_length`` keeps the two directly comparable in
+        DataDog instead of confusingly showing ``length=240 cap=250`` when 50
+        just-under-cap items collectively breached the aggregate guard.
+
+    Catching both axes prevents a single bleed slipping through inside one element
+    AND prevents many "just-under-cap" items adding up to KB-scale list bleed.
+    """
+    if isinstance(value, str):
+        if len(value) > max_len:
+            return True, 'per_item', len(value), max_len
+        return False, 'ok', 0, max_len
+    if isinstance(value, list):
+        max_item = max(
+            (len(item) for item in value if isinstance(item, str)),
+            default=0,
+        )
+        if max_item > max_len:
+            return True, 'per_item', max_item, max_len
+        total = sum(len(item) for item in value if isinstance(item, str))
+        aggregate_cap = max_len * LIST_TOTAL_LENGTH_MULTIPLIER
+        if total > aggregate_cap:
+            return True, 'aggregate', total, aggregate_cap
+        return False, 'ok', 0, max_len
+    return False, 'ok', 0, max_len
+
+
+def cap_string_attributes(
+    response: dict[str, Any],
+    model: type[BaseModel],
+    *,
+    default_max_length: int = DEFAULT_ATTRIBUTE_MAX_LENGTH,
+    prompt_name: str = '',
+    entity_uuid: str = '',
+    group_id: str = '',
+) -> tuple[dict[str, Any], set[str]]:
+    """Drop string (or list-of-string) attributes whose value exceeds a length cap.
+
+    Defends against meta-thinking / schema-description bleed where the LLM dumps
+    multi-paragraph reasoning into a free-form attribute field.
+
+    For string-typed fields the cap is the length of the value. For list-typed
+    fields the cap is enforced both per-item and on the aggregate length of all
+    string elements (max_len × ``LIST_TOTAL_LENGTH_MULTIPLIER``); see
+    ``_check_value_against_cap``.
+
+    Cap precedence: an explicit ``max_length`` on the Pydantic Field wins; otherwise
+    the resolved default (``GRAPHITI_ATTRIBUTE_MAX_LENGTH`` env var if set, else
+    ``default_max_length``). Non-string, non-string-list fields pass through untouched.
+
+    Returns ``(kept, dropped)``:
+      * ``kept`` — the response dict with over-cap fields removed (with one exception,
+        below).
+      * ``dropped`` — the set of field names that were dropped.
+
+    Required-field exception: if a Pydantic field is REQUIRED (no default and no
+    ``Optional``) and the LLM emitted an over-cap value, the value is retained
+    (with a warning) rather than dropped. Dropping a required field would cause
+    the subsequent ``model(**capped)`` validation in the node path to fail the
+    entire response. Customers who want stricter behavior on required fields
+    should set an explicit ``max_length`` on the Pydantic Field; Pydantic will
+    enforce it at validation time.
+
+    Logging deliberately uses ``entity_uuid`` (not name) per AGENTS.md "no PII in logs".
+    """
+    effective_default = _resolve_default_max_length(default_max_length)
+    kept: dict[str, Any] = {}
+    dropped: set[str] = set()
+    for field_name, value in response.items():
+        max_len = _field_max_length(model, field_name) or effective_default
+        exceeded, reason, observed_length, breached_cap = _check_value_against_cap(value, max_len)
+        if not exceeded:
+            kept[field_name] = value
+            continue
+        # Required-field carve-out: don't drop, would crash Pydantic validation.
+        if _field_is_required(model, field_name):
+            logger.warning(
+                'attribute_length_cap_skipped_required '
+                'prompt=%s group_id=%s entity_uuid=%s field=%s '
+                'reason=%s length=%d cap=%d',
+                prompt_name,
+                group_id or '<unknown>',
+                entity_uuid or '<unknown>',
+                field_name,
+                reason,
+                observed_length,
+                breached_cap,
+            )
+            kept[field_name] = value
+            continue
+        logger.info(
+            'attribute_length_cap_exceeded '
+            'prompt=%s group_id=%s entity_uuid=%s field=%s '
+            'reason=%s length=%d cap=%d',
+            prompt_name,
+            group_id or '<unknown>',
+            entity_uuid or '<unknown>',
+            field_name,
+            reason,
+            observed_length,
+            breached_cap,
+        )
+        dropped.add(field_name)
+    return kept, dropped
+
+
+def apply_capped_attributes(
+    response: dict[str, Any],
+    model: type[BaseModel],
+    prior_attributes: dict[str, Any],
+    *,
+    merge_mode: Literal['overlay', 'replace'],
+    default_max_length: int = DEFAULT_ATTRIBUTE_MAX_LENGTH,
+    prompt_name: str = '',
+    entity_uuid: str = '',
+    group_id: str = '',
+) -> tuple[dict[str, Any], set[str]]:
+    """Cap the LLM response and merge it with prior attributes per the merge mode.
+
+    See the module-level docstring for the semantics of each ``merge_mode``. The
+    return value is ``(merged, dropped)``; the dropped set is exposed for callers
+    that want to log or react to it independently.
+    """
+    kept, dropped = cap_string_attributes(
+        response,
+        model,
+        default_max_length=default_max_length,
+        prompt_name=prompt_name,
+        entity_uuid=entity_uuid,
+        group_id=group_id,
+    )
+    if merge_mode == 'overlay':
+        merged: dict[str, Any] = {**prior_attributes, **kept}
+    elif merge_mode == 'replace':
+        merged = dict(kept)
+        for field in dropped:
+            if field in prior_attributes:
+                merged[field] = prior_attributes[field]
+    else:  # pragma: no cover — Literal protects this at type-check time.
+        raise ValueError(f'merge_mode must be "overlay" or "replace", got {merge_mode!r}')
+    return merged, dropped

--- a/graphiti_core/utils/maintenance/edge_operations.py
+++ b/graphiti_core/utils/maintenance/edge_operations.py
@@ -42,6 +42,7 @@ from graphiti_core.search.search_config import SearchResults
 from graphiti_core.search.search_config_recipes import EDGE_HYBRID_SEARCH_RRF
 from graphiti_core.search.search_filters import SearchFilters
 from graphiti_core.utils.datetime_utils import ensure_utc, utc_now
+from graphiti_core.utils.maintenance.attribute_utils import apply_capped_attributes
 from graphiti_core.utils.maintenance.dedup_helpers import _normalize_string_exact
 from graphiti_core.utils.text_utils import concatenate_episodes
 
@@ -663,8 +664,18 @@ async def resolve_extracted_edge(
                 response_model=edge_model,  # type: ignore
                 model_size=ModelSize.small,
                 prompt_name='extract_edges.extract_attributes',
+                attribute_extraction=True,
             )
-            extracted_edge.attributes = edge_attributes_response
+            merged, _ = apply_capped_attributes(
+                edge_attributes_response,
+                edge_model,
+                extracted_edge.attributes,
+                merge_mode='replace',
+                prompt_name='extract_edges.extract_attributes',
+                entity_uuid=extracted_edge.uuid,
+                group_id=extracted_edge.group_id,
+            )
+            extracted_edge.attributes = merged
 
         await _extract_edge_timestamps(llm_client, extracted_edge, episode)
 
@@ -779,10 +790,22 @@ async def resolve_extracted_edge(
             response_model=edge_model,  # type: ignore
             model_size=ModelSize.small,
             prompt_name='extract_edges.extract_attributes',
+            attribute_extraction=True,
         )
 
-        resolved_edge.attributes = edge_attributes_response
+        merged, _ = apply_capped_attributes(
+            edge_attributes_response,
+            edge_model,
+            resolved_edge.attributes,
+            merge_mode='replace',
+            prompt_name='extract_edges.extract_attributes',
+            entity_uuid=resolved_edge.uuid,
+            group_id=resolved_edge.group_id,
+        )
+        resolved_edge.attributes = merged
     else:
+        # No matching edge schema → no structured attributes apply; clear any stale
+        # attributes left from a prior schema. Intentionally not merged.
         resolved_edge.attributes = {}
 
     # Extract timestamps for new edges (duplicated edges retain their existing timestamps)

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -42,6 +42,7 @@ from graphiti_core.prompts.extract_nodes import (
 from graphiti_core.search.search_filters import SearchFilters
 from graphiti_core.search.search_utils import node_similarity_search
 from graphiti_core.utils.datetime_utils import utc_now
+from graphiti_core.utils.maintenance.attribute_utils import apply_capped_attributes
 from graphiti_core.utils.maintenance.dedup_helpers import (
     DedupCandidateIndexes,
     DedupResolutionState,
@@ -757,9 +758,10 @@ async def extract_attributes_from_nodes(
         ]
     )
 
-    # Apply attributes to nodes
+    # _extract_entity_attributes returns the already-merged attribute dict
+    # (overlay of prior + cap-kept fields), so direct assignment is the merge.
     for node, attributes in zip(nodes, attribute_results, strict=True):
-        node.attributes.update(attributes)
+        node.attributes = attributes
 
     # Extract summaries in batch
     await _extract_entity_summaries_batch(
@@ -805,12 +807,27 @@ async def _extract_entity_attributes(
         model_size=ModelSize.small,
         group_id=node.group_id,
         prompt_name='extract_nodes.extract_attributes',
+        attribute_extraction=True,
     )
 
-    # validate response
-    entity_type(**llm_response)
+    # Overlay merge: cap-dropped or LLM-omitted fields keep prior values.
+    # See attribute_utils for the merge_mode contract; the edge path uses 'replace'.
+    merged, _ = apply_capped_attributes(
+        llm_response,
+        entity_type,
+        node.attributes,
+        merge_mode='overlay',
+        prompt_name='extract_nodes.extract_attributes',
+        entity_uuid=node.uuid,
+        group_id=node.group_id,
+    )
 
-    return llm_response
+    # Shape validation only — we discard the validated instance because returning
+    # `model_dump()` would expand defaults across all fields and clobber prior
+    # values that the merge above just preserved.
+    entity_type(**merged)
+
+    return merged
 
 
 async def _extract_entity_summaries_batch(

--- a/tests/llm_client/test_client.py
+++ b/tests/llm_client/test_client.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 from graphiti_core.llm_client.client import LLMClient
 from graphiti_core.llm_client.config import LLMConfig
+from graphiti_core.prompts.models import Message
 
 
 class MockLLMClient(LLMClient):
@@ -55,3 +56,53 @@ def test_clean_input():
 
     for input_str, expected in test_cases:
         assert client._clean_input(input_str) == expected, f'Failed for input: {repr(input_str)}'
+
+
+def test_attribute_extraction_preamble_no_op_when_disabled():
+    client = MockLLMClient(LLMConfig())
+    messages = [Message(role='system', content='base'), Message(role='user', content='hi')]
+    client._apply_attribute_extraction_preamble(messages, attribute_extraction=False)
+    assert messages[0].content == 'base'
+    assert messages[1].content == 'hi'
+
+
+def test_attribute_extraction_preamble_appends_to_system():
+    client = MockLLMClient(LLMConfig())
+    messages = [
+        Message(role='system', content='You are helpful.'),
+        Message(role='user', content='hi'),
+    ]
+    client._apply_attribute_extraction_preamble(messages, attribute_extraction=True)
+    assert messages[0].content.startswith('You are helpful.')
+    assert 'ATTRIBUTE EXTRACTION:' in messages[0].content
+    assert 'NEVER themselves valid values' in messages[0].content
+    assert messages[1].content == 'hi'  # user message untouched
+
+
+def test_attribute_extraction_preamble_is_idempotent():
+    client = MockLLMClient(LLMConfig())
+    messages = [
+        Message(role='system', content='You are helpful.'),
+        Message(role='user', content='hi'),
+    ]
+    client._apply_attribute_extraction_preamble(messages, attribute_extraction=True)
+    once = messages[0].content
+    client._apply_attribute_extraction_preamble(messages, attribute_extraction=True)
+    assert messages[0].content == once, 'second call must not double-append'
+
+
+def test_attribute_extraction_preamble_falls_back_to_first_message_if_no_system():
+    client = MockLLMClient(LLMConfig())
+    messages = [Message(role='user', content='hi')]
+    client._apply_attribute_extraction_preamble(messages, attribute_extraction=True)
+    assert 'ATTRIBUTE EXTRACTION:' in messages[0].content
+    assert messages[0].content.endswith('hi')
+    # Sentinel must be at the front so the idempotency check finds it.
+    assert messages[0].content.startswith('<<graphiti.attr_extraction.preamble.v1>>')
+
+
+def test_attribute_extraction_preamble_handles_empty_messages():
+    client = MockLLMClient(LLMConfig())
+    messages: list[Message] = []
+    client._apply_attribute_extraction_preamble(messages, attribute_extraction=True)
+    assert messages == []

--- a/tests/utils/maintenance/test_attribute_utils.py
+++ b/tests/utils/maintenance/test_attribute_utils.py
@@ -1,0 +1,256 @@
+import logging
+
+import pytest
+from pydantic import BaseModel, Field
+
+from graphiti_core.utils.maintenance.attribute_utils import (
+    DEFAULT_ATTRIBUTE_MAX_LENGTH,
+    LIST_TOTAL_LENGTH_MULTIPLIER,
+    apply_capped_attributes,
+    cap_string_attributes,
+)
+
+
+class _Person(BaseModel):
+    phones: str | None = Field(
+        default=None,
+        description='Phone numbers, comma-separated, with type tag where known',
+    )
+    industry: str | None = Field(default=None, description='Industry sector')
+    description: str | None = Field(
+        default=None,
+        max_length=2000,
+        description='Long-form description',
+    )
+    aliases: list[str] | None = Field(default=None, description='Alternate names')
+
+
+def test_short_string_passes_through():
+    response = {'phones': '415-555-0142', 'industry': 'SaaS'}
+    kept, dropped = cap_string_attributes(response, _Person)
+    assert kept == response
+    assert dropped == set()
+
+
+def test_overlong_string_dropped():
+    rant = 'x' * (DEFAULT_ATTRIBUTE_MAX_LENGTH * 10)
+    response = {'phones': rant, 'industry': 'SaaS'}
+    kept, dropped = cap_string_attributes(response, _Person)
+    assert 'phones' not in kept, 'over-cap field must be dropped, not truncated'
+    assert kept['industry'] == 'SaaS'
+    assert dropped == {'phones'}
+
+
+def test_explicit_max_length_honored():
+    long_desc = 'a' * 1500
+    kept, dropped = cap_string_attributes({'description': long_desc}, _Person)
+    assert kept['description'] == long_desc
+    assert dropped == set()
+
+
+def test_explicit_max_length_enforced_when_exceeded():
+    kept, dropped = cap_string_attributes({'description': 'a' * 2500}, _Person)
+    assert 'description' not in kept
+    assert dropped == {'description'}
+
+
+def test_non_string_fields_pass_through():
+    class Mixed(BaseModel):
+        amount: float | None = None
+        notes: str | None = None
+
+    response = {'amount': 42.5, 'notes': 'short note'}
+    kept, dropped = cap_string_attributes(response, Mixed)
+    assert kept == response
+    assert dropped == set()
+
+
+def test_list_with_one_overlong_element_drops_field():
+    bleed = 'x' * (DEFAULT_ATTRIBUTE_MAX_LENGTH + 1)
+    response = {'aliases': ['Sammy', bleed, 'Sam R.']}
+    kept, dropped = cap_string_attributes(response, _Person)
+    assert 'aliases' not in kept
+    assert dropped == {'aliases'}
+
+
+def test_list_aggregate_length_caught():
+    """Many just-under-cap elements collectively exceed max_len * multiplier."""
+    item = 'x' * (DEFAULT_ATTRIBUTE_MAX_LENGTH - 1)
+    response = {'aliases': [item] * (LIST_TOTAL_LENGTH_MULTIPLIER + 2)}
+    kept, dropped = cap_string_attributes(response, _Person)
+    assert 'aliases' not in kept
+    assert dropped == {'aliases'}
+
+
+def test_list_short_passes_through():
+    response = {'aliases': ['Sammy', 'Sam R.', 'S. Rivera']}
+    kept, dropped = cap_string_attributes(response, _Person)
+    assert kept == response
+    assert dropped == set()
+
+
+def test_required_field_overcap_kept_with_warning(caplog):
+    """A required string field with an over-cap value cannot be dropped without
+    failing Pydantic validation; the helper retains the bleed and logs louder."""
+
+    class StrictPerson(BaseModel):
+        full_name: str = Field(..., description='Full legal name')
+
+    bleed = 'x' * (DEFAULT_ATTRIBUTE_MAX_LENGTH + 50)
+    with caplog.at_level(logging.WARNING):
+        kept, dropped = cap_string_attributes(
+            {'full_name': bleed},
+            StrictPerson,
+            prompt_name='extract_nodes.extract_attributes',
+            entity_uuid='abc-123',
+            group_id='tenant-x',
+        )
+    # Bleed is retained, NOT dropped — Pydantic validation would otherwise fail.
+    assert kept == {'full_name': bleed}
+    assert dropped == set()
+    matching = [
+        rec for rec in caplog.records if 'attribute_length_cap_skipped_required' in rec.message
+    ]
+    assert matching, 'expected a warning about the required-field carve-out'
+    assert all(rec.levelno == logging.WARNING for rec in matching)
+
+
+def test_logs_info_on_drop_with_uuid_and_group_id_no_pii(caplog):
+    response = {'phones': 'x' * (DEFAULT_ATTRIBUTE_MAX_LENGTH + 1)}
+    with caplog.at_level(logging.INFO):
+        cap_string_attributes(
+            response,
+            _Person,
+            prompt_name='extract_nodes.extract_attributes',
+            entity_uuid='abc-123-uuid',
+            group_id='tenant-x',
+        )
+    matching = [rec for rec in caplog.records if 'attribute_length_cap_exceeded' in rec.message]
+    assert matching, 'expected an info-level log on cap drop'
+    assert all(rec.levelno == logging.INFO for rec in matching)
+    assert any(
+        'phones' in rec.message
+        and 'abc-123-uuid' in rec.message
+        and 'tenant-x' in rec.message
+        and 'reason=per_item' in rec.message
+        for rec in matching
+    )
+    assert not any('Sam Rivera' in rec.message for rec in matching)
+
+
+def test_log_aggregate_trigger_reports_aggregate_length_and_cap(caplog):
+    """When list-aggregate fires, length= must be the total (not max element)
+    and cap= must be the aggregate cap, so DataDog operators see the breach
+    directly instead of the misleading length=under-cap cap=per-item view."""
+    item = 'x' * (DEFAULT_ATTRIBUTE_MAX_LENGTH - 1)
+    items = [item] * (LIST_TOTAL_LENGTH_MULTIPLIER + 2)
+    expected_total = sum(len(i) for i in items)
+    expected_cap = DEFAULT_ATTRIBUTE_MAX_LENGTH * LIST_TOTAL_LENGTH_MULTIPLIER
+    with caplog.at_level(logging.INFO):
+        cap_string_attributes(
+            {'aliases': items},
+            _Person,
+            prompt_name='extract_nodes.extract_attributes',
+            entity_uuid='node-uuid',
+            group_id='tenant-x',
+        )
+    matching = [rec for rec in caplog.records if 'attribute_length_cap_exceeded' in rec.message]
+    assert len(matching) == 1
+    msg = matching[0].message
+    assert 'reason=aggregate' in msg
+    assert f'length={expected_total}' in msg
+    assert f'cap={expected_cap}' in msg
+    # Sanity: aggregate length must exceed the aggregate cap (otherwise the test
+    # is wrong, not the helper).
+    assert expected_total > expected_cap
+
+
+def test_env_var_overrides_default(monkeypatch):
+    monkeypatch.setenv('GRAPHITI_ATTRIBUTE_MAX_LENGTH', '50')
+    long_value = 'x' * 100
+    kept, dropped = cap_string_attributes({'phones': long_value}, _Person)
+    assert 'phones' not in kept
+    assert dropped == {'phones'}
+
+
+def test_env_var_invalid_falls_back_to_default(monkeypatch, caplog):
+    monkeypatch.setenv('GRAPHITI_ATTRIBUTE_MAX_LENGTH', 'not-a-number')
+    short_value = 'x' * 100
+    with caplog.at_level(logging.WARNING):
+        kept, dropped = cap_string_attributes({'phones': short_value}, _Person)
+    assert kept == {'phones': short_value}
+    assert dropped == set()
+
+
+def test_env_var_explicit_max_length_still_wins(monkeypatch):
+    monkeypatch.setenv('GRAPHITI_ATTRIBUTE_MAX_LENGTH', '50')
+    long_desc = 'a' * 1500
+    kept, dropped = cap_string_attributes({'description': long_desc}, _Person)
+    assert kept == {'description': long_desc}
+    assert dropped == set()
+
+
+@pytest.mark.parametrize('bad_value', ['0', '-10', '   ', ''])
+def test_env_var_non_positive_or_blank_falls_back(monkeypatch, bad_value):
+    monkeypatch.setenv('GRAPHITI_ATTRIBUTE_MAX_LENGTH', bad_value)
+    kept, dropped = cap_string_attributes({'phones': 'x' * 100}, _Person)
+    assert kept == {'phones': 'x' * 100}
+    assert dropped == set()
+
+
+def test_invalid_env_warning_dedups_across_calls(monkeypatch, caplog):
+    from graphiti_core.utils.maintenance import attribute_utils
+
+    monkeypatch.setattr(attribute_utils, '_warned_invalid_env', set())
+    monkeypatch.setenv('GRAPHITI_ATTRIBUTE_MAX_LENGTH', 'garbage')
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(5):
+            cap_string_attributes({'phones': 'x' * 50}, _Person)
+
+    invalid_warnings = [
+        rec
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING and 'GRAPHITI_ATTRIBUTE_MAX_LENGTH' in rec.message
+    ]
+    assert len(invalid_warnings) == 1
+
+
+# --- apply_capped_attributes (unified node/edge merge helper) -----------------
+
+
+def test_apply_overlay_keeps_prior_for_omitted_and_dropped_fields():
+    prior = {'phones': '415-555-0142', 'industry': 'Software'}
+    bleed = 'x' * (DEFAULT_ATTRIBUTE_MAX_LENGTH + 1)
+    llm = {'phones': bleed}  # industry omitted; phones over-cap
+    merged, dropped = apply_capped_attributes(llm, _Person, prior, merge_mode='overlay')
+    assert merged['phones'] == '415-555-0142'  # cap-dropped; prior preserved
+    assert merged['industry'] == 'Software'  # LLM-omitted; prior preserved
+    assert dropped == {'phones'}
+
+
+def test_apply_overlay_legitimate_update_passes_through():
+    prior = {'phones': '415-555-0142', 'industry': 'Software'}
+    llm = {'industry': 'SaaS'}
+    merged, dropped = apply_capped_attributes(llm, _Person, prior, merge_mode='overlay')
+    assert merged == {'phones': '415-555-0142', 'industry': 'SaaS'}
+    assert dropped == set()
+
+
+def test_apply_replace_clears_omitted_but_preserves_dropped():
+    prior = {'phones': '415-555-0142', 'industry': 'Software'}
+    bleed = 'x' * (DEFAULT_ATTRIBUTE_MAX_LENGTH + 1)
+    llm = {'phones': bleed}  # industry omitted; phones over-cap
+    merged, dropped = apply_capped_attributes(llm, _Person, prior, merge_mode='replace')
+    assert merged['phones'] == '415-555-0142'  # cap-dropped; prior restored
+    assert 'industry' not in merged  # LLM-omitted; cleared
+    assert dropped == {'phones'}
+
+
+def test_apply_replace_legitimate_update_replaces_prior_and_clears_omitted():
+    prior = {'phones': '415-555-0142', 'industry': 'Software'}
+    llm = {'industry': 'SaaS'}
+    merged, dropped = apply_capped_attributes(llm, _Person, prior, merge_mode='replace')
+    # phones was omitted by the LLM → cleared per replace semantics.
+    assert merged == {'industry': 'SaaS'}
+    assert dropped == set()

--- a/tests/utils/maintenance/test_edge_operations.py
+++ b/tests/utils/maintenance/test_edge_operations.py
@@ -701,3 +701,73 @@ async def test_extract_edges_keeps_valid_edges_with_same_name_different_nodes(mo
     assert len(edges) == 1
     assert edges[0].source_node_uuid == 'alice_uuid'
     assert edges[0].target_node_uuid == 'paris_uuid'
+
+
+class _EmploymentEdge(BaseModel):
+    """Edge attribute schema mirroring a customer's EMPLOYMENT relation."""
+
+    title: str | None = None
+    is_current: str | None = None
+
+
+@pytest.mark.asyncio
+async def test_resolve_extracted_edge_overcap_attribute_preserves_prior(monkeypatch):
+    """End-to-end: when the LLM bleeds meta-reasoning into one attribute, the
+    cap drops that field and the merge logic falls back to the prior on-edge
+    value — without affecting fields the LLM legitimately updated."""
+    from graphiti_core.utils.maintenance import edge_operations as edge_ops
+
+    # Avoid the timestamps LLM call that follows attribute extraction.
+    monkeypatch.setattr(edge_ops, '_extract_edge_timestamps', AsyncMock(return_value=None))
+
+    # The LLM returns a clean update for `title` but bleeds 9 KB of meta-reasoning into
+    # `is_current` — the kind of failure the customer reported.
+    bleed = (
+        'true (implied by context, but no new information explicitly stated. '
+        'I should ideally remove it or set it to null. However, the instruction '
+        'is to preserve existing values...) '
+    ) * 30
+    llm_client = MagicMock()
+    llm_client.generate_response = AsyncMock(
+        return_value={'title': 'Senior Engineer', 'is_current': bleed}
+    )
+
+    extracted_edge = EntityEdge(
+        source_node_uuid='person_uuid',
+        target_node_uuid='company_uuid',
+        name='EMPLOYMENT',
+        group_id='group_1',
+        fact='Sam was promoted to Senior Engineer at Northwind',
+        episodes=[],
+        created_at=datetime.now(timezone.utc),
+        valid_at=None,
+        invalid_at=None,
+        attributes={'title': 'Engineer', 'is_current': 'true'},
+    )
+
+    episode = EpisodicNode(
+        uuid='episode_uuid',
+        name='Episode',
+        group_id='group_1',
+        source='message',
+        source_description='desc',
+        content='Sam was promoted to Senior Engineer.',
+        valid_at=datetime.now(timezone.utc),
+    )
+
+    resolved, dupes, invalidated = await resolve_extracted_edge(
+        llm_client,
+        extracted_edge,
+        related_edges=[],
+        existing_edges=[],
+        episode=episode,
+        edge_type_candidates={'EMPLOYMENT': _EmploymentEdge},
+    )
+
+    # Title should reflect the legitimate LLM update.
+    assert resolved.attributes['title'] == 'Senior Engineer'
+    # is_current was bleed-dropped, so the prior value must be preserved (not the
+    # 9 KB rant, not None, not absent).
+    assert resolved.attributes['is_current'] == 'true'
+    assert dupes == []
+    assert invalidated == []


### PR DESCRIPTION
## Summary

Three independent improvements developed in our internal fork that should flow forward to OSS. Lint (`make lint`) passes cleanly; `make format` produced one unrelated whitespace fix that's included as its own commit.

### 1. `fix: prevent attribute hallucination bleed into graph fields`

Customer reported up to 9KB of LLM meta-reasoning landing in entity attribute fields (`phones`, `industry`) — the model was dumping its internal deliberation and echoing schema description text verbatim back into values.

Three layered defenses:

- **Prompt hardening** in `extract_attributes` (nodes + edges) with hard rules forbidding parenthetical reasoning, deliberative phrases, candidate alternatives, schema-description echoes, and "null"/"N/A" sentence stand-ins.
- **OUTPUT DISCIPLINE block** in the combined extraction prompt to close the "topic-as-Person" failure mode (full-sentence entity names) and pre-empt reasoning leaks into fact text and `relation_type`.
- **Shared attribute-extraction preamble** plumbed through every concrete provider override (OpenAI / Anthropic / Gemini / GLiNER2) via `_apply_attribute_extraction_preamble` on `LLMClient`. The base `generate_response` path is bypassed by every concrete provider's structured-output wiring, so the framing had to land on each override directly. Sentinel-based idempotency (`<<graphiti.attr_extraction.preamble.v1>>`) so it can be called multiple times safely.

Structural backstop: `cap_string_attributes` drops any string attribute >250 chars (configurable per-field via `Field(max_length=...)`, or globally via `GRAPHITI_ATTRIBUTE_MAX_LENGTH`) before it reaches the graph. `list[str]` support enforces both per-item and aggregate (`max_len × 8`) length checks; the aggregate-axis trigger is reported distinctly so DataDog lines don't look like a misconfigured cap. Required-field carve-out retains the value with a louder WARNING rather than dropping (otherwise the over-cap value would `ValidationError` the entire entity). Unified `apply_capped_attributes(merge_mode='overlay'|'replace')` helper makes the node/edge merge asymmetry explicit at each call site. `group_id` flows to the log line for tenant correlation.

### 2. `feat(prompts): improve combined extraction entity precision and edge quality`

Targets six classes of low-quality entities (multi-choice fragments, clock times, quantities, coordinates, imperative tip phrases, slogans) plus two systematic edge regressions (location-fragmentation through scenery intermediaries, dropped multi-episode setup facts).

- ENTITY RULE 6 expanded into 8 sub-bullets covering the targeted skip classes
- ENTITY RULE 9 added for didactic / tutorial scaffolding
- FACT RULE 4 strengthened to call out narrative announcements, forward commitments, plans, emotional setup as real facts in conversational episodes
- FACT RULE 8 added requiring direct speaker-to-target edges over fragmenting through scenery / observed-feature intermediaries
- Negative examples block (A-G) with paired source-and-extraction guidance per class

**Locomo 500-example evaluation (prompt change only):**
- Entity F1: 0.674 (flat); precision −0.028, recall +0.025
- Edge volume: +7.7% over baseline; gold-edge recall +0.9pp
- Fact-text Jaccard on matched edges: 0.341 → 0.381
- Targeted entity classes on LME-derivative sample: quantities −93%, imperative tips −40%

### 3. `feat(saga): use episode reference time for saga summarization watermark`

Saga (thread summary) timestamps were being stamped with wall-clock time instead of the originating episode's reference timestamp.

`SagaNode` now carries two watermarks with deliberately different roles:

- `last_summarized_at` (wall-clock): the **filter** watermark. `summarize_saga` picks up any episode whose `created_at > this value`. Wall-clock + `created_at` comparison keeps backfilled episodes reachable on the next run (a backfilled episode has `valid_at` in the past but `created_at = now`).
- `last_summarized_episode_valid_at` (episode time): the **temporal** watermark. Maximum `valid_at` across episodes covered by the current summary. Public/temporal consumers ("how recent is this summary's content in event-time?") should use this field. Advances monotonically forward.

Other changes:

- `_get_or_create_saga`: rename `now` → `created_at`; callers pass the episode's `valid_at` so a newly minted saga's `created_at` matches the episode that produced it.
- `saga_get_episode_contents` (interface + implementations): return shape widens to `list[tuple[str, datetime | None]]` so callers can compute the episode-time watermark. Filter remains `ep.created_at > since`.
- `nodes.py` + `node_db_queries.py`: `last_summarized_episode_valid_at` field with persistence and read-back wiring (save query, `SAGA_NODE_RETURN`, `get_saga_node_from_record`).

## Bundling

Bundled as a single PR for review economy, since all three changes are self-contained and were already shipped together internally. Happy to split if reviewers prefer.

## Not included here: `max_coroutines` follow-ups

PR #1472 (open, same author) covers the bulk of per-instance `max_coroutines` wiring. Subsequent internal work added (a) per-search-method dispatch threading, (b) lifting the `MAX_COMMUNITY_BUILD_CONCURRENCY` cap, and (c) docstring polish. I'll push those as follow-up commits to that branch rather than duplicating them here.

## Test plan

- [x] `make format`: 1 unrelated reformat (separate commit on this branch)
- [x] `make lint` (ruff + pyright): clean
- [ ] `make test`: ran locally; will rely on CI for the authoritative pass
- [ ] Customer validation on the attribute-bleed fix (covered internally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)