### PR TITLE
fix: correct sort direction in episode_mentions_reranker

### DIFF
--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -1888,10 +1888,10 @@ async def episode_mentions_reranker(
 
     for uuid in sorted_uuids:
         if uuid not in scores:
-            scores[uuid] = float('inf')
+            scores[uuid] = 0
 
-    # rerank on shortest distance
-    sorted_uuids.sort(key=lambda cur_uuid: scores[cur_uuid])
+    # rerank on mention count (most mentioned first)
+    sorted_uuids.sort(key=lambda cur_uuid: scores[cur_uuid], reverse=True)
 
     return [uuid for uuid in sorted_uuids if scores[uuid] >= min_score], [
         scores[uuid] for uuid in sorted_uuids if scores[uuid] >= min_score


### PR DESCRIPTION
Fix sort direction in episode_mentions_reranker. Two changes: 1) float(inf) to 0 so zero-mention nodes sort to bottom 2) Added reverse=True for descending mention count. Closes #1342