### PR TITLE
fix(mcp): omit temperature for Anthropic/Gemini/Groq when unset (#1103)

### DIFF
--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -90,6 +90,30 @@ def _validate_api_key(provider_name: str, api_key: str | None, logger) -> str:
     return api_key
 
 
+def _build_graphiti_llm_config(
+    *,
+    api_key: str,
+    model: str,
+    max_tokens: int,
+    temperature: float | None,
+    base_url: str | None = None,
+) -> GraphitiLLMConfig:
+    """Build a core LLMConfig, omitting temperature/base_url when unset.
+
+    The MCP ``temperature`` defaults to ``None``. Unlike the OpenAI client, the
+    Anthropic/Gemini/Groq clients pass ``config.temperature`` to their provider
+    APIs verbatim, so a ``None`` would be sent as ``temperature: null`` and
+    rejected (e.g. the Anthropic 400 in #1103). Omitting the kwarg lets core's
+    LLMConfig default (1.0) apply instead, while an explicit value is preserved.
+    """
+    kwargs: dict = {'api_key': api_key, 'model': model, 'max_tokens': max_tokens}
+    if temperature is not None:
+        kwargs['temperature'] = temperature
+    if base_url is not None:
+        kwargs['base_url'] = base_url
+    return GraphitiLLMConfig(**kwargs)
+
+
 def is_non_openai_provider(base_url: str | None) -> bool:
     """
     Detect if the base_url points to a non-OpenAI provider.
@@ -240,12 +264,12 @@ class LLMClientFactory:
                 api_key = config.providers.anthropic.api_key
                 _validate_api_key('Anthropic', api_key, logger)
 
-                llm_config = GraphitiLLMConfig(
+                # Omit temperature when unset: AnthropicClient passes it to the API
+                # verbatim, so a None would be rejected (#1103). Core's default applies.
+                llm_config = _build_graphiti_llm_config(
                     api_key=api_key,
                     model=config.model,
-                    # None is intentional for reasoning models; core LLMConfig stores it
-                    # verbatim and downstream clients omit temperature when it is None.
-                    temperature=config.temperature,  # type: ignore[arg-type]
+                    temperature=config.temperature,
                     max_tokens=config.max_tokens,
                 )
                 return AnthropicClient(config=llm_config)
@@ -259,12 +283,12 @@ class LLMClientFactory:
                 api_key = config.providers.gemini.api_key
                 _validate_api_key('Gemini', api_key, logger)
 
-                llm_config = GraphitiLLMConfig(
+                # Omit temperature when unset: GeminiClient passes it to the API
+                # verbatim, so a None would be rejected. Core's default applies.
+                llm_config = _build_graphiti_llm_config(
                     api_key=api_key,
                     model=config.model,
-                    # None is intentional for reasoning models; core LLMConfig stores it
-                    # verbatim and downstream clients omit temperature when it is None.
-                    temperature=config.temperature,  # type: ignore[arg-type]
+                    temperature=config.temperature,
                     max_tokens=config.max_tokens,
                 )
                 return GeminiClient(config=llm_config)
@@ -278,13 +302,13 @@ class LLMClientFactory:
                 api_key = config.providers.groq.api_key
                 _validate_api_key('Groq', api_key, logger)
 
-                llm_config = GraphitiLLMConfig(
+                # Omit temperature when unset: GroqClient passes it to the API
+                # verbatim, so a None would be rejected. Core's default applies.
+                llm_config = _build_graphiti_llm_config(
                     api_key=api_key,
                     base_url=config.providers.groq.api_url,
                     model=config.model,
-                    # None is intentional for reasoning models; core LLMConfig stores it
-                    # verbatim and downstream clients omit temperature when it is None.
-                    temperature=config.temperature,  # type: ignore[arg-type]
+                    temperature=config.temperature,
                     max_tokens=config.max_tokens,
                 )
                 return GroqClient(config=llm_config)

--- a/mcp_server/tests/test_factories.py
+++ b/mcp_server/tests/test_factories.py
@@ -14,11 +14,15 @@ from graphiti_core.llm_client.azure_openai_client import AzureOpenAILLMClient
 from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
 
 from config.schema import (
+    AnthropicProviderConfig,
     AzureOpenAIProviderConfig,
+    GeminiProviderConfig,
+    GroqProviderConfig,
     LLMConfig,
     LLMProvidersConfig,
     OpenAIProviderConfig,
 )
+from services import factories
 from services.factories import (
     LLMClientFactory,
     is_non_openai_provider,
@@ -152,3 +156,69 @@ class TestAzureReasoningEffort:
         client = LLMClientFactory.create(self._config('gpt-4.1'))
         assert isinstance(client, AzureOpenAILLMClient)
         assert client.reasoning is None
+
+
+class TestNonOpenAITemperatureDefault:
+    """Anthropic/Gemini/Groq pass temperature to their APIs verbatim.
+
+    The MCP temperature defaults to None; sending it through would be rejected
+    (e.g. Anthropic 400, #1103). The factory must omit it when unset so core's
+    LLMConfig default (1.0) applies, while preserving an explicit value.
+    """
+
+    class _DummyClient:
+        def __init__(self, config, **kwargs):
+            self.config = config
+            self.temperature = config.temperature
+            self.kwargs = kwargs
+
+    @staticmethod
+    def _config(provider: str, temperature: float | None) -> LLMConfig:
+        providers = LLMProvidersConfig()
+        if provider == 'anthropic':
+            providers.anthropic = AnthropicProviderConfig(api_key='test-anthropic-key')
+            model = 'claude-sonnet-4-5-20250929'
+        elif provider == 'gemini':
+            providers.gemini = GeminiProviderConfig(api_key='test-gemini-key')
+            model = 'gemini-2.5-pro'
+        elif provider == 'groq':
+            providers.groq = GroqProviderConfig(
+                api_key='test-groq-key', api_url='https://api.groq.com/openai/v1'
+            )
+            model = 'llama-3.3-70b-versatile'
+        else:
+            raise ValueError(f'Unsupported provider for test: {provider}')
+        return LLMConfig(
+            provider=provider,
+            model=model,
+            temperature=temperature,
+            max_tokens=2048,
+            providers=providers,
+        )
+
+    @pytest.mark.parametrize(
+        ('provider', 'has_flag', 'client_attr'),
+        [
+            ('anthropic', 'HAS_ANTHROPIC', 'AnthropicClient'),
+            ('gemini', 'HAS_GEMINI', 'GeminiClient'),
+            ('groq', 'HAS_GROQ', 'GroqClient'),
+        ],
+    )
+    def test_none_temperature_falls_back_to_core_default(
+        self, monkeypatch, provider, has_flag, client_attr
+    ):
+        monkeypatch.setattr(factories, has_flag, True)
+        monkeypatch.setattr(factories, client_attr, self._DummyClient, raising=False)
+
+        client = LLMClientFactory.create(self._config(provider, temperature=None))
+
+        # core LLMConfig default temperature is 1.0 (not None)
+        assert client.temperature == 1
+
+    def test_explicit_temperature_is_preserved(self, monkeypatch):
+        monkeypatch.setattr(factories, 'HAS_ANTHROPIC', True)
+        monkeypatch.setattr(factories, 'AnthropicClient', self._DummyClient, raising=False)
+
+        client = LLMClientFactory.create(self._config('anthropic', temperature=0.42))
+
+        assert client.temperature == 0.42


### PR DESCRIPTION
## Summary

The MCP `temperature` config defaults to `None`. The OpenAI client omits temperature for reasoning models, but the **Anthropic / Gemini / Groq** clients pass `config.temperature` to their provider APIs **verbatim** — so a `None` is serialized as `temperature: null` and rejected (the Anthropic **400** in #1103).

This builds the core `LLMConfig` via a small `_build_graphiti_llm_config` helper that **omits `temperature` (and `base_url`) when unset**, so core's `LLMConfig` default (`1.0`) applies. An explicitly-set temperature is preserved.

Verified against the pinned `graphiti-core`:
- `LLMConfig().temperature` == `1.0`
- `AnthropicClient` (`anthropic_client.py:291`), `GroqClient` (`:75`), `GeminiClient` (`:294`) all pass `temperature=self.temperature` unconditionally.

## Provenance
Reimplements **#1464** (rafaelreis-r/Yifan… community fix — credit to the original author) directly on `main`; the original was CI-red and behind. Same approach + the same test intent, extended to a parametrized suite over all three providers.

## Tests
Added to `mcp_server/tests/test_factories.py` (`TestNonOpenAITemperatureDefault`): `None` → core default `1.0` for anthropic/gemini/groq, and an explicit value is preserved. **28/28 factory tests pass locally**, ruff clean.

Fixes #1103

🤖 Generated with [Claude Code](https://claude.com/claude-code)