### PR TITLE
ci: harden exit-5 handling in the live-test workflows (MCP backport + diagnostics)

### DIFF
--- a/.github/workflows/mcp-server-tests.yml
+++ b/.github/workflows/mcp-server-tests.yml
@@ -72,11 +72,13 @@ jobs:
           SEMAPHORE_LIMIT: "20"
         # pytest exits 5 when no tests are collected. The legitimate case is a fork
         # PR with no OPENAI_API_KEY: the suite self-skips at module level. When the
-        # key IS present (same-repo run), FalkorDB is already up — the prior step
-        # gates on it — so exit 5 instead means a broken test selection (the
-        # `integration` marker or the test file was renamed) and must fail loudly,
-        # rather than reporting a green build that tested nothing. Import errors
-        # (exit 2) and real test failures (exit 1) always fail the job.
+        # key IS present (same-repo run) exit 5 is unexpected — the live suite should
+        # have run — so fail loudly rather than report a green build that tested
+        # nothing. Likely causes: FalkorDB became unreachable (the suite also skips at
+        # module level when it can't connect, even though the prior step gated it), or
+        # the `integration` marker was renamed/removed so the selection matches
+        # nothing. Real failures (exit 1), import errors (exit 2), and usage errors
+        # such as a renamed test-file path (exit 4) always fail the job too.
         run: |
           set +e
           uv run pytest tests/test_live_falkordb_int.py -m integration -p no:cacheprovider
@@ -86,7 +88,7 @@ jobs:
               echo 'No live tests ran (no OPENAI_API_KEY — fork PR self-skip); treating as success.'
               exit 0
             fi
-            echo 'pytest collected no tests but OPENAI_API_KEY is set — likely a broken test selection (renamed marker/file). Failing.' >&2
+            echo 'pytest collected no tests but OPENAI_API_KEY is set — the live suite should have run. FalkorDB likely became unreachable, or the integration test selection broke (renamed marker). Failing.' >&2
             exit 1
           fi
           exit "$code"

--- a/.github/workflows/mcp-server-tests.yml
+++ b/.github/workflows/mcp-server-tests.yml
@@ -70,16 +70,23 @@ jobs:
           MODEL_NAME: gpt-4.1-mini
           # Raise episode/LLM-call concurrency so the live episode processes quickly.
           SEMAPHORE_LIMIT: "20"
-        # pytest exits 5 when no tests are collected — which happens when the suite
-        # self-skips (a fork PR has no OPENAI_API_KEY, or FalkorDB is unreachable).
-        # Treat that as success rather than a CI failure; any real test failure
-        # (exit 1) still fails the job.
+        # pytest exits 5 when no tests are collected. The legitimate case is a fork
+        # PR with no OPENAI_API_KEY: the suite self-skips at module level. When the
+        # key IS present (same-repo run), FalkorDB is already up — the prior step
+        # gates on it — so exit 5 instead means a broken test selection (the
+        # `integration` marker or the test file was renamed) and must fail loudly,
+        # rather than reporting a green build that tested nothing. Import errors
+        # (exit 2) and real test failures (exit 1) always fail the job.
         run: |
           set +e
           uv run pytest tests/test_live_falkordb_int.py -m integration -p no:cacheprovider
           code=$?
           if [ "$code" -eq 5 ]; then
-            echo 'No live tests ran (suite self-skipped — no OpenAI key / FalkorDB); treating as success.'
-            exit 0
+            if [ -z "$OPENAI_API_KEY" ]; then
+              echo 'No live tests ran (no OPENAI_API_KEY — fork PR self-skip); treating as success.'
+              exit 0
+            fi
+            echo 'pytest collected no tests but OPENAI_API_KEY is set — likely a broken test selection (renamed marker/file). Failing.' >&2
+            exit 1
           fi
           exit "$code"

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -76,11 +76,13 @@ jobs:
           SEMAPHORE_LIMIT: "20"
         # pytest exits 5 when no tests are collected. The legitimate case is a fork
         # PR with no OPENAI_API_KEY: the suite self-skips at module level. When the
-        # key IS present (same-repo run), FalkorDB is already up — the prior step
-        # gates on it — so exit 5 instead means a broken test selection (the
-        # `integration` marker or the test file was renamed) and must fail loudly,
-        # rather than reporting a green build that tested nothing. Import errors
-        # (exit 2) and real test failures (exit 1) always fail the job.
+        # key IS present (same-repo run) exit 5 is unexpected — the live suite should
+        # have run — so fail loudly rather than report a green build that tested
+        # nothing. Likely causes: FalkorDB became unreachable (the suite also skips at
+        # module level when it can't connect, even though the prior step gated it), or
+        # the `integration` marker was renamed/removed so the selection matches
+        # nothing. Real failures (exit 1), import errors (exit 2), and usage errors
+        # such as a renamed test-file path (exit 4) always fail the job too.
         run: |
           set +e
           uv run pytest tests/test_live_falkordb_int.py -m integration -p no:cacheprovider
@@ -90,7 +92,7 @@ jobs:
               echo 'No live tests ran (no OPENAI_API_KEY — fork PR self-skip); treating as success.'
               exit 0
             fi
-            echo 'pytest collected no tests but OPENAI_API_KEY is set — likely a broken test selection (renamed marker/file). Failing.' >&2
+            echo 'pytest collected no tests but OPENAI_API_KEY is set — the live suite should have run. FalkorDB likely became unreachable, or the integration test selection broke (renamed marker). Failing.' >&2
             exit 1
           fi
           exit "$code"


### PR DESCRIPTION
## Summary

Hardens the exit-code-5 handling in the live-test workflows.

1. **Backports the fail-loudly fix to `mcp-server-tests.yml`** (the server got it in #1560). The exit-5→success path is now gated on `OPENAI_API_KEY` being absent, so a fork PR's module-level self-skip stays green while a same-repo run that unexpectedly collects zero tests fails instead of reporting a green build that tested nothing.
2. **Clarifies the failure diagnostic in both workflows** (review follow-up).

## Exit-5 causes (corrected)

`pytest` exits 5 when no tests are collected. With the key present (same-repo run), that's unexpected and the job now fails loudly. It can be reached by either:

- **FalkorDB became unreachable** — the suite has a *second* module-level skip via a host-side TCP check to `localhost:6379`, distinct from the workflow's in-container `redis-cli ping` readiness gate. Normally equivalent under `--network host`, but not the same check.
- **The `integration` marker was renamed/removed** — `-m integration` then matches nothing.

(A renamed/removed **test file** is a pytest *usage error* → exit **4**, not 5 — still caught by `exit "$code"`. The earlier description conflated this with the marker case; only the marker case routes through the exit-5 branch.)

| Scenario | Before | After |
|----------|--------|-------|
| Fork PR (no key) → module self-skip → exit 5 | success | success |
| Same-repo, key present, exit 5 (FalkorDB down **or** marker renamed) | silent green | **fail** |
| Renamed test-file path (exit 4) / import error (exit 2) / real failure (exit 1) | fail | fail |

Workflow-only — no test or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)