### PR TITLE
fix(kuzu): set _database default and create FTS indices in build_indices_and_constraints (#1258)

### DIFF
--- a/graphiti_core/driver/kuzu_driver.py
+++ b/graphiti_core/driver/kuzu_driver.py
@@ -44,6 +44,7 @@ from graphiti_core.driver.operations.has_episode_edge_ops import HasEpisodeEdgeO
 from graphiti_core.driver.operations.next_episode_edge_ops import NextEpisodeEdgeOperations
 from graphiti_core.driver.operations.saga_node_ops import SagaNodeOperations
 from graphiti_core.driver.operations.search_ops import SearchOperations
+from graphiti_core.graph_queries import get_fulltext_indices, get_range_indices
 
 logger = logging.getLogger(__name__)
 
@@ -143,6 +144,11 @@ class KuzuDriver(GraphDriver):
         max_concurrent_queries: int = 1,
     ):
         super().__init__()
+        # GraphDriver declares ``_database: str`` typed but with no default;
+        # Graphiti.add_episode and add_episode_bulk both read
+        # ``self.driver._database``. Empty string mirrors
+        # ``default_group_id: str = ''`` on the base class. See #1258.
+        self._database = ''
         self.db = kuzu.Database(db)
 
         self.setup_schema()
@@ -243,10 +249,30 @@ class KuzuDriver(GraphDriver):
         pass
 
     async def build_indices_and_constraints(self, delete_existing: bool = False):
-        # Kuzu doesn't support dynamic index creation like Neo4j or FalkorDB
-        # Schema and indices are created during setup_schema()
-        # This method is required by the abstract base class but is a no-op for Kuzu
-        pass
+        # ``setup_schema`` creates the *tables*; FTS indices are a separate pass
+        # via ``CALL CREATE_FTS_INDEX``. ``Graphiti.build_indices_and_constraints``
+        # calls into this method (not graph_ops directly), so this is the entry
+        # point that must produce the FTS indices — otherwise subsequent
+        # ``CALL QUERY_FTS_INDEX`` raises ``Table X doesn't have an index Y``.
+        #
+        # We can't delegate to ``self._graph_ops.build_indices_and_constraints``
+        # because (a) Kuzu has no ``CREATE_FTS_INDEX IF NOT EXISTS`` and raises
+        # ``Index <name> already exists`` on a second call, and (b) graph_ops
+        # uses ``semaphore_gather`` with no idempotency. So we iterate
+        # sequentially and treat ``delete_existing=False`` as "ensure indices
+        # exist", swallowing the specific "already exists" error class.
+        # See #1258.
+        queries = get_range_indices(GraphProvider.KUZU) + get_fulltext_indices(
+            GraphProvider.KUZU
+        )
+        for query in queries:
+            try:
+                await self.execute_query(query)
+            except Exception as e:  # noqa: BLE001 — narrowed on message below
+                if 'already exists' in str(e) and not delete_existing:
+                    logger.debug('Index already exists, skipping: %s', query[:80])
+                    continue
+                raise
 
     def setup_schema(self):
         conn = kuzu.Connection(self.db)

