### PR TITLE
fix: handle datetime/date in to_prompt_json

### DIFF
--- a/graphiti_core/prompts/prompt_helpers.py
+++ b/graphiti_core/prompts/prompt_helpers.py
@@ -15,9 +15,25 @@ limitations under the License.
 """
 
 import json
+from datetime import date, datetime
 from typing import Any
 
 DO_NOT_ESCAPE_UNICODE = '\nDo not escape unicode characters.\n'
+
+
+def _json_fallback(obj: Any) -> str:
+    """`json.dumps(default=...)` handler for values the stock encoder rejects.
+
+    Entity and edge attribute dicts commonly carry `datetime`/`date` values
+    (e.g. a date extracted into an entity attribute). Without a fallback,
+    serializing them for a prompt raises
+    `TypeError: Object of type datetime is not JSON serializable`. Dates are
+    rendered as ISO-8601; any other non-serializable value falls back to its
+    `str()` so prompt construction never crashes.
+    """
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    return str(obj)
 
 
 def to_prompt_json(data: Any, ensure_ascii: bool = False, indent: int | None = None) -> str:
@@ -36,5 +52,10 @@ def to_prompt_json(data: Any, ensure_ascii: bool = False, indent: int | None = N
         By default (ensure_ascii=False), non-ASCII characters (e.g., Korean, Japanese, Chinese)
         are preserved in their original form in the prompt, making them readable
         in LLM logs and improving model understanding.
+
+        Values the standard JSON encoder cannot serialize (e.g. ``datetime``)
+        are handled via ``_json_fallback``: dates become ISO-8601 strings and
+        anything else falls back to ``str()``, so prompt construction never
+        raises on real-world attribute data.
     """
-    return json.dumps(data, ensure_ascii=ensure_ascii, indent=indent)
+    return json.dumps(data, ensure_ascii=ensure_ascii, indent=indent, default=_json_fallback)

--- a/tests/test_prompt_helpers.py
+++ b/tests/test_prompt_helpers.py
@@ -1,0 +1,62 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+from datetime import date, datetime, timezone
+
+from graphiti_core.prompts.prompt_helpers import to_prompt_json
+
+
+def test_to_prompt_json_serializes_datetime():
+    """datetime values serialize as ISO-8601 strings instead of raising.
+
+    Regression test: entity/edge attribute dicts routinely carry datetime
+    values (e.g. an entity attribute extracted as a date). Serializing them
+    for a summary/extraction prompt previously raised
+    `TypeError: Object of type datetime is not JSON serializable`.
+    """
+    dt = datetime(2024, 3, 15, 9, 30, tzinfo=timezone.utc)
+    result = to_prompt_json({'signed_at': dt, 'name': 'Acme contract'})
+
+    parsed = json.loads(result)
+    assert parsed['name'] == 'Acme contract'
+    assert parsed['signed_at'] == dt.isoformat()
+
+
+def test_to_prompt_json_serializes_date():
+    """`date` (not just `datetime`) also serializes as ISO-8601."""
+    result = to_prompt_json({'effective': date(2024, 1, 1)})
+    assert json.loads(result)['effective'] == '2024-01-01'
+
+
+def test_to_prompt_json_serializes_nested_datetime():
+    """datetimes nested inside lists/dicts are handled too."""
+    dt = datetime(2024, 3, 15, 9, 30, tzinfo=timezone.utc)
+    result = to_prompt_json({'events': [{'at': dt}]})
+    assert json.loads(result)['events'][0]['at'] == dt.isoformat()
+
+
+def test_to_prompt_json_preserves_plain_data():
+    """Already-serializable data is unaffected by the datetime fallback."""
+    data = {'facts': ['a', 'b'], 'count': 3, 'nested': {'k': None}}
+    assert json.loads(to_prompt_json(data)) == data
+
+
+def test_to_prompt_json_preserves_unicode_and_indent():
+    """`ensure_ascii=False` keeps non-ASCII readable; `indent` still applies."""
+    result = to_prompt_json({'city': 'Brüssel'}, indent=2)
+    assert 'Brüssel' in result  # not \u-escaped
+    assert '\n' in result  # indent applied


### PR DESCRIPTION
## Problem

Fixes #1526.

`to_prompt_json` (`graphiti_core/prompts/prompt_helpers.py`) calls `json.dumps(data, ...)` with no `default=` handler, so any `datetime`/`date` value in the serialized data raises:

```
TypeError: Object of type datetime is not JSON serializable
```

This surfaces during entity-summary regeneration —
`extract_attributes_from_nodes → _extract_entity_summaries_batch → extract_summaries_batch → to_prompt_json(context['attributes'])` — whenever an entity attribute holds a date (common with custom entity types that declare `datetime`/`date` fields, e.g. a contract `signed_at` or a person `date_of_birth`). The first ingest of a brand-new entity succeeds (no summary regen, so the dump never runs); the second ingest touching the same entity triggers the regen and crashes.

### Repro

```python
from datetime import datetime, timezone
from graphiti_core.prompts.prompt_helpers import to_prompt_json

to_prompt_json({"signed_at": datetime(2024, 3, 15, tzinfo=timezone.utc)})
# TypeError: Object of type datetime is not JSON serializable
```

## Fix

Add a `default=` fallback to `to_prompt_json`:
- `date` / `datetime` → ISO-8601 (`.isoformat()`)
- anything else json can't encode → `str()`

Output is **unchanged** for already-serializable data (the `default=` callable only fires for values the stock encoder rejects). Since this serializes prompt content for an LLM, ISO-8601 dates are also more readable than the raw error path.

## Tests

Adds `tests/test_prompt_helpers.py` (pure unit, no Neo4j/LLM, runs under `make test`):
- datetime → ISO-8601
- date → ISO-8601
- datetime nested in lists/dicts
- plain data round-trips unchanged
- `ensure_ascii=False` unicode + `indent` preserved

```
make lint   # ruff check + pyright: clean
make format # clean
pytest tests/test_prompt_helpers.py  # 5 passed
```

## Notes

- No new dependencies (stdlib `datetime` only).
- Bug fix to existing functionality; < 20 LOC, no RFC needed per CONTRIBUTING.