### PR TITLE
fix: filter Neptune query params

### DIFF
--- a/graphiti_core/driver/neptune_driver.py
+++ b/graphiti_core/driver/neptune_driver.py
@@ -17,6 +17,7 @@ limitations under the License.
 import asyncio
 import datetime
 import logging
+import re
 from collections.abc import Coroutine
 from typing import Any
 
@@ -58,6 +59,10 @@ from graphiti_core.driver.operations.search_ops import SearchOperations
 
 logger = logging.getLogger(__name__)
 DEFAULT_SIZE = 10
+PARAM_PATTERN = re.compile(r'\$([A-Za-z_][A-Za-z0-9_]*)')
+NEPTUNE_AOSS_INDEX_ALIASES = {
+    'communities': 'community_name',
+}
 
 aoss_indices = [
     {
@@ -280,14 +285,27 @@ class NeptuneDriver(GraphDriver):
     async def execute_query(
         self, cypher_query_, **kwargs: Any
     ) -> tuple[list[dict[str, Any]], None, None]:
-        params = dict(kwargs)
+        params = self._normalize_query_params(cypher_query_, kwargs)
         if isinstance(cypher_query_, list):
             result: list[dict[str, Any]] = []
             for q in cypher_query_:
-                result, _, _ = self._run_query(q[0], q[1])
+                result, _, _ = self._run_query(
+                    q[0], self._normalize_query_params(q[0], {'params': q[1]})
+                )
             return result, None, None
         else:
             return self._run_query(cypher_query_, params)
+
+    def _normalize_query_params(self, cypher_query_: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
+        query_kwargs = dict(kwargs)
+        params = dict(query_kwargs.pop('params', {}) or {})
+        params.update(query_kwargs)
+        referenced_params = set(PARAM_PATTERN.findall(str(cypher_query_)))
+        return {
+            name: value
+            for name, value in params.items()
+            if value is not None and name in referenced_params
+        }
 
     def _run_query(self, cypher_query_, params):
         cypher_query_ = str(self._sanitize_parameters(cypher_query_, params))
@@ -349,11 +367,12 @@ class NeptuneDriver(GraphDriver):
         return {}
 
     def save_to_aoss(self, name: str, data: list[dict]) -> int:
+        index_name = NEPTUNE_AOSS_INDEX_ALIASES.get(name.lower(), name.lower())
         for index in aoss_indices:
-            if name.lower() == index['index_name']:
+            if index_name == index['index_name']:
                 to_index = []
                 for d in data:
-                    item = {'_index': name, '_id': d['uuid']}
+                    item = {'_index': index['index_name'], '_id': d['uuid']}
                     for p in index['body']['mappings']['properties']:
                         if p in d:
                             item[p] = d[p]

--- a/tests/driver/test_neptune_driver.py
+++ b/tests/driver/test_neptune_driver.py
@@ -1,0 +1,104 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import pytest
+
+try:
+    from graphiti_core.driver.neptune_driver import NeptuneDriver
+
+    HAS_NEPTUNE = True
+except ImportError:
+    NeptuneDriver = None
+    HAS_NEPTUNE = False
+
+
+@unittest.skipIf(not HAS_NEPTUNE, 'Neptune dependencies are not installed')
+class TestNeptuneDriver:
+    @staticmethod
+    def _driver() -> NeptuneDriver:
+        driver = NeptuneDriver.__new__(NeptuneDriver)
+        driver.client = MagicMock()
+        driver.aoss_client = MagicMock()
+        return driver
+
+    @pytest.mark.asyncio
+    async def test_execute_query_keeps_only_cypher_referenced_params(self):
+        driver = self._driver()
+        driver.client.query.return_value = [{'uuid': 'node-1'}]
+        query = 'MATCH (n:Entity) WHERE n.group_id IN $group_ids AND n.name = $query RETURN n'
+
+        result = await driver.execute_query(
+            query,
+            params={'group_ids': ['group-1'], 'unreferenced_filter': 'unused'},
+            query='Ada',
+            search_vector=[0.1, 0.2],
+            min_score=0.6,
+            limit=10,
+            database_='tenant-a',
+            routing_='r',
+            optional=None,
+        )
+
+        driver.client.query.assert_called_once_with(
+            query,
+            params={'group_ids': ['group-1'], 'query': 'Ada'},
+        )
+        assert result == ([{'uuid': 'node-1'}], None, None)
+
+    @pytest.mark.asyncio
+    async def test_execute_query_preserves_referenced_limit(self):
+        driver = self._driver()
+        driver.client.query.return_value = [{'uuid': 'node-1'}]
+        query = 'MATCH (n:Entity) WHERE n.group_id = $group_id RETURN n LIMIT $limit'
+
+        await driver.execute_query(
+            query,
+            group_id='group-1',
+            limit=5,
+            database_='tenant-a',
+            optional=None,
+        )
+
+        driver.client.query.assert_called_once_with(
+            query,
+            params={'group_id': 'group-1', 'limit': 5},
+        )
+
+    def test_save_to_aoss_aliases_communities_to_community_name(self, monkeypatch):
+        driver = self._driver()
+        captured = {}
+
+        def fake_bulk(client, actions, stats_only):
+            captured['client'] = client
+            captured['actions'] = list(actions)
+            captured['stats_only'] = stats_only
+            return 1, []
+
+        monkeypatch.setattr('graphiti_core.driver.neptune_driver.helpers.bulk', fake_bulk)
+
+        success = driver.save_to_aoss(
+            'communities',
+            [{'uuid': 'community-1', 'name': 'Graphiti users', 'group_id': 'group-1'}],
+        )
+
+        assert success == 1
+        assert captured['client'] == driver.aoss_client
+        assert captured['stats_only'] is True
+        assert captured['actions'][0]['_index'] == 'community_name'
+        assert captured['actions'][0]['uuid'] == 'community-1'


### PR DESCRIPTION
## Summary
- Filter Neptune `execute_query()` kwargs down to non-`None` parameters actually referenced by the Cypher query after flattening nested `params`.
- Keep referenced params such as `LIMIT $limit`, while dropping live-path extras like `search_vector`, `min_score`, `database_`, and `routing_` before they reach Neptune openCypher.
- Alias fallback community AOSS writes from `communities` to the Neptune `community_name` index.
- Add focused `NeptuneDriver` regression coverage for both follow-up paths.

## Context
This is a small follow-up for the live Neptune/AOSS path findings discussed in #1529 and #1539. It intentionally does not include the other #1539 fixes (`clone()` handling or AOSS bulk action `_id` changes), so it can stay focused on query parameter filtering and community index naming.

## Testing
- `uv run --frozen --extra dev --extra neptune pytest tests/driver/test_neptune_driver.py -q`
- `uv run --frozen --extra dev --extra neptune ruff check graphiti_core/driver/neptune_driver.py tests/driver/test_neptune_driver.py`
- `uv run --frozen --extra dev --extra neptune ruff format --check graphiti_core/driver/neptune_driver.py tests/driver/test_neptune_driver.py`
- `uv run --frozen --extra dev --extra neptune pyright graphiti_core/driver/neptune_driver.py`