### PR TITLE
ci(server): live end-to-end regression test + PR check

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -1,0 +1,89 @@
+name: Server Tests
+
+# Live end-to-end regression tests for the Graphiti graph_service (REST API)
+# against FalkorDB and a real OpenAI model. Spawns the FastAPI server as a
+# subprocess and exercises the public API end to end (ingest -> async process ->
+# search -> delete). Runs on PRs and pushes to main that touch the server. The
+# OpenAI key comes from the `development` GitHub environment; fork PRs receive no
+# secrets, so the suite skips itself there (the test module skips when
+# OPENAI_API_KEY is unset).
+on:
+  push:
+    branches: [main]
+    paths:
+      - "server/**"
+      - ".github/workflows/server-tests.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "server/**"
+      - ".github/workflows/server-tests.yml"
+
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref so repeated pushes don't keep paying for
+# real OpenAI calls.
+concurrency:
+  group: server-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  live-server-tests:
+    runs-on: depot-ubuntu-22.04
+    environment: development
+    # Insurance against a hung server subprocess / uv sync.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.10"
+      - name: Install uv
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+        with:
+          version: "latest"
+      - name: Start FalkorDB
+        # Run the database on the host network rather than a `services:` block: on
+        # the depot-ubuntu runner pool bridge-network NAT silently drops packets to
+        # published service-container ports. Readiness is checked via `docker exec`.
+        run: docker run -d --name falkordb --network host falkordb/falkordb:latest
+      - name: Install dependencies
+        working-directory: server
+        run: uv sync --extra dev
+      - name: Wait for FalkorDB
+        run: |
+          for i in $(seq 1 30); do
+            if docker exec falkordb redis-cli ping 2>/dev/null | grep -q PONG; then
+              echo "falkordb ready after ${i}s"; break
+            fi
+            if [ "$i" -eq 30 ]; then echo "falkordb did not become ready in 30s" >&2; docker logs falkordb; exit 1; fi
+            sleep 1
+          done
+      - name: Run live server integration tests
+        working-directory: server
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          DB_BACKEND: falkordb
+          FALKORDB_HOST: localhost
+          FALKORDB_PORT: "6379"
+          # gpt-5.5 is the graphiti-core default, but it requires a key/account
+          # with fast gpt-5.5 access; CI pins a lighter, broadly-available model so
+          # the live test stays fast and reliable. It exercises the same pipeline.
+          MODEL_NAME: gpt-4.1-mini
+          # Raise episode/LLM-call concurrency so the live episode processes quickly.
+          SEMAPHORE_LIMIT: "20"
+        # pytest exits 5 when no tests are collected — which happens when the suite
+        # self-skips (a fork PR has no OPENAI_API_KEY, or FalkorDB is unreachable).
+        # Treat that as success rather than a CI failure; any real test failure
+        # (exit 1) still fails the job.
+        run: |
+          set +e
+          uv run pytest tests/test_live_falkordb_int.py -m integration -p no:cacheprovider
+          code=$?
+          if [ "$code" -eq 5 ]; then
+            echo 'No live tests ran (suite self-skipped — no OpenAI key / FalkorDB); treating as success.'
+            exit 0
+          fi
+          exit "$code"

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -74,16 +74,23 @@ jobs:
           MODEL_NAME: gpt-4.1-mini
           # Raise episode/LLM-call concurrency so the live episode processes quickly.
           SEMAPHORE_LIMIT: "20"
-        # pytest exits 5 when no tests are collected — which happens when the suite
-        # self-skips (a fork PR has no OPENAI_API_KEY, or FalkorDB is unreachable).
-        # Treat that as success rather than a CI failure; any real test failure
-        # (exit 1) still fails the job.
+        # pytest exits 5 when no tests are collected. The legitimate case is a fork
+        # PR with no OPENAI_API_KEY: the suite self-skips at module level. When the
+        # key IS present (same-repo run), FalkorDB is already up — the prior step
+        # gates on it — so exit 5 instead means a broken test selection (the
+        # `integration` marker or the test file was renamed) and must fail loudly,
+        # rather than reporting a green build that tested nothing. Import errors
+        # (exit 2) and real test failures (exit 1) always fail the job.
         run: |
           set +e
           uv run pytest tests/test_live_falkordb_int.py -m integration -p no:cacheprovider
           code=$?
           if [ "$code" -eq 5 ]; then
-            echo 'No live tests ran (suite self-skipped — no OpenAI key / FalkorDB); treating as success.'
-            exit 0
+            if [ -z "$OPENAI_API_KEY" ]; then
+              echo 'No live tests ran (no OPENAI_API_KEY — fork PR self-skip); treating as success.'
+              exit 0
+            fi
+            echo 'pytest collected no tests but OPENAI_API_KEY is set — likely a broken test selection (renamed marker/file). Failing.' >&2
+            exit 1
           fi
           exit "$code"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -25,6 +25,9 @@ dev = [
     "pytest-xdist>=3.6.1",
     "ruff>=0.6.2",
     "fastapi-cli>=0.0.5",
+    # FalkorDB driver, needed by the live end-to-end test (tests/test_live_falkordb_int.py)
+    # which exercises the db_backend='falkordb' path. Not a runtime dependency.
+    "graphiti-core[falkordb]>=0.28.2",
 ]
 
 [build-system]
@@ -36,6 +39,9 @@ packages = ["graph_service"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
+markers = [
+    "integration: live end-to-end tests requiring FalkorDB and an OpenAI API key",
+]
 
 [tool.ruff]
 line-length = 100

--- a/server/tests/test_live_falkordb_int.py
+++ b/server/tests/test_live_falkordb_int.py
@@ -32,6 +32,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import uuid
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -77,8 +78,10 @@ def _free_port() -> int:
 
 
 def _unique_token() -> str:
-    # Alphanumeric only: safe as both a FalkorDB graph name and a group_id.
-    return f'srvtest{int(time.time())}{os.getpid()}'
+    # Alphanumeric only: safe as both a FalkorDB graph name and a group_id. A uuid
+    # (not a timestamp+pid) guarantees a distinct graph per fixture even for tests
+    # set up within the same second or run under pytest-xdist.
+    return f'srvtest{uuid.uuid4().hex}'
 
 
 def _wait_for_health(proc: subprocess.Popen, base_url: str, log, timeout: float = 90.0) -> None:
@@ -153,15 +156,28 @@ def _wait_for_episodes(
     timeout: float = 180.0,
     poll: float = 3.0,
 ) -> list:
+    """Poll GET /episodes until ``expected`` episodes are persisted.
+
+    /episodes is only called after /healthcheck has passed, so the server is
+    fully up: a 5xx here is a real error (e.g. a FalkorDB query failure) and is
+    surfaced immediately rather than masked as a slow generic timeout. Any other
+    non-200 is remembered and reported if the wait ultimately times out.
+    """
     deadline = time.monotonic() + timeout
+    last_error: str | None = None
     while time.monotonic() < deadline:
         resp = client.get(f'/episodes/{group_id}', params={'last_n': 50})
         if resp.status_code == 200:
             episodes = resp.json()
             if isinstance(episodes, list) and len(episodes) >= expected:
                 return episodes
+        elif resp.status_code >= 500:
+            raise AssertionError(f'/episodes returned {resp.status_code}: {resp.text[:500]}')
+        else:
+            last_error = f'{resp.status_code} {resp.text[:500]}'
         time.sleep(poll)
-    return []
+    detail = f'; last non-200 from /episodes: {last_error}' if last_error else ''
+    raise AssertionError(f'episode was not processed within {timeout:.0f}s{detail}')
 
 
 def _search_until(
@@ -213,9 +229,9 @@ def test_ingest_search_delete_e2e(live_server: tuple[str, str]) -> None:
             )
             assert add.status_code == 202, f'add /messages failed: {add.status_code} {add.text}'
 
-            # 2. Wait for the async worker to persist the episode.
+            # 2. Wait for the async worker to persist the episode (raises with
+            # detail on a server error or timeout).
             episodes = _wait_for_episodes(client, group_id)
-            assert episodes, 'episode was not processed within the timeout'
             assert any(e.get('group_id') == group_id for e in episodes)
 
             # 3. At least one fact (edge) was extracted and is searchable.

--- a/server/tests/test_live_falkordb_int.py
+++ b/server/tests/test_live_falkordb_int.py
@@ -1,0 +1,227 @@
+"""Live end-to-end regression test for the graph_service REST API.
+
+Spawns the FastAPI server (``graph_service.main:app``) as a uvicorn subprocess
+backed by FalkorDB (the default test database) and a real OpenAI model, then
+exercises the public API end to end:
+
+    POST /messages (async ingest)
+        -> poll GET /episodes/{group_id} until the episode is persisted
+        -> POST /search and assert at least one fact was extracted
+        -> DELETE /group/{group_id} to clean up.
+
+This is the server counterpart to ``mcp_server``'s live test. It is skipped
+automatically unless an OpenAI API key is available AND FalkorDB is reachable:
+
+- Local: the project-root ``.env`` is loaded, so an ``OPENAI_API_KEY`` there is
+  picked up. Start FalkorDB first, e.g.::
+
+      docker run -d --name falkordb -p 6379:6379 falkordb/falkordb:latest
+      cd server && uv run pytest tests/test_live_falkordb_int.py
+
+- CI: ``OPENAI_API_KEY`` comes from the GitHub environment and FalkorDB runs as a
+  container (see .github/workflows/server-tests.yml).
+
+The model is taken from ``MODEL_NAME`` (CI pins a lighter, broadly-available
+model for speed/reliability), falling back to the server's configured default.
+"""
+
+import contextlib
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from dotenv import load_dotenv
+
+# Load the project-root .env for local runs (CI provides the env directly).
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+load_dotenv(_REPO_ROOT / '.env')
+
+SERVER_DIR = Path(__file__).resolve().parent.parent
+FALKORDB_HOST = os.environ.get('FALKORDB_HOST', 'localhost')
+FALKORDB_PORT = int(os.environ.get('FALKORDB_PORT', '6379'))
+
+pytestmark = [pytest.mark.integration]
+
+
+def _falkordb_reachable(host: str, port: int) -> bool:
+    """Best-effort TCP check that a FalkorDB (Redis) endpoint is reachable."""
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+# Skip the whole module unless prerequisites are present, so the suite is a no-op
+# locally without setup and on fork PRs (which have no secrets).
+if not os.environ.get('OPENAI_API_KEY'):
+    pytest.skip('OPENAI_API_KEY not set; skipping live server tests', allow_module_level=True)
+if not _falkordb_reachable(FALKORDB_HOST, FALKORDB_PORT):
+    pytest.skip(
+        f'FalkorDB not reachable at {FALKORDB_HOST}:{FALKORDB_PORT}; skipping live server tests',
+        allow_module_level=True,
+    )
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+
+
+def _unique_token() -> str:
+    # Alphanumeric only: safe as both a FalkorDB graph name and a group_id.
+    return f'srvtest{int(time.time())}{os.getpid()}'
+
+
+def _wait_for_health(proc: subprocess.Popen, base_url: str, log, timeout: float = 90.0) -> None:
+    """Block until the server answers /healthcheck (lifespan startup complete)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            log.seek(0)
+            raise RuntimeError(
+                f'server exited early (code {proc.returncode}):\n{log.read().decode(errors="replace")}'
+            )
+        with contextlib.suppress(httpx.HTTPError):
+            if httpx.get(f'{base_url}/healthcheck', timeout=2).status_code == 200:
+                return
+        time.sleep(1)
+    log.seek(0)
+    raise RuntimeError(
+        f'server did not become healthy within {timeout}s:\n{log.read().decode(errors="replace")}'
+    )
+
+
+@pytest.fixture
+def live_server() -> Iterator[tuple[str, str]]:
+    """Spawn the graph_service on a fresh FalkorDB graph; yield (base_url, group_id)."""
+    port = _free_port()
+    token = _unique_token()
+    env = {
+        **os.environ,
+        'DB_BACKEND': 'falkordb',
+        'FALKORDB_HOST': FALKORDB_HOST,
+        'FALKORDB_PORT': str(FALKORDB_PORT),
+        # A fresh logical graph per run isolates the test and keeps a long-lived
+        # local FalkorDB from accumulating data across runs.
+        'FALKORDB_DATABASE': token,
+    }
+    # Not a context manager: the handle must outlive setup (the subprocess writes
+    # to it across the yield) and is closed explicitly in the finally block.
+    log = tempfile.TemporaryFile()  # noqa: SIM115
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            '-m',
+            'uvicorn',
+            'graph_service.main:app',
+            '--host',
+            '127.0.0.1',
+            '--port',
+            str(port),
+        ],
+        cwd=str(SERVER_DIR),
+        env=env,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+    )
+    base_url = f'http://127.0.0.1:{port}'
+    try:
+        _wait_for_health(proc, base_url, log)
+        yield base_url, token
+    finally:
+        proc.terminate()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=10)
+        if proc.poll() is None:
+            proc.kill()
+        log.close()
+
+
+def _wait_for_episodes(
+    client: httpx.Client,
+    group_id: str,
+    expected: int = 1,
+    timeout: float = 180.0,
+    poll: float = 3.0,
+) -> list:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resp = client.get(f'/episodes/{group_id}', params={'last_n': 50})
+        if resp.status_code == 200:
+            episodes = resp.json()
+            if isinstance(episodes, list) and len(episodes) >= expected:
+                return episodes
+        time.sleep(poll)
+    return []
+
+
+def _search_until(
+    client: httpx.Client, group_id: str, query: str, attempts: int = 6, poll: float = 3.0
+) -> list:
+    """POST /search, retrying until facts appear (index/processing lag)."""
+    facts: list = []
+    for _ in range(attempts):
+        resp = client.post(
+            '/search', json={'group_ids': [group_id], 'query': query, 'max_facts': 10}
+        )
+        assert resp.status_code == 200, f'/search failed: {resp.status_code} {resp.text}'
+        facts = resp.json().get('facts', [])
+        if facts:
+            return facts
+        time.sleep(poll)
+    return facts
+
+
+def test_healthcheck(live_server: tuple[str, str]) -> None:
+    base_url, _ = live_server
+    with httpx.Client(base_url=base_url, timeout=10) as client:
+        resp = client.get('/healthcheck')
+        assert resp.status_code == 200
+        assert resp.json().get('status') == 'healthy'
+
+
+def test_ingest_search_delete_e2e(live_server: tuple[str, str]) -> None:
+    base_url, group_id = live_server
+    with httpx.Client(base_url=base_url, timeout=30) as client:
+        try:
+            # 1. Ingest a message with clearly-extractable entities and a relationship.
+            add = client.post(
+                '/messages',
+                json={
+                    'group_id': group_id,
+                    'messages': [
+                        {
+                            'content': (
+                                'Alice is a software engineer at Acme Corporation. '
+                                'She works on the Graphiti project.'
+                            ),
+                            'role_type': 'user',
+                            'role': 'alice',
+                            'name': 'intro',
+                        }
+                    ],
+                },
+            )
+            assert add.status_code == 202, f'add /messages failed: {add.status_code} {add.text}'
+
+            # 2. Wait for the async worker to persist the episode.
+            episodes = _wait_for_episodes(client, group_id)
+            assert episodes, 'episode was not processed within the timeout'
+            assert any(e.get('group_id') == group_id for e in episodes)
+
+            # 3. At least one fact (edge) was extracted and is searchable.
+            facts = _search_until(client, group_id, 'Alice Acme Corporation Graphiti')
+            assert facts, 'expected at least one extracted fact'
+        finally:
+            # Always clean up this run's data, even if an assertion above failed.
+            with contextlib.suppress(httpx.HTTPError):
+                client.delete(f'/group/{group_id}')

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -36,6 +36,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "backoff"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -203,6 +212,19 @@ wheels = [
 ]
 
 [[package]]
+name = "falkordb"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "redis" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/3a/58da510e5800a5cdbf9591111e4287cbf68b475bf074db12a94e5db8bcea/falkordb-1.6.1.tar.gz", hash = "sha256:bbef448a0b43e00ff3062bd6201368618d7b36e969d16ba71e8b8e3fa90873d4", size = 103185, upload-time = "2026-04-28T13:24:44.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/02/1cf9cef72228ca2b2776b4ed0cb2645298ddcc57c1fe2c545cd46bc11eae/falkordb-1.6.1-py3-none-any.whl", hash = "sha256:cf51caeb433c04db303de5967a0c2590675fcc0354e80997870b1e0497d30c34", size = 37802, upload-time = "2026-04-28T13:24:45.677Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
@@ -247,6 +269,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "fastapi-cli" },
+    { name = "graphiti-core", extra = ["falkordb"] },
     { name = "pydantic" },
     { name = "pyright" },
     { name = "pytest" },
@@ -261,6 +284,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastapi-cli", marker = "extra == 'dev'", specifier = ">=0.0.5" },
     { name = "graphiti-core", specifier = ">=0.28.2" },
+    { name = "graphiti-core", extras = ["falkordb"], marker = "extra == 'dev'", specifier = ">=0.28.2" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", marker = "extra == 'dev'", specifier = ">=2.8.2" },
     { name = "pydantic-settings", specifier = ">=2.4.0" },
@@ -290,6 +314,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/62/6d/81b78aec2030bff0030bbabb8b227a6fa3c5fb49fb11e8501e7d0f39f3fe/graphiti_core-0.28.2.tar.gz", hash = "sha256:9b2a72f117827e015a21b610eb2c3acbe05310b79736abef7372e81247578e9d", size = 6846195, upload-time = "2026-03-11T16:20:02.736Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/cd/e6203f1fee0a8e2a797f2d5f9a867513e0c63af4e19fdd1c5a7e14a47670/graphiti_core-0.28.2-py3-none-any.whl", hash = "sha256:4e1c19b7bc70a73a612a473144ed4b3fe615ac6d4c5d6b10f48e206a858bcb53", size = 314919, upload-time = "2026-03-11T16:20:01.037Z" },
+]
+
+[package.optional-dependencies]
+falkordb = [
+    { name = "falkordb" },
 ]
 
 [[package]]
@@ -868,6 +897,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
+name = "redis"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a live end-to-end regression check for the `server/` REST API (`graph_service`), mirroring the existing `mcp-server-tests.yml` workflow.

**`server/tests/test_live_falkordb_int.py`** — spawns the FastAPI server as a uvicorn subprocess backed by FalkorDB + a real OpenAI model, and exercises the public API end to end:

- `POST /messages` (async ingest) → poll `GET /episodes/{group_id}` until the episode is persisted → `POST /search` and assert at least one fact was extracted → `DELETE /group/{group_id}` cleanup.
- Plus a `GET /healthcheck` smoke test.
- Self-skips (module-level) when `OPENAI_API_KEY` is unset **or** FalkorDB is unreachable, so it's a no-op on fork PRs and on local checkouts without setup.

**`.github/workflows/server-tests.yml`** — mirrors `mcp-server-tests.yml`:

- Triggers on PRs/pushes to `main` touching `server/**` or the workflow file.
- Depot runner, FalkorDB on the host network (bridge-NAT workaround), `development` environment for the OpenAI key.
- Pins `MODEL_NAME=gpt-4.1-mini` and `SEMAPHORE_LIMIT=20` for speed/reliability.
- Treats pytest exit code 5 (no tests collected — the self-skip case on fork PRs) as success; real failures still fail the job.

**`server/pyproject.toml`** — registers the `integration` pytest marker and adds `graphiti-core[falkordb]` to the **dev** dependencies. The server already branches on `db_backend='falkordb'` but never installed the driver; this is test-only so production installs stay lean.

## Validation

Run locally against a real FalkorDB container + live OpenAI:

- Live run: **2 passed in ~16s** (ingest → process → search → delete).
- Self-skip path (DB unreachable / no key): pytest exits **5**, which the workflow maps to success.

## Note for reviewers

The server advertises a FalkorDB backend (`db_backend='falkordb'`) but its **production** deps don't include the driver — a `db_backend=falkordb` deployment hits `ImportError: falkordb is required` today. This PR only adds the driver to dev deps (for the test). Whether to also add `graphiti-core[falkordb]` to the server's runtime dependencies is a separate call worth making.

🤖 Generated with [Claude Code](https://claude.com/claude-code)