### PR TITLE
fix(falkordb): route single-group reads onto the group's graph

### DIFF
--- a/graphiti_core/decorators.py
+++ b/graphiti_core/decorators.py
@@ -44,13 +44,18 @@ def handle_multiple_group_ids(func: F) -> F:
         if group_ids is None and group_ids_pos is not None and len(args) > group_ids_pos:
             group_ids = args[group_ids_pos]
 
-        # Only handle FalkorDB with multiple group_ids
+        # FalkorDB stores each group_id in its own graph, so reads must clone the
+        # driver onto the group's graph. This applies to a single group_id too: the
+        # base driver points at default_db, so an unrouted single-group read finds
+        # nothing (writes mutate self.driver and masked this in same-process tests).
+        # Blank/None entries mean "unspecified" (mirrors search()'s `!= ['']` rule),
+        # so filter them out rather than routing onto an empty graph name.
+        routable_group_ids = [gid for gid in group_ids if gid] if group_ids else []
         if (
             hasattr(self, 'clients')
             and hasattr(self.clients, 'driver')
             and self.clients.driver.provider == GraphProvider.FALKORDB
-            and group_ids
-            and len(group_ids) > 1
+            and routable_group_ids
         ):
             # Execute for each group_id concurrently
             driver = self.clients.driver
@@ -68,7 +73,7 @@ def handle_multiple_group_ids(func: F) -> F:
                 )
 
             results = await semaphore_gather(
-                *[execute_for_group(gid) for gid in group_ids],
+                *[execute_for_group(gid) for gid in routable_group_ids],
                 max_coroutines=getattr(self, 'max_coroutines', None),
             )
 

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -322,17 +322,24 @@ class FalkorDriver(GraphDriver):
 
     def clone(self, database: str) -> 'GraphDriver':
         """
-        Returns a shallow copy of this driver with a different default database.
-        Reuses the same connection (e.g. FalkorDB, Neo4j).
-        """
-        if database == self._database:
-            cloned = self
-        elif database == self.default_group_id:
-            cloned = FalkorDriver(falkor_db=self.client)
-        else:
-            # Create a new instance of FalkorDriver with the same connection but a different database
-            cloned = FalkorDriver(falkor_db=self.client, database=database)
+        Returns a driver bound to ``database``, reusing this driver's connection.
 
+        Constructed drivers are memoized per database. FalkorDriver.__init__
+        schedules build_indices_and_constraints() on every construction, which is
+        load-bearing exactly once per group (a new group's graph needs its indices
+        built) but pure churn on every subsequent read. Caching keeps the
+        once-per-group index build while removing the per-call constructor cost
+        that single-group reads would otherwise incur on every query.
+        """
+        target = 'default_db' if database == self.default_group_id else database
+        if target == self._database:
+            return self
+
+        cache = self.__dict__.setdefault('_clone_cache', {})
+        cloned = cache.get(target)
+        if cloned is None:
+            cloned = FalkorDriver(falkor_db=self.client, database=target)
+            cache[target] = cloned
         return cloned
 
     async def health_check(self) -> None:


### PR DESCRIPTION
## Summary
Single-group reads against FalkorDB return nothing even when the data is physically present in the group's graph. `handle_multiple_group_ids` only re-routed the driver onto the group graph when `len(group_ids) > 1`, so a single-group read fell through to the base driver (pinned at `default_db`) and queried the wrong graph.

## Root cause
FalkorDB stores each `group_id` in its own graph, so a read must clone the driver onto that graph. The decorator gated that routing on `len(group_ids) > 1`. The write path mutates `self.driver` onto the group graph, which is why same-process write-then-read tests masked the bug — the reader inherited the mutated driver. A fresh reader process with a single `group_id` queried `default_db` and got 0 results.

Reproduced: `GRAPH.QUERY <group>` showed episodes + facts present; a single-group `get_episodes([group])` returned 0; a two-group `[group, other]` search returned everything (because `len > 1` routed).

## What changed
- **`decorators.py`** — replace the `len > 1` gate with a blank-filtered `routable_group_ids` (mirrors `search()`'s `!= ['']` convention). A single real group now routes; a `['']`/`[None]` group no longer routes onto an empty graph name.
- **`falkordb_driver.py`** — memoize `clone()` per database. `__init__` schedules `build_indices_and_constraints()` on every construction — load-bearing exactly once per group, but pure churn on every subsequent read now that single-group reads clone. Caching keeps the once-per-group index build while removing the per-call constructor cost.

## Verification
- Single-group `get_episodes([group])` now returns the group's facts against a live FalkorDB (previously 0).
- Memoized `clone()`: repeated clone of the same db returns the same object (no churn); `default_group_id` maps to `default_db`; self-clone returns self; a new group is constructed once then cached, and the new group's graph still gets its indices built.

## Follow-up (not in this PR)
The write-path `self.driver` mutation in `graphiti.py` could be made non-mutating so reads and writes share one routing mechanism, removing the asymmetry that masked this bug.