### PR TITLE
fix: pass database_ as connection-level parameter in Neo4jDriver.execute_query()

### DIFF
--- a/graphiti_core/driver/neo4j_driver.py
+++ b/graphiti_core/driver/neo4j_driver.py
@@ -161,15 +161,17 @@ class Neo4jDriver(GraphDriver):
                 raise
 
     async def execute_query(self, cypher_query_: LiteralString, **kwargs: Any) -> EagerResult:
-        # Check if database_ is provided in kwargs.
-        # If not populated, set the value to retain backwards compatibility
+        # Extract params from kwargs; pass database_ as a connection-level parameter
+        # (not inside parameters_ which would make it a Cypher query parameter)
         params = kwargs.pop('params', None)
         if params is None:
             params = {}
-        params.setdefault('database_', self._database)
+        database = kwargs.pop('database_', self._database)
 
         try:
-            result = await self.client.execute_query(cypher_query_, parameters_=params, **kwargs)
+            result = await self.client.execute_query(
+                cypher_query_, parameters_=params, database_=database, **kwargs
+            )
         except Exception as e:
             logger.error(f'Error executing Neo4j query: {e}\n{cypher_query_}\n{params}')
             raise


### PR DESCRIPTION
## Description

Fixes a bug where `Neo4jDriver.execute_query()` was placing the `database_` parameter inside the `parameters_` dict, causing it to be treated as a Cypher query parameter (`$database_`) rather than a connection-level database selection. This meant search queries would run on the default database instead of the target database.

## Root Cause

In the original code:
```python
params.setdefault(database_, self._database)
result = await self.client.execute_query(cypher_query_, parameters_=params, **kwargs)
```

The `database_` value was passed inside `parameters_`, which is the dict for Cypher query parameters. The Neo4j Python driver expects `database_` as a separate keyword argument to `execute_query()`.

## Fix

Extract `database_` from kwargs and pass it directly to `self.client.execute_query()` as the `database_` keyword argument, keeping `params` separate for actual Cypher query parameters.

## Changes

- `graphiti_core/driver/neo4j_driver.py`: Modified `execute_query()` to pass `database_` as a connection-level parameter instead of inside the Cypher query parameters dict.

## Testing

This change is a straightforward parameter passing fix. The existing test suite requires Neo4j connectivity (integration tests), which cannot be run without a running Neo4j instance. The fix follows the same pattern used by `transaction()` and `session()` methods which correctly pass `database=self._database`.

Closes #1481

---

_This PR was created with AI assistance._