### PR TITLE
fix(docker): align FalkorDB compose service port with container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,12 +69,12 @@ services:
       context: .
     profiles: ["falkordb"]
     ports:
-      - "8001:8001"
+      - "8001:8000"
     depends_on:
       falkordb:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/healthcheck')"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthcheck')"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -84,7 +84,7 @@ services:
       - FALKORDB_PORT=6379
       - FALKORDB_DATABASE=default_db
       - GRAPHITI_BACKEND=falkordb
-      - PORT=8001
+      - PORT=8000
       - db_backend=falkordb
 
 volumes:


### PR DESCRIPTION
## Summary

Follow-up to #1126. That PR fixed the FalkorDB Docker image so the server builds, boots, and connects to FalkorDB — but the `graph-falkordb` compose service was still wired to the wrong port, so the profile comes up **unhealthy** and is **unreachable on its published port**.

The Dockerfile CMD binds uvicorn to container port **8000**:
```
CMD ["uv", "run", "--no-sync", "uvicorn", "graph_service.main:app", "--host", "0.0.0.0", "--port", "8000"]
```
…but the `graph-falkordb` service published `8001:8001`, healthchecked on `8001`, and set `PORT=8001`. Nothing listens on container port 8001, so:
- the healthcheck fails → container marked `unhealthy`
- `localhost:8001` on the host → connection refused

## Fix

Keep the external port `8001` (distinct from the Neo4j-backed `graph` service on 8000) but route it to container `8000` where uvicorn actually listens:
- `ports: "8001:8001"` → `"8001:8000"`
- healthcheck `localhost:8001` → `localhost:8000`
- `PORT=8001` → `PORT=8000` (the app ignores this env since the port is hardcoded in CMD; set to match reality)

FalkorDB's own database port (`6379`, Redis protocol) is unchanged.

## Verification

Built and ran the `falkordb` profile locally with this change:
```
graph-falkordb   Up (healthy)   0.0.0.0:8001->8000/tcp
$ curl localhost:8001/healthcheck
{"status":"healthy"}   # HTTP 200
```
Without the change, the same container reports `(unhealthy)` and `localhost:8001` is refused.

## Type of Change
- [x] Bug fix

## Testing
- [x] Verified locally (docker compose --profile falkordb up → healthy + reachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)