### PR TITLE
fix: stop lucene_sanitize escaping individual uppercase letters (breaks BM25)

### DIFF
--- a/graphiti_core/helpers.py
+++ b/graphiti_core/helpers.py
@@ -100,16 +100,17 @@ def lucene_sanitize(query: str) -> str:
             ':': r'\:',
             '\\': r'\\',
             '/': r'\/',
-            'O': r'\O',
-            'R': r'\R',
-            'N': r'\N',
-            'T': r'\T',
-            'A': r'\A',
-            'D': r'\D',
         }
     )
 
     sanitized = query.translate(escape_map)
+
+    # Escape the Lucene boolean operators (AND, OR, NOT) as whole words only.
+    # Previously these were approximated by escaping the individual uppercase
+    # letters O/R/N/T/A/D, which corrupted any query containing those letters
+    # (e.g. "NORD stream" -> "\N\O\R\D stream") and broke BM25 matching (#1302).
+    sanitized = re.sub(r'\b(AND|OR|NOT)\b', r'\\\1', sanitized)
+
     return sanitized
 
 

--- a/tests/helpers_test.py
+++ b/tests/helpers_test.py
@@ -186,7 +186,7 @@ def test_lucene_sanitize():
     queries = [
         (
             'This has every escape character + - && || ! ( ) { } [ ] ^ " ~ * ? : \\ /',
-            '\\This has every escape character \\+ \\- \\&\\& \\|\\| \\! \\( \\) \\{ \\} \\[ \\] \\^ \\" \\~ \\* \\? \\: \\\\ \\/',
+            'This has every escape character \\+ \\- \\&\\& \\|\\| \\! \\( \\) \\{ \\} \\[ \\] \\^ \\" \\~ \\* \\? \\: \\\\ \\/',
         ),
         ('this has no escape characters', 'this has no escape characters'),
     ]
@@ -194,6 +194,29 @@ def test_lucene_sanitize():
     for query, assert_result in queries:
         result = lucene_sanitize(query)
         assert assert_result == result
+
+
+def test_lucene_sanitize_preserves_uppercase_words():
+    # Regression test for #1302: lucene_sanitize must NOT escape individual
+    # uppercase letters (O R N T A D). Only the Lucene boolean operators
+    # AND / OR / NOT should be escaped, and only as whole words.
+    queries = [
+        # Plain uppercase tokens must be left untouched.
+        ('NORD stream', 'NORD stream'),
+        ('EBITDA forecast', 'EBITDA forecast'),
+        ('DATA', 'DATA'),
+        # Boolean operators are still escaped, but only as whole words.
+        ('cats AND dogs', 'cats \\AND dogs'),
+        ('foo OR bar', 'foo \\OR bar'),
+        ('NOT spam', '\\NOT spam'),
+        # A whole-word operator embedded in another word must NOT be escaped.
+        ('ANDES mountains', 'ANDES mountains'),
+        ('NORTH', 'NORTH'),
+    ]
+
+    for query, assert_result in queries:
+        result = lucene_sanitize(query)
+        assert assert_result == result, f'{query!r} -> {result!r} (expected {assert_result!r})'
 
 
 async def get_node_count(driver: GraphDriver, uuids: list[str]) -> int:


### PR DESCRIPTION
## Summary
`lucene_sanitize()` escaped **individual uppercase letters** O/R/N/T/A/D as a crude approximation of escaping the Lucene boolean operators AND/OR/NOT. Because `str.maketrans` / `str.translate` operate per-character, every uppercase O, R, N, T, A, or D in a query was backslash-escaped — corrupting most real-world queries and breaking BM25 fulltext matching.

On current `main`:
- `"NORD stream"` → `"\N\O\R\D stream"`
- `"EBITDA forecast"` → `"EBI\T\D\A forecast"`

## Root cause
`graphiti_core/helpers.py::lucene_sanitize` builds `escape_map = str.maketrans({... 'O': r'\O', 'R': r'\R', 'N': r'\N', 'T': r'\T', 'A': r'\A', 'D': r'\D'})`. Per-character translation escapes those letters everywhere, not just inside the operators AND/OR/NOT.

## Fix
- Remove the six single-letter entries from `escape_map`.
- Escape the boolean operators as **whole words** instead: `re.sub(r'\b(AND|OR|NOT)\b', r'\\\1', sanitized)` (`re` is stdlib — no new dependency).
- `graphiti_core/helpers.py` +7/-6.

Behavior after the fix:
- `"NORD stream"` → `"NORD stream"` (unchanged)
- `"cats AND dogs"` → `"cats \AND dogs"` (operator still escaped, as a whole word)
- `"ANDES mountains"` → `"ANDES mountains"` (operator substring inside a word is not escaped)

## Testing
- Updated the pre-existing `test_lucene_sanitize`, whose expected value encoded the old bug (a leading `\` on "This" from the `T` rule).
- Added `test_lucene_sanitize_preserves_uppercase_words` covering plain uppercase tokens, whole-word operator escaping, and embedded-operator non-escaping.
- Service-free (no DB/LLM): `uv run pytest tests/helpers_test.py::test_lucene_sanitize_preserves_uppercase_words` and the existing `test_lucene_sanitize` both pass.

Closes #1302

Type of change: **Bug fix**.

---
*Drafted with AI assistance (Claude Opus) and verified against current `main`. The Zep CLA will be signed by me (the human contributor) when the CLA-assistant bot prompts.*
