### PR TITLE
fix(mcp): preserve FalkorDB URI username

### DIFF
--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -187,6 +187,7 @@ class FalkorDBProviderConfig(BaseModel):
     """FalkorDB provider configuration."""
 
     uri: str = 'redis://localhost:6379'
+    username: str | None = None
     password: str | None = None
     database: str = 'default_db'
 

--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -232,6 +232,7 @@ class GraphitiService:
                     falkor_driver = FalkorDriver(
                         host=db_config['host'],
                         port=db_config['port'],
+                        username=db_config.get('username'),
                         password=db_config['password'],
                         database=db_config['database'],
                     )

--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -463,17 +463,20 @@ class DatabaseDriverFactory:
                 from urllib.parse import urlparse
 
                 uri = os.environ.get('FALKORDB_URI', falkor_config.uri)
+                username = os.environ.get('FALKORDB_USERNAME')
                 password = os.environ.get('FALKORDB_PASSWORD', falkor_config.password)
 
                 # Parse the URI to extract host and port
                 parsed = urlparse(uri)
                 host = parsed.hostname or 'localhost'
                 port = parsed.port or 6379
+                username = username or parsed.username or falkor_config.username
 
                 return {
                     'driver': 'falkordb',
                     'host': host,
                     'port': port,
+                    'username': username,
                     'password': password,
                     'database': falkor_config.database,
                 }

--- a/mcp_server/tests/test_falkordb_config.py
+++ b/mcp_server/tests/test_falkordb_config.py
@@ -1,0 +1,44 @@
+from config.schema import DatabaseConfig, DatabaseProvidersConfig, FalkorDBProviderConfig
+from services.factories import DatabaseDriverFactory
+
+
+def test_falkordb_config_preserves_uri_username(monkeypatch):
+    monkeypatch.delenv('FALKORDB_URI', raising=False)
+    monkeypatch.delenv('FALKORDB_USERNAME', raising=False)
+    monkeypatch.delenv('FALKORDB_PASSWORD', raising=False)
+
+    config = DatabaseConfig(
+        provider='falkordb',
+        providers=DatabaseProvidersConfig(
+            falkordb=FalkorDBProviderConfig(
+                uri='redis://falkordb:secret@example.cloud:6379',
+                database='cloud-db',
+            )
+        ),
+    )
+
+    db_config = DatabaseDriverFactory.create_config(config)
+
+    assert db_config['host'] == 'example.cloud'
+    assert db_config['port'] == 6379
+    assert db_config['username'] == 'falkordb'
+    assert db_config['password'] is None
+    assert db_config['database'] == 'cloud-db'
+
+
+def test_falkordb_username_env_overrides_uri(monkeypatch):
+    monkeypatch.setenv('FALKORDB_URI', 'redis://uri-user:secret@example.cloud:6380')
+    monkeypatch.setenv('FALKORDB_USERNAME', 'env-user')
+    monkeypatch.setenv('FALKORDB_PASSWORD', 'env-secret')
+
+    config = DatabaseConfig(
+        provider='falkordb',
+        providers=DatabaseProvidersConfig(falkordb=FalkorDBProviderConfig()),
+    )
+
+    db_config = DatabaseDriverFactory.create_config(config)
+
+    assert db_config['host'] == 'example.cloud'
+    assert db_config['port'] == 6380
+    assert db_config['username'] == 'env-user'
+    assert db_config['password'] == 'env-secret'


### PR DESCRIPTION
## Summary

Fixes getzep/graphiti#1522.

FalkorDB Cloud URIs can include a username, for example `redis://falkordb:<password>@host:port`. The MCP server factory parsed host and port from `FALKORDB_URI`, but dropped `parsed.username`; `GraphitiService` then built `FalkorDriver` without a username, so the client authenticated as the implicit Redis default user.

This keeps the existing URI/password behavior and adds username propagation:

- parse the username from `FALKORDB_URI`
- allow `FALKORDB_USERNAME` / config username to override it
- pass the username into `FalkorDriver`
- add MCP server config tests for URI username preservation and env override

## To verify

- `$env:PYTHONPATH='..;src'; python -m pytest tests\test_falkordb_config.py -q` -> `2 passed`
- `python -m py_compile src\config\schema.py src\services\factories.py src\graphiti_mcp_server.py tests\test_falkordb_config.py`
- `python -m ruff check src\config\schema.py src\services\factories.py src\graphiti_mcp_server.py tests\test_falkordb_config.py`
- `python -m ruff format --check src\config\schema.py src\services\factories.py src\graphiti_mcp_server.py tests\test_falkordb_config.py`
- `git diff --check`
