### PR TITLE
fix(falkor): strip nul bytes from parameters

### DIFF
--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -72,6 +72,18 @@ from graphiti_core.utils.datetime_utils import convert_datetimes_to_strings
 logger = logging.getLogger(__name__)
 
 
+def _strip_nul_bytes(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.replace('\x00', '')
+    if isinstance(value, dict):
+        return {key: _strip_nul_bytes(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_strip_nul_bytes(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_strip_nul_bytes(item) for item in value)
+    return value
+
+
 class FalkorDriverSession(GraphDriverSession):
     provider = GraphProvider.FALKORDB
 
@@ -98,10 +110,12 @@ class FalkorDriverSession(GraphDriverSession):
         if isinstance(query, list):
             for cypher, params in query:
                 params = convert_datetimes_to_strings(params)
+                params = _strip_nul_bytes(params)
                 await self.graph.query(str(cypher), params)  # type: ignore[reportUnknownArgumentType]
         else:
             params = dict(kwargs)
             params = convert_datetimes_to_strings(params)
+            params = _strip_nul_bytes(params)
             await self.graph.query(str(query), params)  # type: ignore[reportUnknownArgumentType]
         # Assuming `graph.query` is async (ideal); otherwise, wrap in executor
         return None
@@ -225,6 +239,7 @@ class FalkorDriver(GraphDriver):
 
         # Convert datetime objects to ISO strings (FalkorDB does not support datetime objects directly)
         params = convert_datetimes_to_strings(dict(kwargs))
+        params = _strip_nul_bytes(params)
 
         try:
             result = await graph.query(cypher_query_, params)  # type: ignore[reportUnknownArgumentType]

--- a/tests/driver/test_falkordb_driver.py
+++ b/tests/driver/test_falkordb_driver.py
@@ -160,6 +160,26 @@ class TestFalkorDriver:
         call_args = mock_graph.query.call_args[0]
         assert call_args[1]['created_at'] == test_datetime.isoformat()
 
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_execute_query_strips_nul_bytes_from_parameters(self):
+        mock_graph = MagicMock()
+        mock_result = MagicMock()
+        mock_result.header = []
+        mock_result.result_set = []
+        mock_graph.query = AsyncMock(return_value=mock_result)
+        self.mock_client.select_graph.return_value = mock_graph
+
+        await self.driver.execute_query(
+            'CREATE (n:Node) SET n.content = $content',
+            content='Seamless Recruiting \x00 Onboarding',
+            nested={'values': ['ok\x00', 'clean']},
+        )
+
+        call_args = mock_graph.query.call_args[0]
+        assert call_args[1]['content'] == 'Seamless Recruiting  Onboarding'
+        assert call_args[1]['nested'] == {'values': ['ok', 'clean']}
+
     @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
     def test_session_creation(self):
         """Test session creation with specific database."""
@@ -297,6 +317,25 @@ class TestFalkorDriverSession:
         self.mock_graph.query.assert_called_once()
         call_args = self.mock_graph.query.call_args[0]
         assert call_args[1]['created_at'] == test_datetime.isoformat()
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_run_strips_nul_bytes_from_list_query_parameters(self):
+        self.mock_graph.query = AsyncMock()
+
+        queries = [
+            (
+                'CREATE (n:Node) SET n.content = $content',
+                {'content': 'a\x00b', 'items': ('x\x00', 'y')},
+            )
+        ]
+
+        await self.session.run(queries)
+
+        self.mock_graph.query.assert_called_once_with(
+            'CREATE (n:Node) SET n.content = $content',
+            {'content': 'ab', 'items': ('x', 'y')},
+        )
 
 
 class TestDatetimeConversion:


### PR DESCRIPTION
## Summary

Fixes getzep/graphiti#1525.

FalkorDB rejects query parameters that contain embedded NUL bytes, and the failure happens before the query body runs. Ingested text from PDFs/PPTX can contain stray `\x00`, so a single bad string can make a whole bulk save query fail.

This strips NUL bytes from FalkorDB query parameters before calling the FalkorDB client. The cleanup is recursive for dict/list/tuple values and is applied in both driver paths that send params:

- `FalkorDriver.execute_query(...)`
- `FalkorDriverSession.run(...)`, including list-of-query batches

Valid strings are unchanged; only `\x00` is removed.

## To verify

- `$env:DISABLE_KUZU='True'; <pytest bootstrap>; pytest tests/driver/test_falkordb_driver.py::{new and adjacent tests} -q` -> `4 passed`
- `python -m py_compile graphiti_core\driver\falkordb_driver.py tests\driver\test_falkordb_driver.py`
- `python -m ruff check graphiti_core\driver\falkordb_driver.py tests\driver\test_falkordb_driver.py`
- `python -m ruff format --check graphiti_core\driver\falkordb_driver.py tests\driver\test_falkordb_driver.py`
- `git diff --check`

Note: this Windows environment has another editable checkout exposing a top-level `tests` package, so I used a small bootstrap to point `tests` at this repository before invoking pytest. `DISABLE_KUZU=True` avoids importing the optional Kuzu driver for these Falkor-only unit tests.
