### PR TITLE
feat(llm): default to gpt-5.5 with model-tied reasoning effort

### DIFF
--- a/graphiti_core/llm_client/azure_openai_client.py
+++ b/graphiti_core/llm_client/azure_openai_client.py
@@ -80,8 +80,9 @@ class AzureOpenAILLMClient(BaseOpenAIClient):
                 'text_format': response_model,  # type: ignore
             }
 
-            if reasoning:
-                request_kwargs['reasoning'] = {'effort': reasoning}  # type: ignore
+            effort = self._resolve_reasoning_effort(model, reasoning)
+            if effort:
+                request_kwargs['reasoning'] = {'effort': effort}  # type: ignore
 
             if verbosity:
                 request_kwargs['text'] = {'verbosity': verbosity}  # type: ignore

--- a/graphiti_core/llm_client/config.py
+++ b/graphiti_core/llm_client/config.py
@@ -51,7 +51,7 @@ class LLMConfig:
                                                 This is required for making authorized requests.
 
                 model (str, optional): The specific LLM model to use for generating responses.
-                                                                Defaults to "gpt-4.1-mini".
+                                                                Defaults to "gpt-5.5".
 
                 base_url (str, optional): The base URL of the LLM API service.
                                                                         Defaults to "https://api.openai.com", which is OpenAI's standard API endpoint.

--- a/graphiti_core/llm_client/openai_base_client.py
+++ b/graphiti_core/llm_client/openai_base_client.py
@@ -31,9 +31,11 @@ from .errors import RateLimitError, RefusalError
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = 'gpt-4.1-mini'
+DEFAULT_MODEL = 'gpt-5.5'
 DEFAULT_SMALL_MODEL = 'gpt-4.1-nano'
-DEFAULT_REASONING = 'minimal'
+# 'auto' is a sentinel meaning "pick a reasoning effort based on the model"
+# (resolved by _resolve_reasoning_effort); it is never sent to the API.
+DEFAULT_REASONING = 'auto'
 DEFAULT_VERBOSITY = 'low'
 
 
@@ -112,6 +114,30 @@ class BaseOpenAIClient(LLMClient):
             return self.small_model or DEFAULT_SMALL_MODEL
         else:
             return self.model or DEFAULT_MODEL
+
+    @staticmethod
+    def _resolve_reasoning_effort(model: str, reasoning: str | None) -> str | None:
+        """Resolve the reasoning effort to send for a reasoning model.
+
+        The sentinel ``'auto'`` (the default) is resolved per-model:
+
+        * ``gpt-5.5`` and newer use ``'none'`` — reasoning off, the cheapest and
+          fastest setting, which gives comparable extraction quality at far lower
+          cost and latency for Graphiti's structured-output workload.
+        * Any other reasoning model resolves to ``None`` (the parameter is
+          omitted and the API applies its own default). We deliberately do not
+          guess a floor, because the lowest valid effort differs by snapshot —
+          e.g. ``gpt-5.0`` accepts ``'minimal'``, ``gpt-5.4-mini`` requires
+          ``'low'``, and ``gpt-5.5`` uses ``'none'``. Pin one with ``reasoning=``.
+
+        Any non-sentinel value (including ``None``) is returned unchanged, so an
+        explicit caller override always wins.
+        """
+        if reasoning != 'auto':
+            return reasoning
+        if model.startswith('gpt-5.5'):
+            return 'none'
+        return None
 
     def _handle_structured_response(self, response: Any) -> tuple[dict[str, Any], int, int]:
         """Handle structured response parsing and validation.

--- a/graphiti_core/llm_client/openai_base_client.py
+++ b/graphiti_core/llm_client/openai_base_client.py
@@ -121,9 +121,11 @@ class BaseOpenAIClient(LLMClient):
 
         The sentinel ``'auto'`` (the default) is resolved per-model:
 
-        * ``gpt-5.5`` and newer use ``'none'`` — reasoning off, the cheapest and
+        * The ``gpt-5.5`` family uses ``'none'`` — reasoning off, the cheapest and
           fastest setting, which gives comparable extraction quality at far lower
-          cost and latency for Graphiti's structured-output workload.
+          cost and latency for Graphiti's structured-output workload. (Matched by
+          prefix; a future ``gpt-5.6``/``gpt-6`` falls through to the branch below
+          until added here, since newer snapshots may not accept ``'none'``.)
         * Any other reasoning model resolves to ``None`` (the parameter is
           omitted and the API applies its own default). We deliberately do not
           guess a floor, because the lowest valid effort differs by snapshot —

--- a/graphiti_core/llm_client/openai_base_client.py
+++ b/graphiti_core/llm_client/openai_base_client.py
@@ -126,20 +126,22 @@ class BaseOpenAIClient(LLMClient):
           cost and latency for Graphiti's structured-output workload. (Matched by
           prefix; a future ``gpt-5.6``/``gpt-6`` falls through to the branch below
           until added here, since newer snapshots may not accept ``'none'``.)
-        * Any other reasoning model resolves to ``None`` (the parameter is
-          omitted and the API applies its own default). We deliberately do not
-          guess a floor, because the lowest valid effort differs by snapshot —
-          e.g. ``gpt-5.0`` accepts ``'minimal'``, ``gpt-5.4-mini`` requires
-          ``'low'``, and ``gpt-5.5`` uses ``'none'``. Pin one with ``reasoning=``.
+        * Every other model uses ``'minimal'`` — the cheapest broadly-supported
+          reasoning tier and the long-standing default. Returning ``'minimal'``
+          (rather than omitting the parameter) is deliberate: it keeps non-gpt-5.5
+          reasoning models from silently jumping to the API's more expensive
+          default effort. Models whose lowest valid tier differs (e.g.
+          ``gpt-5.4-mini`` requires ``'low'``) should set ``reasoning=`` explicitly.
 
         Any non-sentinel value (including ``None``) is returned unchanged, so an
-        explicit caller override always wins.
+        explicit caller override always wins. The result is only sent for
+        reasoning models — non-reasoning models ignore it.
         """
         if reasoning != 'auto':
             return reasoning
         if model.startswith('gpt-5.5'):
             return 'none'
