### PR TITLE
fix(mcp): extend model env overrides to all configs + test provider routing

### DIFF
--- a/mcp_server/config/config-docker-falkordb-combined.yaml
+++ b/mcp_server/config/config-docker-falkordb-combined.yaml
@@ -8,7 +8,7 @@ server:
 
 llm:
   provider: "openai"  # Options: openai, azure_openai, anthropic, gemini, groq
-  model: "gpt-4o-mini"
+  model: ${MODEL_NAME:gpt-4o-mini}
   max_tokens: 4096
 
   providers:
@@ -40,7 +40,7 @@ llm:
 
 embedder:
   provider: "openai"  # Options: openai, azure_openai, gemini, voyage
-  model: "text-embedding-3-small"
+  model: ${EMBEDDER_MODEL:text-embedding-3-small}
   dimensions: 1536
 
   providers:

--- a/mcp_server/config/config-docker-neo4j.yaml
+++ b/mcp_server/config/config-docker-neo4j.yaml
@@ -8,7 +8,7 @@ server:
   
 llm:
   provider: "openai"  # Options: openai, azure_openai, anthropic, gemini, groq
-  model: "gpt-4o-mini"
+  model: ${MODEL_NAME:gpt-4o-mini}
   max_tokens: 4096
   
   providers:
@@ -40,7 +40,7 @@ llm:
 
 embedder:
   provider: "openai"  # Options: openai, azure_openai, gemini, voyage
-  model: "text-embedding-3-small"
+  model: ${EMBEDDER_MODEL:text-embedding-3-small}
   dimensions: 1536
   
   providers:

--- a/mcp_server/config/config.yaml
+++ b/mcp_server/config/config.yaml
@@ -12,7 +12,7 @@ server:
   
 llm:
   provider: "openai"  # Options: openai, azure_openai, anthropic, gemini, groq
-  model: "gpt-4o-mini"
+  model: ${MODEL_NAME:gpt-4o-mini}
   max_tokens: 4096
   
   providers:
@@ -44,7 +44,7 @@ llm:
 
 embedder:
   provider: "openai"  # Options: openai, azure_openai, gemini, voyage
-  model: "text-embedding-3-small"
+  model: ${EMBEDDER_MODEL:text-embedding-3-small}
   dimensions: 1536
   
   providers:

--- a/mcp_server/tests/test_factories.py
+++ b/mcp_server/tests/test_factories.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Unit tests for service factory provider detection and client routing."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add the src directory to the path (mirrors the other factory tests)
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+from graphiti_core.llm_client import OpenAIClient
+from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
+
+from config.schema import LLMConfig, LLMProvidersConfig, OpenAIProviderConfig
+from services.factories import LLMClientFactory, is_non_openai_provider
+
+
+class TestIsNonOpenAIProvider:
+    """Tests for the base_url-based provider detection."""
+
+    @pytest.mark.parametrize(
+        'base_url',
+        [
+            None,
+            '',
+            'https://api.openai.com/v1',
+            'https://api.openai.com',
+            'https://my-resource.openai.azure.com',
+        ],
+    )
+    def test_official_or_unset_is_openai(self, base_url):
+        """Unset, empty, or official OpenAI/Azure endpoints are treated as OpenAI."""
+        assert is_non_openai_provider(base_url) is False
+
+    @pytest.mark.parametrize(
+        'base_url',
+        [
+            'http://localhost:11434/v1',  # Ollama
+            'http://localhost:1234/v1',  # LM Studio
+            'http://localhost:8000/v1',  # vLLM
+            'https://my-proxy.internal/v1',
+        ],
+    )
+    def test_compatible_providers_are_non_openai(self, base_url):
+        """OpenAI-compatible third-party endpoints are detected as non-OpenAI."""
+        assert is_non_openai_provider(base_url) is True
+
+
+class TestLLMClientFactoryRouting:
+    """Tests that the factory selects the right client based on base_url."""
+
+    @staticmethod
+    def _config(api_url: str) -> LLMConfig:
+        return LLMConfig(
+            provider='openai',
+            model='gpt-4o-mini',
+            providers=LLMProvidersConfig(
+                openai=OpenAIProviderConfig(api_key='test-key', api_url=api_url)
+            ),
+        )
+
+    def test_official_openai_uses_openai_client(self):
+        client = LLMClientFactory.create(self._config('https://api.openai.com/v1'))
+        assert isinstance(client, OpenAIClient)
+        assert not isinstance(client, OpenAIGenericClient)
+
+    def test_ollama_uses_generic_client(self):
+        client = LLMClientFactory.create(self._config('http://localhost:11434/v1'))
+        assert isinstance(client, OpenAIGenericClient)


### PR DESCRIPTION
## Summary

Follow-up to #1146, addressing the two minor items from review.

**1. Config consistency.** #1146 made the LLM/embedder model names env-configurable (`${MODEL_NAME}` / `${EMBEDDER_MODEL}`) but only in `config-docker-falkordb.yaml`. This extends the same override to the other three MCP config files so OpenAI-compatible providers (Ollama, LM Studio, vLLM) can be configured regardless of which config/profile is used:
- `config.yaml`
- `config-docker-neo4j.yaml`
- `config-docker-falkordb-combined.yaml`

Defaults are unchanged (`gpt-4o-mini` / `text-embedding-3-small`), so this is backward compatible.

**2. Tests.** Adds `mcp_server/tests/test_factories.py` covering the provider-detection logic #1146 introduced:
- `is_non_openai_provider()` — official OpenAI/Azure endpoints, empty, and `None` → `False`; Ollama/LM Studio/vLLM/custom endpoints → `True`.
- `LLMClientFactory` routing — official OpenAI → `OpenAIClient`; Ollama base_url → `OpenAIGenericClient`.

## Verification
- `pytest tests/test_factories.py` → **11 passed**
- `ruff check` / `ruff format --check` → clean
- All three edited configs load with correct defaults; `MODEL_NAME=llama3 EMBEDDER_MODEL=nomic-embed-text` resolves to `llama3` / `nomic-embed-text`.

## Type of Change
- [x] Bug fix (consistency) + tests

## Testing
- [x] Unit tests added
- [x] Verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)