--- a/tests/driver/test_kuzu_driver.py
+++ b/tests/driver/test_kuzu_driver.py
@@ -1,0 +1,127 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+---
+
+Regression tests for #1258:
+
+  - KuzuDriver was missing the ``_database`` attribute that
+    ``Graphiti.add_episode`` and ``add_episode_bulk`` read.
+  - KuzuDriver.build_indices_and_constraints was a no-op, so the FTS
+    indices required by search queries never got created through the
+    ``Graphiti.build_indices_and_constraints`` entry point.
+"""
+
+import unittest
+
+import pytest
+
+from graphiti_core.driver.driver import GraphProvider
+
+try:
+    from graphiti_core.driver.kuzu_driver import KuzuDriver
+
+    HAS_KUZU = True
+except ImportError:
+    KuzuDriver = None
+    HAS_KUZU = False
+
+
+class TestKuzuDriverDatabaseAndFTS:
+    """Regression tests for the two bugs reported in #1258."""
+
+    @unittest.skipIf(not HAS_KUZU, 'kuzu is not installed')
+    def test_provider_is_kuzu(self):
+        driver = KuzuDriver(':memory:')
+        assert driver.provider == GraphProvider.KUZU
+
+    @unittest.skipIf(not HAS_KUZU, 'kuzu is not installed')
+    def test_database_attribute_is_set(self):
+        """Bug 1 from #1258: KuzuDriver.__init__ must set ``_database``.
+
+        Without this, ``Graphiti.add_episode`` (graphiti.py:1032) and
+        ``Graphiti.add_episode_bulk`` (graphiti.py:1113) raise
+        ``AttributeError: 'KuzuDriver' object has no attribute '_database'``.
+        Empty string matches ``GraphDriver.default_group_id: str = ''``.
+        """
+        driver = KuzuDriver(':memory:')
+        assert hasattr(driver, '_database')
+        assert driver._database == ''
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_KUZU, 'kuzu is not installed')
+    async def test_build_indices_and_constraints_creates_fts_indices(self):
+        """Bug 2 from #1258: ``build_indices_and_constraints`` was a no-op.
+
+        ``Graphiti.build_indices_and_constraints`` calls into the driver's
+        method (not graph_ops directly), so this is the entry point that
+        must produce the FTS indices. Without them, subsequent
+        ``CALL QUERY_FTS_INDEX`` raises:
+            ``Binder exception: Table Entity doesn't have an index with name node_name_and_summary``
+        """
+        driver = KuzuDriver(':memory:')
+        await driver.build_indices_and_constraints(delete_existing=False)
+
+        # If FTS indices were built, this query runs without raising.
+        # (Returns an empty result because no Entities were inserted.)
+        rows, _, _ = await driver.execute_query(
+            "CALL QUERY_FTS_INDEX('Entity', 'node_name_and_summary', 'test', TOP := 10) "
+            'RETURN node.uuid AS uuid'
+        )
+        assert rows == []
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_KUZU, 'kuzu is not installed')
+    async def test_build_indices_and_constraints_is_idempotent(self):
+        """Calling ``build_indices_and_constraints`` twice with
+        ``delete_existing=False`` must not raise. ``Graphiti`` may call
+        it multiple times across a process lifetime."""
+        driver = KuzuDriver(':memory:')
+        await driver.build_indices_and_constraints(delete_existing=False)
+        # Second call must not raise.
+        await driver.build_indices_and_constraints(delete_existing=False)
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_KUZU, 'kuzu is not installed')
+    async def test_search_pipeline_after_build_indices_works(self):
+        """End-to-end smoke: after build_indices_and_constraints, the
+        complete FTS pipeline (insert + search) succeeds. This is the
+        scenario the original #1258 bug report blocks on."""
+        from datetime import datetime, timezone
+
+        driver = KuzuDriver(':memory:')
+        await driver.build_indices_and_constraints(delete_existing=False)
+
+        # Insert one Entity and search via the FTS index.
+        await driver.execute_query(
+            'CREATE (n:Entity {uuid: $uuid, name: $name, group_id: $gid, '
+            'labels: $labels, created_at: $created_at, '
+            'name_embedding: $embedding, summary: $summary, attributes: $attrs})',
+            uuid='u1',
+            name='Avaloq Core',
+            gid='g',
+            labels=['App'],
+            created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            embedding=[0.1] * 1024,
+            summary='core banking',
+            attrs='{}',
+        )
+
+        rows, _, _ = await driver.execute_query(
+            "CALL QUERY_FTS_INDEX('Entity', 'node_name_and_summary', 'Avaloq', TOP := 10) "
+            'RETURN node.uuid AS uuid'
+        )
+        uuids = {r['uuid'] for r in rows}
+        assert 'u1' in uuids


### PR DESCRIPTION
Fixes #1258.

