### PR TITLE
ci(mcp): treat pytest exit-5 (suite self-skipped) as success

### DIFF
--- a/.github/workflows/mcp-server-tests.yml
+++ b/.github/workflows/mcp-server-tests.yml
@@ -70,4 +70,16 @@ jobs:
           MODEL_NAME: gpt-4.1-mini
           # Raise episode/LLM-call concurrency so the live episode processes quickly.
           SEMAPHORE_LIMIT: "20"
-        run: uv run pytest tests/test_live_falkordb_int.py -m integration -p no:cacheprovider
+        # pytest exits 5 when no tests are collected — which happens when the suite
+        # self-skips (a fork PR has no OPENAI_API_KEY, or FalkorDB is unreachable).
+        # Treat that as success rather than a CI failure; any real test failure
+        # (exit 1) still fails the job.
+        run: |
+          set +e
+          uv run pytest tests/test_live_falkordb_int.py -m integration -p no:cacheprovider
+          code=$?
+          if [ "$code" -eq 5 ]; then
+            echo 'No live tests ran (suite self-skipped — no OpenAI key / FalkorDB); treating as success.'
+            exit 0
+          fi
+          exit "$code"


### PR DESCRIPTION
## Problem
The live MCP test (`mcp-server-tests.yml`) **self-skips** when prerequisites are absent — most importantly on **fork PRs**, which receive no `OPENAI_API_KEY` (it's an environment secret), and when FalkorDB is unreachable. When the module skips, pytest collects 0 tests and **exits with code 5** ("no tests ran"), which GitHub marks as a **failed check**.

Seen on fork PR **#1376** (touches `mcp_server/**`): `OPENAI_API_KEY:` empty → `collected 0 items / 1 skipped` → `exit code 5` → ❌. The intended graceful "no-op skip" on fork PRs shows up red.

## Fix
Wrap the pytest invocation so **exit code 5 is treated as success** (with a clear log line). A real test failure (exit 1) still fails the job.

```bash
uv run pytest ...
code=$?
[ "$code" -eq 5 ] && { echo 'No live tests ran (self-skipped); treating as success.'; exit 0; }
exit "$code"
```

Verified locally: with no FalkorDB the suite self-skips → pytest exits 5 → wrapper exits 0.

## Impact
Unblocks the live-mcp-tests check on all fork PRs touching `mcp_server` (including #1376, whose code is otherwise green: rebased, 5 config tests pass, CLA signed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)