### PR TITLE
fix: exclude chat/search variants from reasoning-model detection (#902)

### DIFF
--- a/graphiti_core/llm_client/openai_client.py
+++ b/graphiti_core/llm_client/openai_client.py
@@ -24,6 +24,20 @@ from .config import DEFAULT_MAX_TOKENS, LLMConfig
 from .openai_base_client import DEFAULT_REASONING, DEFAULT_VERBOSITY, BaseOpenAIClient
 
 
+def _is_reasoning_model(model: str) -> bool:
+    """Return True for OpenAI reasoning models (o1/o3/gpt-5 family) that accept
+    the `reasoning.effort` parameter.
+
+    Chat-tuned and search variants (e.g. ``gpt-5-chat-latest``,
+    ``gpt-5-search-api``) match the ``gpt-5`` prefix but are NOT reasoning
+    models — they reject ``reasoning.effort`` and must route through the normal
+    completion path without it. See issue #902.
+    """
+    if '-chat' in model or '-search' in model:
+        return False
+    return model.startswith(('gpt-5', 'o1', 'o3'))
+
+
 class OpenAIClient(BaseOpenAIClient):
     """
     OpenAIClient is a client class for interacting with OpenAI's language models.
@@ -73,10 +87,9 @@ class OpenAIClient(BaseOpenAIClient):
         verbosity: str | None = None,
     ):
         """Create a structured completion using OpenAI's beta parse API."""
-        # Reasoning models (gpt-5 family) don't support temperature
-        is_reasoning_model = (
-            model.startswith('gpt-5') or model.startswith('o1') or model.startswith('o3')
-        )
+        # Reasoning models (o1/o3/gpt-5, excluding chat/search variants) don't
+        # support temperature and require the reasoning.effort param; see _is_reasoning_model.
+        is_reasoning_model = _is_reasoning_model(model)
 
         request_kwargs = {
             'model': model,
@@ -111,10 +124,9 @@ class OpenAIClient(BaseOpenAIClient):
         verbosity: str | None = None,
     ):
         """Create a regular completion with JSON format."""
-        # Reasoning models (gpt-5 family) don't support temperature
-        is_reasoning_model = (
-            model.startswith('gpt-5') or model.startswith('o1') or model.startswith('o3')
-        )
+        # Reasoning models (o1/o3/gpt-5, excluding chat/search variants) don't
+        # support temperature and require the reasoning.effort param; see _is_reasoning_model.
+        is_reasoning_model = _is_reasoning_model(model)
 
         return await self.client.chat.completions.create(
             model=model,

--- a/tests/llm_client/test_openai_reasoning_detection.py
+++ b/tests/llm_client/test_openai_reasoning_detection.py
@@ -1,0 +1,27 @@
+import pytest
+
+from graphiti_core.llm_client.openai_client import _is_reasoning_model
+
+
+@pytest.mark.parametrize(
+    'model,expected',
+    [
+        # reasoning models -> param should be sent
+        ('gpt-5', True),
+        ('gpt-5-mini', True),
+        ('gpt-5.4', True),
+        ('o1', True),
+        ('o3', True),
+        ('o3-mini', True),
+        # chat / search variants -> param must NOT be sent (issue #902)
+        ('gpt-5-chat-latest', False),
+        ('gpt-5.3-chat-latest', False),
+        ('gpt-5-search-api', False),
+        # non-reasoning models
+        ('gpt-4o', False),
+        ('gpt-4.1', False),
+        ('gpt-4o-mini', False),
+    ],
+)
+def test_is_reasoning_model(model: str, expected: bool) -> None:
+    assert _is_reasoning_model(model) is expected


### PR DESCRIPTION
## Summary
Fixes #902.

`OpenAIClient` decides whether to send `reasoning.effort` via `model.startswith(('gpt-5','o1','o3'))`. That also matches non-reasoning variants i.e.  `gpt-5-chat-latest`, `gpt-5.3-chat-latest`, `gpt-5-search-api`, which reject the parameter and return:
`400 - Unsupported parameter: 'reasoning.effort' is not supported with this model.`

This is the failure reported in #902.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
Extract the detection into a shared `_is_reasoning_model()` helper used by both completion paths (the predicate was duplicated), and exclude `-chat`/`-search` variants so they route through the normal path without the reasoning param.

Distinct from #1378/#1395, which change the effort *value* (`minimal`→`low`). For chat/search variants no value works, the parameter itself is unsupported. `gpt-5-mini` and other true reasoning models remain correctly classified.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

Added `tests/llm_client/test_openai_reasoning_detection.py` (parametrized: reasoning models → True, chat/search variants → False, gpt-4o/4.1 → False). `make format`, `make lint`, `make pyright` all clean.

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Closes #902

## Open question for maintainers
The same prefix check is mirrored in `mcp_server/src/services/factories.py`. I scoped this PR to `graphiti_core` (self-contained, benefits all consumers). Happy to extend to the MCP factory here or in a follow-up. 