### PR TITLE
fix: validate embeddings for NaN/Inf values with automatic retry

### DIFF
--- a/graphiti_core/embedder/openai.py
+++ b/graphiti_core/embedder/openai.py
@@ -14,12 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import logging
+
+import numpy as np
 from collections.abc import Iterable
 
 from openai import AsyncAzureOpenAI, AsyncOpenAI
 from openai.types import EmbeddingModel
 
 from .client import EmbedderClient, EmbedderConfig
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_EMBEDDING_MODEL = 'text-embedding-3-small'
 
@@ -51,16 +56,66 @@ class OpenAIEmbedder(EmbedderClient):
         else:
             self.client = AsyncOpenAI(api_key=config.api_key, base_url=config.base_url)
 
+    async def _validate_embedding(self, embedding: list[float], label: str) -> list[float]:
+        """Validate embedding for NaN/Inf values. Retry once if invalid."""
+        arr = np.asarray(embedding, dtype=np.float64)
+        if np.all(np.isfinite(arr)):
+            return embedding
+
+        bad_count = int(np.sum(~np.isfinite(arr)))
+        logger.warning(
+            f'Embedding contains {bad_count}/{len(embedding)} NaN/Inf values '
+            f'(label: {label}). Retrying...'
+        )
+        raise ValueError(
+            f'Embedding returned {bad_count}/{len(embedding)} non-finite values. '
+            f'The provider may have returned a corrupt response.'
+        )
+
     async def create(
         self, input_data: str | list[str] | Iterable[int] | Iterable[Iterable[int]]
     ) -> list[float]:
         result = await self.client.embeddings.create(
             input=input_data, model=self.config.embedding_model
         )
-        return result.data[0].embedding[: self.config.embedding_dim]
+        embedding = result.data[0].embedding[: self.config.embedding_dim]
+        try:
+            return await self._validate_embedding(embedding, 'create')
+        except ValueError:
+            # Retry once: NaN could be transient provider-side corruption
+            logger.info('Retrying embedding call after NaN detection...')
+            result = await self.client.embeddings.create(
+                input=input_data, model=self.config.embedding_model
+            )
+            embedding = result.data[0].embedding[: self.config.embedding_dim]
+            await self._validate_embedding(embedding, 'create_retry')
+            return embedding
 
     async def create_batch(self, input_data_list: list[str]) -> list[list[float]]:
         result = await self.client.embeddings.create(
             input=input_data_list, model=self.config.embedding_model
         )
-        return [embedding.embedding[: self.config.embedding_dim] for embedding in result.data]
+        embeddings = [
+            embedding.embedding[: self.config.embedding_dim] for embedding in result.data
+        ]
+        try:
+            validated = []
+            for i, emb in enumerate(embeddings):
+                validated.append(await self._validate_embedding(emb, f'batch[{i}]'))
+            return validated
+        except ValueError:
+            pass
+
+        # Retry full batch once
+        logger.info(f'Retrying batch embedding call after NaN detection...')
+        result = await self.client.embeddings.create(
+            input=input_data_list, model=self.config.embedding_model
+        )
+        embeddings_retry = [
+            e.embedding[: self.config.embedding_dim] for e in result.data
+        ]
+        validated = []
+        for j, emb_retry in enumerate(embeddings_retry):
+            await self._validate_embedding(emb_retry, f'batch_retry[{j}]')
+            validated.append(emb_retry)
+        return validated


### PR DESCRIPTION
## Description

Embedding providers can occasionally return corrupted responses containing NaN or Inf values in the embedding vector. When this happens, cosine similarity comparisons (used for entity deduplication) silently produce wrong results — `cosine_similarity(NaN, any_vector)` never exceeds 0.6, causing the dedup step to miss existing entities and create duplicate nodes.

This is related to Issue #1505.

### Changes
1. Added `_validate_embedding()` method that checks for NaN/Inf using numpy
2. On detection, logs a warning and raises ValueError to trigger a single retry
3. Both `create()` and `create_batch()` use this validation with automatic retry
4. Added `logging` and `numpy` imports

### Testing
- Tested with a local FalkorDB instance and DeepSeek/Tencent embedding APIs
- NaN detection correctly catches corrupt embeddings and retries
- After retry, the second call typically returns valid embeddings