### PR TITLE
ci: bump claude-code-action to v1.0.139 (agent SDK that recognizes Opus 4.8)

### DIFF
--- a/.github/workflows/claude-code-review-manual.yml
+++ b/.github/workflows/claude-code-review-manual.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 1
 
       - name: Claude Code Review
-        uses: anthropics/claude-code-action@ba026a3e56b9f646ae3b1be02dd9c0812aa2f8ae # v1
+        uses: anthropics/claude-code-action@64de744025ca9e24df2b88204b4f1e968f39f009 # v1.0.139
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Use this token for GitHub API calls instead of exchanging the OIDC token for a

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Claude Code Review
         if: steps.check_size.outputs.skip != 'true'
-        uses: anthropics/claude-code-action@ba026a3e56b9f646ae3b1be02dd9c0812aa2f8ae # v1
+        uses: anthropics/claude-code-action@64de744025ca9e24df2b88204b4f1e968f39f009 # v1.0.139
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Use this token for GitHub API calls instead of exchanging the OIDC token for a

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@ba026a3e56b9f646ae3b1be02dd9c0812aa2f8ae # v1
+        uses: anthropics/claude-code-action@64de744025ca9e24df2b88204b4f1e968f39f009 # v1.0.139
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Use this token for GitHub API calls instead of exchanging the OIDC token for a

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Run PR Triage
         if: steps.check_size.outputs.skip != 'true'
-        uses: anthropics/claude-code-action@ba026a3e56b9f646ae3b1be02dd9c0812aa2f8ae # v1
+        uses: anthropics/claude-code-action@64de744025ca9e24df2b88204b4f1e968f39f009 # v1.0.139
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Use this token for GitHub API calls instead of exchanging the OIDC token for a
@@ -265,7 +265,7 @@ jobs:
 
       - name: Batch triage
         if: steps.prs.outputs.pr_numbers != ''
-        uses: anthropics/claude-code-action@ba026a3e56b9f646ae3b1be02dd9c0812aa2f8ae # v1
+        uses: anthropics/claude-code-action@64de744025ca9e24df2b88204b4f1e968f39f009 # v1.0.139
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Use this token for GitHub API calls instead of exchanging the OIDC token for a


### PR DESCRIPTION
Follow-up to the merged review-workflow fixes (#1540 `id-token`, #1542 `github_token` + `synchronize` + model string). Those got the reviewer **running**, but a real run revealed it executed on **`claude-sonnet-4-6`**, not `claude-opus-4-8`.

## Why
The pinned action (`ba026a3`) bundles `@anthropic-ai/claude-agent-sdk` **0.2.90**, which predates Opus 4.8. The `--model claude-opus-4-8` value (a valid, complete model id) was **unrecognized by that SDK, which silently fell back to its default `claude-sonnet-4-6`** — the run reported `subtype: success`, just on the wrong model.

## Fix
Bump the pinned SHA to **v1.0.139** (`64de744`), which bundles `@anthropic-ai/claude-agent-sdk` **^0.3.167** — that version recognizes `claude-opus-4-8`. Applied across all five action invocations (review, manual, triage, triage-batch, `@claude`).

⚠️ This pulls in ~130 patch releases of the action (v1.0 → v1.0.139); worth a skim of the action changelog before merge. The change that matters to us is the bundled agent-SDK bump.

## Validation
`pull_request_target` uses the base-branch workflow, so this only takes effect after merge. Post-merge, label/push an eligible PR and confirm the posted review runs on Opus 4.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)