### PR TITLE
fix(falkor): use valid default group id

### DIFF
--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -109,7 +109,7 @@ class FalkorDriverSession(GraphDriverSession):
 
 class FalkorDriver(GraphDriver):
     provider = GraphProvider.FALKORDB
-    default_group_id: str = '\\_'
+    default_group_id: str = '_'
     fulltext_syntax: str = '@'  # FalkorDB uses a redisearch-like syntax for fulltext queries
     aoss_client: None = None
 

--- a/graphiti_core/helpers.py
+++ b/graphiti_core/helpers.py
@@ -71,7 +71,7 @@ def get_default_group_id(provider: GraphProvider) -> str:
     For most databases, the default group id is an empty string, while there are database types that require a specific default group id.
     """
     if provider == GraphProvider.FALKORDB:
-        return '\\_'
+        return '_'
     else:
         return ''
 

--- a/tests/test_group_id_validation.py
+++ b/tests/test_group_id_validation.py
@@ -1,0 +1,10 @@
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.falkordb_driver import FalkorDriver
+from graphiti_core.helpers import get_default_group_id, validate_group_id
+
+
+def test_falkor_default_group_id_is_valid():
+    group_id = get_default_group_id(GraphProvider.FALKORDB)
+
+    assert group_id == FalkorDriver.default_group_id
+    assert validate_group_id(group_id)


### PR DESCRIPTION
﻿## Summary
- change FalkorDB's default group id from the escaped string `\_` to the valid id `_`
- keep `get_default_group_id(GraphProvider.FALKORDB)` and `FalkorDriver.default_group_id` in sync
- add a regression test that the FalkorDB default passes `validate_group_id`

Fixes #1465.

## Tests
- `uv run pytest tests\test_group_id_validation.py -q`
- `uv run ruff check graphiti_core\helpers.py graphiti_core\driver\falkordb_driver.py tests\test_group_id_validation.py`
- `python -m py_compile graphiti_core\helpers.py graphiti_core\driver\falkordb_driver.py tests\test_group_id_validation.py`
- `git diff --check`
