### PR TITLE
mcp_server: allow configuring the cross-encoder (reranker)

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -23,6 +23,7 @@ The Graphiti MCP server provides comprehensive knowledge graph capabilities:
 - **Graph Database Support**: Multiple backend options including FalkorDB (default) and Neo4j
 - **Multiple LLM Providers**: Support for OpenAI, Anthropic, Gemini, Groq, and Azure OpenAI
 - **Multiple Embedding Providers**: Support for OpenAI, Voyage, Sentence Transformers, and Gemini embeddings
+- **Configurable Reranker**: OpenAI, Gemini, or local BGE (BAAI/bge-reranker-v2-m3) via sentence-transformers — pick a reranker that matches your LLM/embedder stack instead of being forced onto OpenAI
 - **Rich Entity Types**: Built-in entity types including Preferences, Requirements, Procedures, Locations, Events, Organizations, Documents, and more for structured knowledge extraction
 - **HTTP Transport**: Default HTTP transport with MCP endpoint at `/mcp/` for broad client compatibility
 - **Queue-based Processing**: Asynchronous episode processing with configurable concurrency limits
@@ -170,6 +171,21 @@ llm:
 database:
   provider: "falkordb"  # Default. Options: "falkordb", "neo4j"
 ```
+
+### Reranker Configuration
+
+Graphiti uses a cross-encoder reranker to re-order results during hybrid search. By default `graphiti-core` instantiates `OpenAIRerankerClient`, which requires `OPENAI_API_KEY` even when your LLM and embedder are configured for a different vendor. To avoid that hidden dependency, configure the reranker explicitly:
+
+```yaml
+cross_encoder:
+  provider: "bge"   # Options: openai (default), gemini, bge
+```
+
+- **openai**: Uses OpenAI chat completions for scoring. Requires `OPENAI_API_KEY`.
+- **gemini**: Uses Gemini for scoring. Requires `GOOGLE_API_KEY`.
+- **bge**: Runs `BAAI/bge-reranker-v2-m3` locally via `sentence-transformers`. No API key. Downloads ~2 GB on first run; GPU-accelerated if a CUDA device is available.
+
+Provider-specific keys live under `cross_encoder.providers.<name>` (see `config/config.yaml`).
 
 ### Using Ollama for Local LLM
 

--- a/mcp_server/config/config.yaml
+++ b/mcp_server/config/config.yaml
@@ -70,6 +70,27 @@ embedder:
       api_url: ${VOYAGE_API_URL:https://api.voyageai.com/v1}
       model: "voyage-3"
 
+cross_encoder:
+  # Reranker used for hybrid search result re-ordering. If this section is
+  # omitted, graphiti-core silently falls back to OpenAIRerankerClient, which
+  # requires OPENAI_API_KEY even when llm.provider and embedder.provider are
+  # set to non-OpenAI vendors.
+  #
+  # Options:
+  #   - openai (default): uses OpenAI chat completions for scoring
+  #   - gemini:           uses Gemini for scoring
+  #   - bge:              runs BAAI/bge-reranker-v2-m3 locally via
+  #                       sentence-transformers (no API key, downloads ~2GB
+  #                       on first run, GPU-accelerated if available)
+  provider: "openai"
+  # model: null  # leave unset to use the provider's default
+  providers:
+    openai:
+      api_key: ${OPENAI_API_KEY}
+      api_url: ${OPENAI_API_URL:https://api.openai.com/v1}
+    gemini:
+      api_key: ${GOOGLE_API_KEY}
+
 database:
   provider: "falkordb"  # Default: falkordb. Options: neo4j, falkordb
 

--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -173,6 +173,24 @@ class EmbedderConfig(BaseModel):
     providers: EmbedderProvidersConfig = Field(default_factory=EmbedderProvidersConfig)
 
 
+class CrossEncoderProvidersConfig(BaseModel):
+    """Cross-encoder (reranker) providers configuration."""
+
+    openai: OpenAIProviderConfig | None = None
+    gemini: GeminiProviderConfig | None = None
+
+
+class CrossEncoderConfig(BaseModel):
+    """Cross-encoder (reranker) configuration."""
+
+    provider: str = Field(
+        default='openai',
+        description='Reranker provider: openai, gemini, or bge (local sentence-transformers)',
+    )
+    model: str | None = Field(default=None, description='Model name (provider-specific default if unset)')
+    providers: CrossEncoderProvidersConfig = Field(default_factory=CrossEncoderProvidersConfig)
+
+
 class Neo4jProviderConfig(BaseModel):
     """Neo4j provider configuration."""
 
@@ -232,6 +250,7 @@ class GraphitiConfig(BaseSettings):
     server: ServerConfig = Field(default_factory=ServerConfig)
     llm: LLMConfig = Field(default_factory=LLMConfig)
     embedder: EmbedderConfig = Field(default_factory=EmbedderConfig)
+    cross_encoder: CrossEncoderConfig = Field(default_factory=CrossEncoderConfig)
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)
     graphiti: GraphitiAppConfig = Field(default_factory=GraphitiAppConfig)
 

--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -31,7 +31,12 @@ from models.response_types import (
     StatusResponse,
     SuccessResponse,
 )
-from services.factories import DatabaseDriverFactory, EmbedderFactory, LLMClientFactory
+from services.factories import (
+    CrossEncoderFactory,
+    DatabaseDriverFactory,
+    EmbedderFactory,
+    LLMClientFactory,
+)
 from services.queue_service import QueueService
 from utils.formatting import format_fact_result
 
@@ -187,6 +192,16 @@ class GraphitiService:
             except Exception as e:
                 logger.warning(f'Failed to create embedder client: {e}')
 
+            # Create cross-encoder (reranker) client based on configured provider
+            cross_encoder_client = None
+            try:
+                cross_encoder_client = CrossEncoderFactory.create(self.config.cross_encoder)
+            except Exception as e:
+                logger.warning(
+                    f'Failed to create cross-encoder client: {e} — '
+                    'Graphiti will fall back to its default OpenAIRerankerClient'
+                )
+
             # Get database configuration
             db_config = DatabaseDriverFactory.create_config(self.config.database)
 
@@ -226,6 +241,7 @@ class GraphitiService:
                         graph_driver=falkor_driver,
                         llm_client=llm_client,
                         embedder=embedder_client,
+                        cross_encoder=cross_encoder_client,
                         max_coroutines=self.semaphore_limit,
                     )
                 else:
@@ -236,6 +252,7 @@ class GraphitiService:
                         password=db_config['password'],
                         llm_client=llm_client,
                         embedder=embedder_client,
+                        cross_encoder=cross_encoder_client,
                         max_coroutines=self.semaphore_limit,
                     )
             except Exception as db_error:

--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -1,6 +1,7 @@
 """Factory classes for creating LLM, Embedder, and Database clients."""
 
 from config.schema import (
+    CrossEncoderConfig,
     DatabaseConfig,
     EmbedderConfig,
     LLMConfig,
@@ -68,6 +69,23 @@ try:
     HAS_GROQ = True
 except ImportError:
     HAS_GROQ = False
+
+try:
+    from graphiti_core.cross_encoder.bge_reranker_client import BGERerankerClient
+
+    HAS_BGE_RERANKER = True
+except ImportError:
+    HAS_BGE_RERANKER = False
+
+try:
+    from graphiti_core.cross_encoder.gemini_reranker_client import GeminiRerankerClient
+
+    HAS_GEMINI_RERANKER = True
+except ImportError:
+    HAS_GEMINI_RERANKER = False
+
+from graphiti_core.cross_encoder.client import CrossEncoderClient
+from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient
 
 
 def _validate_api_key(provider_name: str, api_key: str | None, logger) -> str:
@@ -356,6 +374,62 @@ class EmbedderFactory:
 
             case _:
                 raise ValueError(f'Unsupported Embedder provider: {provider}')
+
+
+class CrossEncoderFactory:
+    """Factory for creating Cross-encoder (reranker) clients based on configuration."""
+
+    @staticmethod
+    def create(config: CrossEncoderConfig) -> CrossEncoderClient:
+        """Create a Cross-encoder client based on the configured provider."""
+        import logging
+
+        logger = logging.getLogger(__name__)
+
+        provider = config.provider.lower()
+
+        match provider:
+            case 'openai':
+                openai_cfg = config.providers.openai
+                if not openai_cfg:
+                    raise ValueError('OpenAI cross-encoder provider configuration not found')
+                api_key = _validate_api_key('OpenAI Reranker', openai_cfg.api_key, logger)
+
+                from graphiti_core.llm_client.config import LLMConfig as CoreLLMConfig
+
+                llm_config = CoreLLMConfig(api_key=api_key, base_url=openai_cfg.api_url)
+                if config.model:
+                    llm_config.model = config.model
+                return OpenAIRerankerClient(config=llm_config)
+
+            case 'gemini':
+                if not HAS_GEMINI_RERANKER:
+                    raise ValueError(
+                        'Gemini reranker not available in current graphiti-core version'
+                    )
+                gemini_cfg = config.providers.gemini
+                if not gemini_cfg:
+                    raise ValueError('Gemini cross-encoder provider configuration not found')
+                api_key = _validate_api_key('Gemini Reranker', gemini_cfg.api_key, logger)
+
+                from graphiti_core.llm_client.config import LLMConfig as CoreLLMConfig
+
+                llm_config = CoreLLMConfig(api_key=api_key)
+                if config.model:
+                    llm_config.model = config.model
+                return GeminiRerankerClient(config=llm_config)
+
+            case 'bge':
+                if not HAS_BGE_RERANKER:
+                    raise ValueError(
+                        'BGE reranker not available — install sentence-transformers '
+                        '(uv sync --extra sentence-transformers or pip install graphiti-core[sentence-transformers])'
+                    )
+                logger.info('Creating BGE local reranker (BAAI/bge-reranker-v2-m3)')
+                return BGERerankerClient()
+
+            case _:
+                raise ValueError(f'Unsupported Cross-encoder provider: {provider}')
 
 
 class DatabaseDriverFactory:


### PR DESCRIPTION
## Summary

The MCP server silently forces an `OPENAI_API_KEY` dependency even when both `llm.provider` and `embedder.provider` are set to non-OpenAI vendors. This PR makes the cross-encoder configurable, mirroring the existing LLM/Embedder factory pattern.

## The problem

`graphiti-core/graphiti.py` defaults its cross-encoder to `OpenAIRerankerClient()` when one isn't supplied:

\`\`\`python
if cross_encoder:
    self.cross_encoder = cross_encoder
else:
    self.cross_encoder = OpenAIRerankerClient()
\`\`\`

The MCP server never passes \`cross_encoder=\` in either of its two \`Graphiti(...)\` call sites (Neo4j and FalkorDB). Result: a user who configures Anthropic+Voyage and assumes they've escaped the OpenAI dependency hits this at startup:

\`\`\`
openai.OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
\`\`\`

The README does not mention rerankers, the config schema has no \`cross_encoder:\` section, and there's no startup log line warning about the fallback. The error surface is a traceback into a third-party module rather than a configuration error from the MCP server.

## What this PR changes

Follows the same pattern as the existing LLM and Embedder factories:

- **\`config/schema.py\`** — adds \`CrossEncoderProvidersConfig\` and \`CrossEncoderConfig\`, plus a top-level \`cross_encoder\` field on \`GraphitiConfig\`.
- **\`services/factories.py\`** — adds \`CrossEncoderFactory\` with three providers:
  - \`openai\` (default — preserves current behavior exactly)
  - \`gemini\` — uses \`GeminiRerankerClient\`
  - \`bge\` — runs \`BAAI/bge-reranker-v2-m3\` locally via \`sentence-transformers\` (no API key, GPU-accelerated if available)
- **\`graphiti_mcp_server.py\`** — builds the reranker via the factory and passes it to both \`Graphiti(...)\` call sites. If factory construction fails, logs a warning and lets graphiti-core fall back — so existing deployments are not regressed.
- **\`config/config.yaml\`** — documents the new section with a comment explaining the silent-default behavior.
- **\`README.md\`** — adds a \"Reranker Configuration\" section so users discover this knob without reading source.

## Backwards compatibility

Default behavior is unchanged. Omitting \`cross_encoder:\` from \`config.yaml\` leaves the factory's provider at \`\"openai\"\`, which constructs the same \`OpenAIRerankerClient()\` graphiti-core would have built. No existing deployment needs changes.

## Test plan

- [x] Smoke-tested end-to-end with \`provider: bge\` against Anthropic LLM + Voyage embedder + Neo4j 5.26: \`Successfully initialized Graphiti client\`, all MCP tools register, stdio handshake completes (\`claude mcp list\` reports \`✓ Connected\`).
- [ ] Should also be smoke-tested with \`provider: openai\` (default) to confirm zero-change behavior.
- [ ] Should be smoke-tested with \`provider: gemini\` if a maintainer has a \`GOOGLE_API_KEY\` handy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)