### PR TITLE
ci: use track_progress for Claude PR review (the actual comment mechanism)

### DIFF
--- a/.github/workflows/claude-code-review-manual.yml
+++ b/.github/workflows/claude-code-review-manual.yml
@@ -39,7 +39,10 @@ jobs:
           # Claude GitHub App token (that exchange 401s — we use our own anthropic_api_key,
           # not the official Claude App). See claude-code-action docs / issue #873.
           github_token: ${{ github.token }}
-          use_sticky_comment: true
+          # track_progress creates/manages the tracking comment the review is posted into
+          # (updated via mcp__github_comment__update_claude_comment). Agent mode +
+          # use_sticky_comment does not create a comment for the review to land in.
+          track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ inputs.pr_number }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -65,7 +65,11 @@ jobs:
           # Claude GitHub App token (that exchange 401s — we use our own anthropic_api_key,
           # not the official Claude App). See claude-code-action docs / issue #873.
           github_token: ${{ github.token }}
-          use_sticky_comment: true
+          # track_progress is the action's PR-review mechanism: it creates and manages a
+          # tracking comment that the review is posted into (updated via the allowlisted
+          # mcp__github_comment__update_claude_comment tool). Plain agent mode +
+          # use_sticky_comment does NOT create a comment for the review to land in.
+          track_progress: true
           allowed_bots: "dependabot"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
**The real fix for "review runs but never posts."** Found by comparing our config against the action's official `examples/pr-review-comprehensive.yml`.

## Root cause
The action's PR-review pattern is **`track_progress: true`** — it *creates and manages the tracking comment that the review is posted into* (the example even notes "similar to v0.x agent mode"). We were using **`use_sticky_comment: true`**, which in plain auto-detected "agent" mode does **not** create a comment for the review to land in. So Opus 4.8 reviewed thoroughly but had nowhere to post — hence "ran successfully, 40 turns, 33 denials, 0 comments" across every attempt.

This also explains why #1545 alone didn't fix it: `track_progress` posts/updates its tracking comment **via `mcp__github_comment__update_claude_comment`** — so that tool (allowlisted in #1545) was necessary *and* `track_progress` is what actually creates the comment. Both are needed; this PR adds the missing half.

## Change
Swap `use_sticky_comment: true` → `track_progress: true` in the auto + manual review workflows. Everything else stays: `pull_request_target` without fork-head checkout, the author/label gate, diff cap, `github_token`, Opus 4.8, and the allowlist (which already includes the comment + inline tools that `track_progress` drives). `pr-triage` is unchanged — it posts its assessment directly via `gh pr comment`.

## Validation
Takes effect after merge. Trigger a review (label/push an eligible PR) — it should now create a tracking comment and post the review into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)