### PR TITLE
fix: omit temperature for reasoning chat completions

### DIFF
--- a/graphiti_core/llm_client/openai_client.py
+++ b/graphiti_core/llm_client/openai_client.py
@@ -116,10 +116,14 @@ class OpenAIClient(BaseOpenAIClient):
             model.startswith('gpt-5') or model.startswith('o1') or model.startswith('o3')
         )
 
-        return await self.client.chat.completions.create(
-            model=model,
-            messages=messages,
-            temperature=temperature if not is_reasoning_model else None,
-            max_tokens=max_tokens,
-            response_format={'type': 'json_object'},
-        )
+        request_kwargs = {
+            'model': model,
+            'messages': messages,
+            'max_tokens': max_tokens,
+            'response_format': {'type': 'json_object'},
+        }
+
+        if not is_reasoning_model and temperature is not None:
+            request_kwargs['temperature'] = temperature
+
+        return await self.client.chat.completions.create(**request_kwargs)

--- a/tests/llm_client/test_openai_client.py
+++ b/tests/llm_client/test_openai_client.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+
+import pytest
+
+from graphiti_core.llm_client.config import LLMConfig
+from graphiti_core.llm_client.openai_client import OpenAIClient
+
+
+class DummyChatCompletions:
+    def __init__(self):
+        self.create_calls: list[dict] = []
+
+    async def create(self, **kwargs):
+        self.create_calls.append(kwargs)
+        message = SimpleNamespace(content='{}')
+        choice = SimpleNamespace(message=message)
+        return SimpleNamespace(choices=[choice])
+
+
+class DummyChat:
+    def __init__(self):
+        self.completions = DummyChatCompletions()
+
+
+class DummyOpenAIClient:
+    def __init__(self):
+        self.chat = DummyChat()
+
+
+@pytest.mark.asyncio
+async def test_reasoning_completion_omits_temperature_key():
+    dummy_client = DummyOpenAIClient()
+    client = OpenAIClient(client=dummy_client, config=LLMConfig())
+
+    await client._create_completion(
+        model='gpt-5-mini',
+        messages=[],
+        temperature=0.7,
+        max_tokens=128,
+    )
+
+    create_args = dummy_client.chat.completions.create_calls[0]
+    assert 'temperature' not in create_args
+
+
+@pytest.mark.asyncio
+async def test_non_reasoning_completion_keeps_temperature_key():
+    dummy_client = DummyOpenAIClient()
+    client = OpenAIClient(client=dummy_client, config=LLMConfig())
+
+    await client._create_completion(
+        model='gpt-4.1-mini',
+        messages=[],
+        temperature=0.4,
+        max_tokens=64,
+    )
+
+    create_args = dummy_client.chat.completions.create_calls[0]
+    assert create_args['temperature'] == 0.4


### PR DESCRIPTION
## Summary
- fixes #878
- builds chat completion kwargs the same way as the Azure client so reasoning models do not receive a temperature key at all
- keeps temperature forwarding for non-reasoning models

## Tests
- python -m py_compile graphiti_core\llm_client\openai_client.py tests\llm_client\test_openai_client.py
- python -m ruff check graphiti_core\llm_client\openai_client.py tests\llm_client\test_openai_client.py
- git diff --check
- pytest target: 2 passed, 1 warning

Note: the pytest command removed unrelated local editable checkout paths from sys.path because this Windows environment has other repos exposing a top-level tests package.