### PR TITLE
Bump graphiti-core version to 0.29.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "graphiti-core"
 description = "A temporal graph building library"
-version = "0.29.0"
+version = "0.29.1"
 authors = [
     { name = "Paul Paliychuk", email = "paul@getzep.com" },
     { name = "Preston Rasmussen", email = "preston@getzep.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -987,7 +987,7 @@ wheels = [
 
 [[package]]
 name = "graphiti-core"
-version = "0.29.0"
+version = "0.29.1"
 source = { editable = "." }
 dependencies = [
     { name = "neo4j" },


### PR DESCRIPTION
## Summary
- Patch bump from 0.29.0 → 0.29.1 ahead of release
- Covers fixes and the forward-port that landed since the 0.29.0 cut: attribute-hallucination guards, combined-extraction precision, saga episode-time watermarks (#1498), MCP provider extras in Docker images (#1461), FalkorDB volume mount fix (#1462), and uv group dependency bumps (#1473)
- Server and MCP server `graphiti-core` requirements will be bumped after 0.29.1 is published to PyPI (matching the prior 0.29.0 process)

## Test plan
- [ ] CI passes (format, lint, tests)
- [ ] After publish: confirm `pip install graphiti-core==0.29.1` resolves on PyPI
- [ ] Follow-up PR to bump server/ and mcp_server/ pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)