### PR TITLE
fix: skip invalid Neo4j embeddings in similarity search

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -200,6 +200,10 @@ class FalkorSearchOperations(SearchOperations):
             filter_queries.append('n.group_id IN $group_ids')
             filter_params['group_ids'] = group_ids
 
+        filter_queries.append(
+            'n.name_embedding IS NOT NULL AND size(n.name_embedding) = size($search_vector)'
+        )
+
         filter_query = ''
         if filter_queries:
             filter_query = ' WHERE ' + (' AND '.join(filter_queries))
@@ -364,6 +368,10 @@ class FalkorSearchOperations(SearchOperations):
             if target_node_uuid is not None:
                 filter_params['target_uuid'] = target_node_uuid
                 filter_queries.append('m.uuid = $target_uuid')
+
+        filter_queries.append(
+            'e.fact_embedding IS NOT NULL AND size(e.fact_embedding) = size($search_vector)'
+        )
 
         filter_query = ''
         if filter_queries:
@@ -548,11 +556,15 @@ class FalkorSearchOperations(SearchOperations):
         min_score: float = 0.6,
     ) -> list[CommunityNode]:
         query_params: dict[str, Any] = {}
+        filter_queries = [
+            'c.name_embedding IS NOT NULL AND size(c.name_embedding) = size($search_vector)'
+        ]
 
-        group_filter_query = ''
         if group_ids is not None:
-            group_filter_query += ' WHERE c.group_id IN $group_ids'
+            filter_queries.insert(0, 'c.group_id IN $group_ids')
             query_params['group_ids'] = group_ids
+
+        group_filter_query = ' WHERE ' + (' AND '.join(filter_queries))
 
         cypher = (
             'MATCH (c:Community)'

--- a/graphiti_core/driver/neo4j/operations/search_ops.py
+++ b/graphiti_core/driver/neo4j/operations/search_ops.py
@@ -142,6 +142,10 @@ class Neo4jSearchOperations(SearchOperations):
             filter_queries.append('n.group_id IN $group_ids')
             filter_params['group_ids'] = group_ids
 
+        filter_queries.append(
+            'n.name_embedding IS NOT NULL AND size(n.name_embedding) = size($search_vector)'
+        )
+
         filter_query = ''
         if filter_queries:
             filter_query = ' WHERE ' + (' AND '.join(filter_queries))
@@ -307,6 +311,10 @@ class Neo4jSearchOperations(SearchOperations):
             if target_node_uuid is not None:
                 filter_params['target_uuid'] = target_node_uuid
                 filter_queries.append('m.uuid = $target_uuid')
+
+        filter_queries.append(
+            'e.fact_embedding IS NOT NULL AND size(e.fact_embedding) = size($search_vector)'
+        )
 
         filter_query = ''
         if filter_queries:
@@ -489,11 +497,15 @@ class Neo4jSearchOperations(SearchOperations):
         min_score: float = 0.6,
     ) -> list[CommunityNode]:
         query_params: dict[str, Any] = {}
+        filter_queries = [
+            'c.name_embedding IS NOT NULL AND size(c.name_embedding) = size($search_vector)'
+        ]
 
-        group_filter_query = ''
         if group_ids is not None:
-            group_filter_query += ' WHERE c.group_id IN $group_ids'
+            filter_queries.insert(0, 'c.group_id IN $group_ids')
             query_params['group_ids'] = group_ids
