### PR TITLE
fix: avoid O(matches×graph) re-MATCH in edge search

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -314,8 +314,8 @@ class FalkorSearchOperations(SearchOperations):
                 'edge_name_and_fact', limit=limit, provider=GraphProvider.FALKORDB
             )
             + """
-            YIELD relationship AS rel, score
-            MATCH (n:Entity)-[e:RELATES_TO {uuid: rel.uuid}]->(m:Entity)
+            YIELD relationship AS e, score
+            WITH e, score, startNode(e) AS n, endNode(e) AS m
             """
             + filter_query
             + """
@@ -427,7 +427,9 @@ class FalkorSearchOperations(SearchOperations):
             UNWIND $bfs_origin_node_uuids AS origin_uuid
             MATCH path = (origin {{uuid: origin_uuid}})-[:RELATES_TO|MENTIONS*1..{max_depth}]->(:Entity)
             UNWIND relationships(path) AS rel
-            MATCH (n:Entity)-[e:RELATES_TO {{uuid: rel.uuid}}]-(m:Entity)
+            WITH rel AS e, startNode(rel) AS n, endNode(rel) AS m
+            WHERE type(e) = 'RELATES_TO'
+            WITH e, n, m
             """
             + filter_query
             + """

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -201,8 +201,8 @@ async def edge_fulltext_search(
         return []
 
     match_query = """
-    YIELD relationship AS rel, score
-    MATCH (n:Entity)-[e:RELATES_TO {uuid: rel.uuid}]->(m:Entity)
+    YIELD relationship AS e, score
+    WITH e, score, startNode(e) AS n, endNode(e) AS m
     """
     if driver.provider == GraphProvider.KUZU:
         match_query = """

--- a/tests/test_falkordb_search_ops.py
+++ b/tests/test_falkordb_search_ops.py
@@ -1,0 +1,68 @@
+"""Query-shape regression tests for FalkorDB edge search (no live database).
+
+Guards the fix for the O(matches×graph) re-MATCH in edge search: the edge
+fulltext and BFS queries must derive endpoints from the relationship returned by
+the index (``startNode``/``endNode``) instead of re-matching every yielded edge
+by uuid against the whole graph (``MATCH (n)-[e {uuid: rel.uuid}]->(m)``), which
+caused multi-minute query times on large graphs.
+
+Harvested and adapted from #1494's driver test; runs as a unit test (a recording
+executor captures the emitted Cypher, so no FalkorDB connection is required).
+"""
+
+from typing import Any
+
+import pytest
+
+from graphiti_core.driver.falkordb.operations.search_ops import FalkorSearchOperations
+from graphiti_core.search.search_filters import SearchFilters
+
+
+class RecordingExecutor:
+    """Captures the Cypher and params a search method emits, returning no rows."""
+
+    def __init__(self):
+        self.cypher_query = ''
+        self.params: dict[str, Any] = {}
+
+    async def execute_query(self, cypher_query_: str, **kwargs: Any):
+        self.cypher_query = cypher_query_
+        self.params = kwargs
+        return [], None, None
+
+
+@pytest.mark.asyncio
+async def test_edge_fulltext_search_uses_returned_relationship_endpoints():
+    executor = RecordingExecutor()
+    operations = FalkorSearchOperations()
+
+    await operations.edge_fulltext_search(
+        executor,
+        'api test system',
+        SearchFilters(),
+        group_ids=['group-a'],
+    )
+
+    assert 'YIELD relationship AS e, score' in executor.cypher_query
+    assert 'WITH e, score, startNode(e) AS n, endNode(e) AS m' in executor.cypher_query
+    # The expensive per-row re-MATCH must be gone.
+    assert 'uuid: rel.uuid' not in executor.cypher_query
+
+
+@pytest.mark.asyncio
+async def test_edge_bfs_search_uses_path_relationship_endpoints():
+    executor = RecordingExecutor()
+    operations = FalkorSearchOperations()
+
+    await operations.edge_bfs_search(
+        executor,
+        ['origin-uuid'],
+        2,
+        SearchFilters(),
+        group_ids=['group-a'],
+    )
+
+    assert 'WITH rel AS e, startNode(rel) AS n, endNode(rel) AS m' in executor.cypher_query
+    # rel is rebound to e before the type guard, so the filter is on type(e).
+    assert "WHERE type(e) = 'RELATES_TO'" in executor.cypher_query
+    assert 'uuid: rel.uuid' not in executor.cypher_query


### PR DESCRIPTION
## Problem

Edge search re-MATCHes every relationship that a fulltext / path call already yielded, instead of using the relationship object directly:

```cypher
CALL db.idx.fulltext.queryRelationships('edge_name_and_fact', $query) YIELD relationship AS rel, score
MATCH (n:Entity)-[e:RELATES_TO {uuid: rel.uuid}]->(m:Entity)
```

The planner can't use the `RELATES_TO.uuid` index to anchor a relationship inside a `(node)-[rel {prop}]->(node)` pattern, so each yielded row triggers a graph-wide scan — O(results × graph).

On a moderately sized FalkorDB graph (**2,852 `Entity` / 18,849 `RELATES_TO` edges**) a single `search_memory_facts` reached **~25 minutes** (`GRAPH.SLOWLOG` latency 1,541,600 ms) and pinned multiple cores. The `db.idx.fulltext.queryRelationships` call itself returns in <1 ms; the re-MATCH is the entire cost.

## Affected code

This re-MATCH pattern appears in two places:

1. **`graphiti_core/search/search_utils.py`** — `edge_fulltext_search`, the **live path** used by `Graphiti.search()` when `driver.search_interface` is unset (the default).
2. **`graphiti_core/driver/falkordb/operations/search_ops.py`** — `edge_fulltext_search` + `edge_bfs_search` in the per-driver search operations.

## Fix

The fulltext / path call already returns the relationship object, so the endpoints are available directly via `startNode()` / `endNode()` — the re-MATCH is unnecessary:

```cypher
CALL db.idx.fulltext.queryRelationships('edge_name_and_fact', $query) YIELD relationship AS e, score
WITH e, score, startNode(e) AS n, endNode(e) AS m
```

`edge_bfs_search` gets the same treatment, with a `type(e) = 'RELATES_TO'` guard since `relationships(path)` over a `RELATES_TO|MENTIONS` path also yields `MENTIONS` edges that the old `[e:RELATES_TO {uuid: ...}]` pattern filtered out implicitly.

## Measurements

Verified end-to-end against a live FalkorDB instance (graphiti-core 0.28.x) — identical `search_memory_facts` calls:

| Search | Before | After |
|---|---:|---:|
| `edge_fulltext_search` (`search_utils.py` path) | ~25 min (timeout) | **<1 s** |
| `edge_fulltext_search` (driver `search_ops.py`) | ~25 min | **~12 ms** |
| `edge_bfs_search` (depth 2, 289-degree origin) | >45 s | **~1 s** |

## Correctness note (`edge_bfs_search`)

The old re-MATCH there was **undirected** — `(n:Entity)-[e:RELATES_TO {uuid: rel.uuid}]-(m:Entity)` — which binds a pinned edge in both directions, returning each edge twice with `source`/`target` swapped (`RETURN DISTINCT` doesn't collapse them). `startNode(e)` / `endNode(e)` returns each edge once in its true orientation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)