### PR TITLE
ci(cla): authenticate CLA Assistant with a GitHub App token, drop the PAT

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,17 +16,27 @@ jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived GitHub App installation token (≈1h, auto-revoked at job
+      # end) instead of a long-lived personal PAT. The App must be installed on this
+      # repo and added to main's branch-protection bypass list so it can commit the
+      # signature file. Requires repo secrets/vars CLA_APP_ID and CLA_APP_PRIVATE_KEY.
+      - name: Generate CLA app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CLA_APP_ID }}
+          private-key: ${{ secrets.CLA_APP_PRIVATE_KEY }}
+
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        # Maintained node24 fork of the (archived) contributor-assistant/github-action.
+        # Pinned to a commit SHA because the fork publishes no semver tags.
+        uses: SiliconLabsSoftware/action-cla-assistant@89980ac6cfe974ea7703b4ccfbaeb1b2cc6065d2 # silabs_flavour_v2 (node24)
         env:
-          # the default github token does not have branch protection override permissions
-          # the repo secrets will need to be updated when the token expires.
-          GITHUB_TOKEN: ${{ secrets.DANIEL_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/getzep/graphiti/blob/main/Zep-CLA.md" # e.g. a CLA or a DCO document
-          # branch should not be protected unless a personal PAT is used
           branch: "main"
           allowlist: paul-paliychuk,prasmussen15,danielchalef,dependabot[bot],ellipsis-dev,Claude[bot],claude[bot]
 


### PR DESCRIPTION
## Why

The `CLAAssistant` check is failing on every PR: it authenticates with a personal PAT (`DANIEL_PAT`) to commit signatures to protected `main`, and that PAT **expired** (`Bad credentials`). PATs expire ~annually and will keep re-breaking this. Separately, the upstream `contributor-assistant/github-action` is **archived** (read-only since 2026-03, stuck on Node 20 — deprecated ~2026-06-16).

## What

- **Drop the PAT.** Mint a short-lived (~1h, auto-revoked) **GitHub App installation token** via `actions/create-github-app-token`. Not tied to a person, no seat, never silently expires.
- **Move off the archived action** to the maintained node24 fork `SiliconLabsSoftware/action-cla-assistant`, pinned to a commit SHA (the fork publishes no semver tags).
- Signatures stay on `main`; `path-to-signatures`, document URL, and allowlist unchanged.

## Required owner setup before this can pass (cannot be done in the workflow)

1. Create a GitHub App (org-owned) with permissions **Contents: R/W, Pull requests: R/W, Issues: R/W**; install it on `getzep/graphiti`.
2. Add repo **variable `CLA_APP_ID`** and **secret `CLA_APP_PRIVATE_KEY`**.
3. Add the App to **`main`'s branch-protection bypass / push allowlist** (or, if required status checks are enforced, a repository ruleset Bypass entry) so it can commit the signature file.
4. Remove the now-unused `DANIEL_PAT` secret.

Until the App + secrets exist, `create-github-app-token` will fail — so merge should be coordinated with that setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)