+
+        group_filter_query = ' WHERE ' + (' AND '.join(filter_queries))
 
         cypher = (
             'MATCH (c:Community)'

--- a/tests/utils/search/test_search_security.py
+++ b/tests/utils/search/test_search_security.py
@@ -6,7 +6,10 @@ from pydantic import ValidationError
 
 from graphiti_core.driver.driver import GraphProvider
 from graphiti_core.driver.falkordb.operations.search_ops import _build_falkor_fulltext_query
-from graphiti_core.driver.neo4j.operations.search_ops import _build_neo4j_fulltext_query
+from graphiti_core.driver.neo4j.operations.search_ops import (
+    Neo4jSearchOperations,
+    _build_neo4j_fulltext_query,
+)
 from graphiti_core.errors import GroupIdValidationError, NodeLabelValidationError
 from graphiti_core.helpers import get_default_group_id, validate_group_id
 from graphiti_core.search.search import search
@@ -17,6 +20,15 @@ from graphiti_core.search.search_filters import (
     node_search_filter_query_constructor,
 )
 from graphiti_core.search.search_utils import fulltext_query
+
+
+class RecordingExecutor:
+    def __init__(self):
+        self.cypher = ''
+
+    async def execute_query(self, cypher, **kwargs):
+        self.cypher = cypher
+        return [], None, None
 
 
 def test_search_filters_reject_unsafe_node_labels():
@@ -109,3 +121,40 @@ def test_falkordb_fulltext_query_escapes_default_group_id():
     built = _build_falkor_fulltext_query('hello', [default])
     assert '@group_id:"\\_"' in built
     assert '@group_id:"_"' not in built
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('method_name', 'expected_guard'),
+    [
+        (
+            'node_similarity_search',
+            'n.name_embedding IS NOT NULL AND size(n.name_embedding) = size($search_vector)',
+        ),
+        (
+            'edge_similarity_search',
+            'e.fact_embedding IS NOT NULL AND size(e.fact_embedding) = size($search_vector)',
+        ),
+        (
+            'community_similarity_search',
+            'c.name_embedding IS NOT NULL AND size(c.name_embedding) = size($search_vector)',
+        ),
+    ],
+)
+async def test_neo4j_similarity_search_filters_invalid_embeddings_before_cosine(
+    method_name, expected_guard
+):
+    executor = RecordingExecutor()
+    operations = Neo4jSearchOperations()
+    method = getattr(operations, method_name)
+
+    if method_name == 'edge_similarity_search':
+        await method(executor, [0.1, 0.2], None, None, SearchFilters(), group_ids=['tenant'])
+    elif method_name == 'community_similarity_search':
+        await method(executor, [0.1, 0.2], group_ids=['tenant'])
+    else:
+        await method(executor, [0.1, 0.2], SearchFilters(), group_ids=['tenant'])
+
+    cosine_index = executor.cypher.index('vector.similarity.cosine')
+    guard_index = executor.cypher.index(expected_guard)
+    assert guard_index < cosine_index

--- a/tests/utils/search/test_search_security.py
+++ b/tests/utils/search/test_search_security.py
@@ -5,7 +5,10 @@ import pytest
 from pydantic import ValidationError
 
 from graphiti_core.driver.driver import GraphProvider
-from graphiti_core.driver.falkordb.operations.search_ops import _build_falkor_fulltext_query
+from graphiti_core.driver.falkordb.operations.search_ops import (
+    FalkorSearchOperations,
+    _build_falkor_fulltext_query,
+)
 from graphiti_core.driver.neo4j.operations.search_ops import (
     Neo4jSearchOperations,
     _build_neo4j_fulltext_query,
@@ -156,5 +159,42 @@ async def test_neo4j_similarity_search_filters_invalid_embeddings_before_cosine(
         await method(executor, [0.1, 0.2], SearchFilters(), group_ids=['tenant'])
 
     cosine_index = executor.cypher.index('vector.similarity.cosine')
+    guard_index = executor.cypher.index(expected_guard)
+    assert guard_index < cosine_index
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('method_name', 'expected_guard'),
+    [
+        (
+            'node_similarity_search',
+            'n.name_embedding IS NOT NULL AND size(n.name_embedding) = size($search_vector)',
+        ),
+        (
+            'edge_similarity_search',
+            'e.fact_embedding IS NOT NULL AND size(e.fact_embedding) = size($search_vector)',
+        ),
+        (
+            'community_similarity_search',
+            'c.name_embedding IS NOT NULL AND size(c.name_embedding) = size($search_vector)',
+        ),
+    ],
+)
+async def test_falkordb_similarity_search_filters_invalid_embeddings_before_cosine(
+    method_name, expected_guard
+):
+    executor = RecordingExecutor()
+    operations = FalkorSearchOperations()
+    method = getattr(operations, method_name)
+
+    if method_name == 'edge_similarity_search':
+        await method(executor, [0.1, 0.2], None, None, SearchFilters(), group_ids=['tenant'])
+    elif method_name == 'community_similarity_search':
+        await method(executor, [0.1, 0.2], group_ids=['tenant'])
+    else:
+        await method(executor, [0.1, 0.2], SearchFilters(), group_ids=['tenant'])
+
+    cosine_index = executor.cypher.index('vec.cosineDistance')
     guard_index = executor.cypher.index(expected_guard)
     assert guard_index < cosine_index


### PR DESCRIPTION
## Summary
- fixes #1328
- skip Neo4j nodes, edges, and communities whose embedding is null or has a different length than the search vector before calling vector.similarity.cosine
- adds a focused query-construction regression test so the guard stays before the cosine call

## Tests
- python -m py_compile graphiti_core\driver\neo4j\operations\search_ops.py tests\utils\search\test_search_security.py
- python -m ruff check graphiti_core\driver\neo4j\operations\search_ops.py tests\utils\search\test_search_security.py
- git diff --check
- pytest target: 11 passed, 1 warning

Note: the pytest command had to remove unrelated editable checkout paths from sys.path because this Windows environment has other local repos exposing a top-level tests package.