Two bugs in `KuzuDriver` that prevent `add_episode` and `search` from running end-to-end on v0.28+. Both surfaced independently while building a sibling `LadybugDriver` (LadybugDB is the embedded MIT-licensed Kuzu successor; that's a separate RFC discussion I'll open after this lands).

## Bug 1 — Missing `_database` attribute

`GraphDriver` declares `_database: str` as a typed-but-unbacked attribute. `Graphiti.add_episode` (graphiti.py:1032) and `Graphiti.add_episode_bulk` (graphiti.py:1113) both read `self.driver._database` for a group-id sanity check. `Neo4jDriver` sets it; `KuzuDriver.__init__` doesn't, so any call into those paths raises:

```
AttributeError: 'KuzuDriver' object has no attribute '_database'.
```

**Fix:** `self._database = ''` in `__init__`, mirroring `default_group_id: str = ''` on the base class.

## Bug 2 — `build_indices_and_constraints` was a no-op

The original comment claimed *"schema and indices are created during setup_schema()"*. That's a half-truth: `setup_schema` creates the *tables*, but FTS indices are emitted by `get_fulltext_indices(GraphProvider.KUZU)` and need a separate `CALL CREATE_FTS_INDEX` pass. `Graphiti.build_indices_and_constraints` calls into this driver method (not graph_ops directly), so the FTS pass never happened through the Graphiti entry point and subsequent `CALL QUERY_FTS_INDEX` raised:

```
Binder exception: Table Entity doesn't have an index with name node_name_and_summary.
```

**Fix:** iterate `get_range_indices` + `get_fulltext_indices` sequentially and swallow the specific `already exists` error class when `delete_existing=False`. The sequential + idempotent path is required because Kuzu does **not** support `CREATE_FTS_INDEX IF NOT EXISTS` — a second call to `build_indices_and_constraints` would otherwise raise `Binder exception: Index <name> already exists`. I verified this against `kuzu>=0.11.3` locally.

Note: I considered delegating to `self._graph_ops.build_indices_and_constraints` but it uses `semaphore_gather` with no idempotency, so the same duplicate-creation problem would surface there. Iterating in the driver keeps the failure mode predictable.

## Tests

New `tests/driver/test_kuzu_driver.py` — five tests, all skipped if `kuzu` is not installed (same `try/except ImportError` pattern as `test_falkordb_driver.py`):

| Test | Asserts |
|---|---|
| `test_provider_is_kuzu` | basic smoke |
| `test_database_attribute_is_set` | Bug 1 regression: `_database == ''` after construction |
| `test_build_indices_and_constraints_creates_fts_indices` | Bug 2 regression: `CALL QUERY_FTS_INDEX` runs without raising after `build_indices_and_constraints` |
| `test_build_indices_and_constraints_is_idempotent` | second call with `delete_existing=False` does not raise |
| `test_search_pipeline_after_build_indices_works` | end-to-end: insert + FTS query succeed |

All 5 pass locally with `kuzu>=0.11.3` installed. Existing FalkorDB tests untouched. No new ruff warnings.

## Verification

```
$ uv pip install -e ".[dev,kuzu]"
$ pytest tests/driver/ -v
...
======================== 28 passed, 1 skipped, 1 warning in 0.39s ========================
$ ruff check graphiti_core/driver/kuzu_driver.py tests/driver/test_kuzu_driver.py
All checks passed!
```

## Diff summary

- `graphiti_core/driver/kuzu_driver.py` — +30 / −4 (one new import, two edited methods)
- `tests/driver/test_kuzu_driver.py` — +127 (new file)

Total: 157 insertions, 4 deletions. Well under the 500-LOC RFC threshold from CONTRIBUTING.md.

## Note about the LadybugDriver

I'm working on adding a `LadybugDriver` for LadybugDB (Kuzu's embedded MIT-licensed successor). The two bugs above surfaced first there, and were then reproducible against `KuzuDriver`. The Ladybug work needs an RFC per CONTRIBUTING.md and will land in a separate issue+PR — this fix is the prerequisite, not the introduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>