### PR TITLE
Track scheduled driver index build tasks

### DIFF
--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -173,7 +173,6 @@ class FalkorDriver(GraphDriver):
         self._next_episode_edge_ops = FalkorNextEpisodeEdgeOperations()
         self._search_ops = FalkorSearchOperations()
         self._graph_ops = FalkorGraphMaintenanceOperations()
-
         self._init_task: asyncio.Task | None = None
         # Schedule the indices and constraints to be built
         try:

--- a/graphiti_core/driver/neo4j_driver.py
+++ b/graphiti_core/driver/neo4j_driver.py
@@ -88,7 +88,6 @@ class Neo4jDriver(GraphDriver):
         self._next_episode_edge_ops = Neo4jNextEpisodeEdgeOperations()
         self._search_ops = Neo4jSearchOperations()
         self._graph_ops = Neo4jGraphMaintenanceOperations()
-
         self._init_task: asyncio.Task | None = None
         # Schedule the indices and constraints to be built
         try:

--- a/tests/driver/test_falkordb_driver.py
+++ b/tests/driver/test_falkordb_driver.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import asyncio
 import os
 import unittest
 from datetime import datetime, timezone
@@ -216,13 +217,41 @@ class TestFalkorDriver:
             # hasattr(self.client, 'aclose') returns False
             # hasattr(self.client.connection, 'aclose') returns False
             # hasattr(self.client.connection, 'close') returns True
-            mock_hasattr.side_effect = lambda obj, attr: (
-                attr == 'close' and obj is mock_connection
-            )
+            mock_hasattr.side_effect = lambda obj, attr: attr == 'close' and obj is mock_connection
 
             await self.driver.close()
 
         mock_connection.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_close_cancels_pending_init_task(self):
+        """Test driver close cancels the constructor-scheduled index build task."""
+        started = asyncio.Event()
+        mock_client = MagicMock()
+        mock_client.aclose = AsyncMock()
+
+        async def build_indices_and_constraints(self, delete_existing: bool = False):
+            started.set()
+            await asyncio.Event().wait()
+
+        with (
+            patch('graphiti_core.driver.falkordb_driver.FalkorDB', return_value=mock_client),
+            patch.object(
+                FalkorDriver,
+                'build_indices_and_constraints',
+                build_indices_and_constraints,
+            ),
+        ):
+            driver = FalkorDriver()
+            assert driver._init_task is not None
+            await asyncio.wait_for(started.wait(), timeout=1)
+
+            task = driver._init_task
+            await driver.close()
+
+        assert task.cancelled()
+        mock_client.aclose.assert_awaited_once()
 
     @pytest.mark.asyncio
     @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')

--- a/tests/driver/test_neo4j_driver.py
+++ b/tests/driver/test_neo4j_driver.py
@@ -1,0 +1,53 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graphiti_core.driver.neo4j_driver import Neo4jDriver
+
+
+@pytest.mark.asyncio
+async def test_close_cancels_pending_init_task():
+    started = asyncio.Event()
+    mock_client = MagicMock()
+    mock_client.close = AsyncMock()
+
+    async def build_indices_and_constraints(self, delete_existing: bool = False):
+        started.set()
+        await asyncio.Event().wait()
+
+    with (
+        patch(
+            'graphiti_core.driver.neo4j_driver.AsyncGraphDatabase.driver', return_value=mock_client
+        ),
+        patch.object(
+            Neo4jDriver,
+            'build_indices_and_constraints',
+            build_indices_and_constraints,
+        ),
+    ):
+        driver = Neo4jDriver('bolt://localhost:7687', 'neo4j', 'password')
+        assert driver._init_task is not None
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+        task = driver._init_task
+        await driver.close()
+
+    assert task.cancelled()
+    mock_client.close.assert_awaited_once()


### PR DESCRIPTION
## Summary

Fixes #1513 by keeping references to the constructor-scheduled index build tasks in the Neo4j and FalkorDB drivers, then cancelling/awaiting them during driver close before closing the underlying database client.

This prevents the fire-and-forget `build_indices_and_constraints()` task from being abandoned when a function-scoped event loop or short-lived application shuts down.

## Changes

- Store the scheduled index build task on `Neo4jDriver` and `FalkorDriver`
- On `close()`, retrieve completed task exceptions or cancel and await pending tasks
- Add regression coverage for pending index task cleanup in both drivers

## Tests

- `/tmp/graphiti/.venv/bin/python -m ruff check graphiti_core/driver/neo4j_driver.py graphiti_core/driver/falkordb_driver.py tests/driver/test_neo4j_driver.py tests/driver/test_falkordb_driver.py`
- `/tmp/graphiti/.venv/bin/python -m pytest tests/driver/test_neo4j_driver.py tests/driver/test_falkordb_driver.py`

Result: 25 passed, 1 skipped.

I have read and agree to the Zep CLA.