-        return None
+        return 'minimal'
 
     def _handle_structured_response(self, response: Any) -> tuple[dict[str, Any], int, int]:
         """Handle structured response parsing and validation.

--- a/graphiti_core/llm_client/openai_client.py
+++ b/graphiti_core/llm_client/openai_client.py
@@ -89,9 +89,11 @@ class OpenAIClient(BaseOpenAIClient):
         if temperature_value is not None:
             request_kwargs['temperature'] = temperature_value
 
-        # Only include reasoning and verbosity parameters for reasoning models
-        if is_reasoning_model and reasoning is not None:
-            request_kwargs['reasoning'] = {'effort': reasoning}  # type: ignore
+        # Only include reasoning and verbosity parameters for reasoning models.
+        # 'auto' is resolved to a per-model effort (e.g. 'none' for gpt-5.5).
+        effort = self._resolve_reasoning_effort(model, reasoning)
+        if is_reasoning_model and effort is not None:
+            request_kwargs['reasoning'] = {'effort': effort}  # type: ignore
 
         if is_reasoning_model and verbosity is not None:
             request_kwargs['text'] = {'verbosity': verbosity}  # type: ignore

--- a/graphiti_core/llm_client/openai_client.py
+++ b/graphiti_core/llm_client/openai_client.py
@@ -91,8 +91,10 @@ class OpenAIClient(BaseOpenAIClient):
 
         # Only include reasoning and verbosity parameters for reasoning models.
         # 'auto' is resolved to a per-model effort (e.g. 'none' for gpt-5.5).
+        # Truthiness guard (matches the Azure client) skips both None and an
+        # empty string, so a stray reasoning='' never sends an invalid effort.
         effort = self._resolve_reasoning_effort(model, reasoning)
-        if is_reasoning_model and effort is not None:
+        if is_reasoning_model and effort:
             request_kwargs['reasoning'] = {'effort': effort}  # type: ignore
 
         if is_reasoning_model and verbosity is not None:

--- a/graphiti_core/llm_client/openai_client.py
+++ b/graphiti_core/llm_client/openai_client.py
@@ -115,15 +115,19 @@ class OpenAIClient(BaseOpenAIClient):
         verbosity: str | None = None,
     ):
         """Create a regular completion with JSON format."""
-        # Reasoning models (gpt-5 family) don't support temperature
+        # Reasoning models (gpt-5 family, o1, o3) reject temperature.
         is_reasoning_model = (
             model.startswith('gpt-5') or model.startswith('o1') or model.startswith('o3')
         )
 
-        return await self.client.chat.completions.create(
-            model=model,
-            messages=messages,
-            temperature=temperature if not is_reasoning_model else None,
-            max_tokens=max_tokens,
-            response_format={'type': 'json_object'},
-        )
+        request_kwargs: dict[str, typing.Any] = {
+            'model': model,
+            'messages': messages,
+            'max_tokens': max_tokens,
+            'response_format': {'type': 'json_object'},
+        }
+        # Omit temperature entirely for reasoning models — don't even send None.
+        if not is_reasoning_model and temperature is not None:
+            request_kwargs['temperature'] = temperature
+
+        return await self.client.chat.completions.create(**request_kwargs)

--- a/tests/llm_client/test_openai_client.py
+++ b/tests/llm_client/test_openai_client.py
@@ -140,3 +140,23 @@ async def test_non_reasoning_model_omits_reasoning_and_keeps_temperature():
     assert call_args.get('temperature') == 0.4
     assert 'reasoning' not in call_args
     assert 'text' not in call_args
+
+
+@pytest.mark.asyncio
+async def test_empty_string_reasoning_is_not_sent():
+    # A stray reasoning='' must not produce an invalid {'effort': ''} on the wire.
+    dummy = DummyOpenAIClient()
+    client = OpenAIClient(config=LLMConfig(), client=dummy)
+
+    await client._create_structured_completion(
+        model='gpt-5.5',
+        messages=[],
+        temperature=None,
+        max_tokens=64,
+        response_model=DummyResponseModel,
+        reasoning='',
+        verbosity='low',
+    )
+
+    call_args = dummy.responses.parse_calls[0]
+    assert 'reasoning' not in call_args

--- a/tests/llm_client/test_openai_client.py
+++ b/tests/llm_client/test_openai_client.py
@@ -54,12 +54,13 @@ def test_default_model_and_reasoning_sentinel():
         # gpt-5.5 family: 'auto' -> reasoning off
         ('gpt-5.5', 'auto', 'none'),
         ('gpt-5.5-mini', 'auto', 'none'),
-        # other reasoning models: don't guess a floor, let the API default
-        ('gpt-5', 'auto', None),
-        ('gpt-5.4-mini', 'auto', None),
-        ('o1', 'auto', None),
-        # non-reasoning model: irrelevant (caller won't send it), still resolves safely
-        ('gpt-4.1', 'auto', None),
+        # every other model: 'minimal' (cheapest tier, prior default) — NOT None,
+        # so non-gpt-5.5 reasoning models don't regress to the API's medium default
+        ('gpt-5', 'auto', 'minimal'),
+        ('gpt-5.4-mini', 'auto', 'minimal'),
+        ('o1', 'auto', 'minimal'),
+        # non-reasoning model: value is ignored by the caller (not a reasoning model)
+        ('gpt-4.1', 'auto', 'minimal'),
         # explicit values always pass through unchanged
         ('gpt-5.5', 'high', 'high'),
         ('gpt-5', 'low', 'low'),
@@ -160,3 +161,61 @@ async def test_empty_string_reasoning_is_not_sent():
 
     call_args = dummy.responses.parse_calls[0]
     assert 'reasoning' not in call_args
+
+
+@pytest.mark.asyncio
+async def test_non_5_5_reasoning_model_defaults_to_minimal_not_api_default():
+    # Regression guard: non-gpt-5.5 reasoning models must keep the cheap 'minimal'
+    # effort (the prior default), not fall through to the API's medium default.
+    dummy = DummyOpenAIClient()
+    client = OpenAIClient(config=LLMConfig(), client=dummy)
+
+    await client._create_structured_completion(
+        model='gpt-5',
+        messages=[],
+        temperature=0.5,
+        max_tokens=64,
+        response_model=DummyResponseModel,
+        reasoning=DEFAULT_REASONING,  # 'auto'
+        verbosity='low',
+    )
+
+    call_args = dummy.responses.parse_calls[0]
+    assert call_args['reasoning'] == {'effort': 'minimal'}
+    assert 'temperature' not in call_args
+
+
+@pytest.mark.asyncio
+async def test_create_completion_omits_temperature_for_reasoning_model():
+    # The JSON-object fallback path must not send temperature (not even None) to
+    # a reasoning model.
+    dummy = DummyOpenAIClient()
+    client = OpenAIClient(config=LLMConfig(), client=dummy)
+
+    await client._create_completion(
+        model='gpt-5.5',
+        messages=[],
+        temperature=0.5,
+        max_tokens=64,
+    )
+
+    assert len(dummy.chat.completions.create_calls) == 1
+    call_args = dummy.chat.completions.create_calls[0]
+    assert 'temperature' not in call_args
+    assert call_args['response_format'] == {'type': 'json_object'}
+
+
+@pytest.mark.asyncio
+async def test_create_completion_keeps_temperature_for_non_reasoning_model():
+    dummy = DummyOpenAIClient()
+    client = OpenAIClient(config=LLMConfig(), client=dummy)
+
+    await client._create_completion(
+        model='gpt-4.1',
+        messages=[],
+        temperature=0.4,
+        max_tokens=64,
+    )
+
+    call_args = dummy.chat.completions.create_calls[0]
+    assert call_args['temperature'] == 0.4

--- a/tests/llm_client/test_openai_client.py
+++ b/tests/llm_client/test_openai_client.py
@@ -1,0 +1,142 @@
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+from graphiti_core.llm_client.config import LLMConfig
+from graphiti_core.llm_client.openai_base_client import DEFAULT_MODEL, DEFAULT_REASONING
+from graphiti_core.llm_client.openai_client import OpenAIClient
+
+
+class DummyResponses:
+    def __init__(self):
+        self.parse_calls: list[dict] = []
+
+    async def parse(self, **kwargs):
+        self.parse_calls.append(kwargs)
+        return SimpleNamespace(output_text='{}')
+
+
+class DummyChatCompletions:
+    def __init__(self):
+        self.create_calls: list[dict] = []
+
+    async def create(self, **kwargs):
+        self.create_calls.append(kwargs)
+        message = SimpleNamespace(content='{}')
+        choice = SimpleNamespace(message=message)
+        return SimpleNamespace(choices=[choice])
+
+
+class DummyChat:
+    def __init__(self):
+        self.completions = DummyChatCompletions()
+
+
+class DummyOpenAIClient:
+    def __init__(self):
+        self.responses = DummyResponses()
+        self.chat = DummyChat()
+
+
+class DummyResponseModel(BaseModel):
+    foo: str
+
+
+def test_default_model_and_reasoning_sentinel():
+    assert DEFAULT_MODEL == 'gpt-5.5'
+    assert DEFAULT_REASONING == 'auto'
+
+
+@pytest.mark.parametrize(
+    ('model', 'reasoning', 'expected'),
+    [
+        # gpt-5.5 family: 'auto' -> reasoning off
+        ('gpt-5.5', 'auto', 'none'),
+        ('gpt-5.5-mini', 'auto', 'none'),
+        # other reasoning models: don't guess a floor, let the API default
+        ('gpt-5', 'auto', None),
+        ('gpt-5.4-mini', 'auto', None),
+        ('o1', 'auto', None),
+        # non-reasoning model: irrelevant (caller won't send it), still resolves safely
+        ('gpt-4.1', 'auto', None),
+        # explicit values always pass through unchanged
+        ('gpt-5.5', 'high', 'high'),
+        ('gpt-5', 'low', 'low'),
+        ('gpt-5.5', None, None),
+    ],
+)
+def test_resolve_reasoning_effort(model, reasoning, expected):
+    assert OpenAIClient._resolve_reasoning_effort(model, reasoning) == expected
+
+
+def test_default_model_for_size_is_gpt_5_5():
+    client = OpenAIClient(config=LLMConfig(), client=DummyOpenAIClient())
+    from graphiti_core.llm_client.config import ModelSize
+
+    assert client._get_model_for_size(ModelSize.medium) == 'gpt-5.5'
+
+
+@pytest.mark.asyncio
+async def test_gpt_5_5_structured_completion_sends_none_effort_and_no_temperature():
+    dummy = DummyOpenAIClient()
+    client = OpenAIClient(config=LLMConfig(), client=dummy)
+
+    await client._create_structured_completion(
+        model='gpt-5.5',
+        messages=[],
+        temperature=0.5,
+        max_tokens=64,
+        response_model=DummyResponseModel,
+        reasoning=DEFAULT_REASONING,  # 'auto'
+        verbosity='low',
+    )
+
+    assert len(dummy.responses.parse_calls) == 1
+    call_args = dummy.responses.parse_calls[0]
+    assert call_args['model'] == 'gpt-5.5'
+    # Reasoning models do not accept temperature
+    assert 'temperature' not in call_args
+    # 'auto' resolves to 'none' for gpt-5.5
+    assert call_args['reasoning'] == {'effort': 'none'}
+    assert call_args['text'] == {'verbosity': 'low'}
+
+
+@pytest.mark.asyncio
+async def test_explicit_reasoning_overrides_auto():
+    dummy = DummyOpenAIClient()
+    client = OpenAIClient(config=LLMConfig(), client=dummy)
+
+    await client._create_structured_completion(
+        model='gpt-5.5',
+        messages=[],
+        temperature=None,
+        max_tokens=64,
+        response_model=DummyResponseModel,
+        reasoning='high',
+        verbosity='low',
+    )
+
+    call_args = dummy.responses.parse_calls[0]
+    assert call_args['reasoning'] == {'effort': 'high'}
+
+
+@pytest.mark.asyncio
+async def test_non_reasoning_model_omits_reasoning_and_keeps_temperature():
+    dummy = DummyOpenAIClient()
+    client = OpenAIClient(config=LLMConfig(), client=dummy)
+
+    await client._create_structured_completion(
+        model='gpt-4.1',
+        messages=[],
+        temperature=0.4,
+        max_tokens=64,
+        response_model=DummyResponseModel,
+        reasoning=DEFAULT_REASONING,
+        verbosity='low',
+    )
+
+    call_args = dummy.responses.parse_calls[0]
+    assert call_args.get('temperature') == 0.4
+    assert 'reasoning' not in call_args
+    assert 'text' not in call_args

--- a/tests/llm_client/test_openai_client.py
+++ b/tests/llm_client/test_openai_client.py
@@ -51,9 +51,9 @@ def test_default_model_and_reasoning_sentinel():
 @pytest.mark.parametrize(
     ('model', 'reasoning', 'expected'),
     [
-        # gpt-5.5 family: 'auto' -> reasoning off
+        # gpt-5.5 -> reasoning off; the dated snapshot must match the prefix too
         ('gpt-5.5', 'auto', 'none'),
-        ('gpt-5.5-mini', 'auto', 'none'),
+        ('gpt-5.5-2026-04-23', 'auto', 'none'),
         # every other model: 'minimal' (cheapest tier, prior default) — NOT None,
         # so non-gpt-5.5 reasoning models don't regress to the API's medium default
         ('gpt-5', 'auto', 'minimal'),


### PR DESCRIPTION
## Summary

- Default OpenAI model → **`gpt-5.5`** (`DEFAULT_MODEL`). This is the single model in the GPT-5.5 family (snapshot `gpt-5.5-2026-04-23`; there is no `gpt-5.5-mini`/`-nano`).
- Reasoning effort is **model-tied** via an `'auto'` sentinel resolved in `BaseOpenAIClient._resolve_reasoning_effort`.
- **Temperature is never sent to reasoning models** on any path.

## Why

Reasoning is expensive/slow for Graphiti's structured-output workload without a meaningful quality gain, so `gpt-5.5` defaults to `reasoning_effort: "none"` (reasoning off). Verified against OpenAI docs: `gpt-5.5`'s enum is `none/low/medium/high/xhigh`.

## Reasoning-effort resolution (`'auto'`)

- **`gpt-5.5` → `'none'`** (reasoning off). Matched with `model.startswith('gpt-5.5')`, so dated snapshots (`gpt-5.5-2026-04-23`) and any future `gpt-5.5-*` are covered.
- **Every other model → `'minimal'`** — the cheapest broadly-supported tier and the long-standing default. Returning `'minimal'` (not omitting the param) is deliberate: it keeps non-`gpt-5.5` reasoning models from silently jumping to the API's **medium** default, which would be *more* reasoning/cost — i.e. **no regression** vs. the prior `DEFAULT_REASONING='minimal'`. `gpt-5.5` gets *less* than before; nothing gets more.
- Models whose lowest valid tier differs (e.g. `gpt-5.4-mini` requires `'low'`) should set `reasoning=` explicitly.
- Any explicit `reasoning=` value passes through unchanged, and is only sent for reasoning models (non-reasoning models ignore it). A falsy value (`''`/`None`) is never sent (truthiness guard, matching the Azure client).

## Temperature

Reasoning models (`gpt-5*`, `o1`, `o3`) reject `temperature`. Both the structured (`responses.parse`) and the JSON-object (`chat.completions`) paths **omit `temperature` entirely** for reasoning models — never sending it, not even `None`. (Azure already omitted it on both paths.)

## Supersedes #1395

Removes the cross-model hardcode rather than swapping `minimal`→`low` (which would go stale on the next model).

## Notes

- `DEFAULT_SMALL_MODEL` stays `gpt-4.1-nano` (cheap, non-reasoning).
- Docs (CLAUDE.md model list, README Azure example) can be refreshed in a follow-up; the mcp_server defaults are handled in #1552/#1553.

## Tests (`tests/llm_client/test_openai_client.py`)

- Resolver matrix: `gpt-5.5` **and its dated snapshot** `gpt-5.5-2026-04-23` → `none`; other models (`gpt-5`, `gpt-5.4-mini`, `o1`) → `minimal`; explicit values pass through; falsy → not sent.
- **Regression guard**: `gpt-5` + `'auto'` → sends `{'effort':'minimal'}` and no temperature.
- `_create_completion`: omits `temperature` for a reasoning model, keeps it for a standard model.

Azure tests still pass. `ruff` + `pyright` clean; 18 llm-client tests pass (+ 4 Azure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)