### PR TITLE
fix(extraction): plumb custom_extraction_instructions into entity summary prompts

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -821,6 +821,7 @@ class Graphiti:
         edge_types: dict[str, type[BaseModel]] | None,
         edge_type_map: dict[tuple[str, str], list[str]],
         episodes: list[EpisodicNode],
+        custom_extraction_instructions: str | None = None,
     ) -> tuple[list[EntityNode], list[EntityEdge], list[EntityEdge], dict[str, str]]:
         """Resolve nodes and edges against the existing graph."""
         nodes_by_uuid: dict[str, EntityNode] = {
@@ -880,6 +881,7 @@ class Graphiti:
                     episode,
                     previous_episodes,
                     entity_types,
+                    custom_extraction_instructions=custom_extraction_instructions,
                 )
                 for episode, previous_episodes in episode_context
             ]
@@ -1030,7 +1032,8 @@ class Graphiti:
             Optional.  list of episode uuids to use as the previous episodes. If this is not provided,
             the most recent episodes by created_at date will be used.
         custom_extraction_instructions : str | None
-            Optional. Custom extraction instructions string to be included in the extract entities and extract edges prompts.
+            Optional. Custom extraction instructions string to be included in the extract entities,
+            extract edges and entity summary prompts.
             This allows for additional instructions or context to guide the extraction process.
         saga : str | SagaNode | None
             Optional. Either a saga name (str) or a SagaNode object to associate this episode with.
@@ -1164,6 +1167,7 @@ class Graphiti:
                     previous_episodes,
                     entity_types,
                     edges=new_edges,
+                    custom_extraction_instructions=custom_extraction_instructions,
                 )
 
                 # Process and save episode data (including saga association if provided)
@@ -1260,8 +1264,8 @@ class Graphiti:
             Optional. A mapping of (source_type, target_type) to allowed edge types.
         custom_extraction_instructions : str | None
             Optional. Custom extraction instructions string to be included in the
-            extract entities and extract edges prompts. This allows for additional
-            instructions or context to guide the extraction process.
+            extract entities, extract edges and entity summary prompts. This allows
+            for additional instructions or context to guide the extraction process.
         saga : str | SagaNode | None
             Optional. Either a saga name (str) or a SagaNode object to associate all episodes with.
             If a string is provided and a saga with this name already exists in the group, the episodes
@@ -1392,6 +1396,7 @@ class Graphiti:
                     edge_types,
                     edge_type_map or edge_type_map_default,
                     episodes,
+                    custom_extraction_instructions=custom_extraction_instructions,
                 )
 
                 # Resolved pointers for episodic edges

--- a/graphiti_core/prompts/extract_nodes.py
+++ b/graphiti_core/prompts/extract_nodes.py
@@ -520,6 +520,8 @@ Each summary must be under {MAX_SUMMARY_CHARS} characters.
 
 {summary_instructions}
 
+{context['custom_extraction_instructions']}
+
 <MESSAGES>
 {to_prompt_json(context['previous_episodes'])}
 {to_prompt_json(context['episode_content'])}
@@ -625,6 +627,8 @@ Preserve all material names, roles, dates, counts, and changes over time that ar
 
 For each entity below, generate an updated summary using ONLY the provided EPISODES and any \
 existing summary already on the entity.
+
+{context['custom_extraction_instructions']}
 
 <EPISODES>
 {to_prompt_json(context['previous_episodes'])}

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -733,6 +733,7 @@ async def extract_attributes_from_nodes(
     edges: list[EntityEdge] | None = None,
     skip_fact_appending: bool = False,
     include_type_descriptions: bool = False,
+    custom_extraction_instructions: str | None = None,
 ) -> list[EntityNode]:
     llm_client = clients.llm_client
     embedder = clients.embedder
@@ -773,6 +774,7 @@ async def extract_attributes_from_nodes(
         edges_by_node,
         skip_fact_appending=skip_fact_appending,
         entity_types=entity_types if include_type_descriptions else None,
+        custom_extraction_instructions=custom_extraction_instructions,
     )
 
     await create_entity_node_embeddings(embedder, nodes)
@@ -840,6 +842,7 @@ async def _extract_entity_summaries_batch(
     *,
     skip_fact_appending: bool = False,
     entity_types: dict[str, type[BaseModel]] | None = None,
+    custom_extraction_instructions: str | None = None,
 ) -> None:
     """Extract summaries for multiple entities in batched LLM calls.
 
@@ -904,6 +907,7 @@ async def _extract_entity_summaries_batch(
                 previous_episodes,
                 use_episode_prompt=skip_fact_appending,
                 entity_types=entity_types,
+                custom_extraction_instructions=custom_extraction_instructions,
             )
             for flight in node_flights
         ]
@@ -918,6 +922,7 @@ async def _process_summary_flight(
     *,
     use_episode_prompt: bool = False,
     entity_types: dict[str, type[BaseModel]] | None = None,
+    custom_extraction_instructions: str | None = None,
 ) -> None:
     """Process a single flight of nodes for batch summarization."""
     # Build entity type descriptions from docstrings, stripping GOOD/BAD
@@ -961,6 +966,7 @@ async def _process_summary_flight(
             else []
         ),
         'entity_type_descriptions': entity_type_descriptions,
+        'custom_extraction_instructions': (custom_extraction_instructions or ''),
     }
 
     # Get group_id from the first node (all nodes in a batch should have same group_id)

--- a/tests/utils/maintenance/test_node_operations.py
+++ b/tests/utils/maintenance/test_node_operations.py
@@ -918,3 +918,124 @@ async def test_batch_summaries_calls_llm_for_long_summary():
     # LLM should have been called to condense the long summary
     llm_client.generate_response.assert_awaited_once()
     assert node.summary == 'Condensed summary'
+
+
+@pytest.mark.asyncio
+async def test_batch_summaries_pass_custom_instructions_to_prompt(monkeypatch):
+    """custom_extraction_instructions must reach the batch summary prompt context."""
+    from graphiti_core.edges import EntityEdge
+    from graphiti_core.utils.text_utils import MAX_SUMMARY_CHARS
+
+    captured_context = {}
+
+    def fake_summaries_batch(context):
+        captured_context.update(context)
+        return ['prompt']
+
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations.prompt_library.extract_nodes.extract_summaries_batch',
+        fake_summaries_batch,
+    )
+
+    llm_client = MagicMock()
+    llm_client.generate_response = AsyncMock(return_value={'summaries': []})
+
+    node = EntityNode(name='Test Node', group_id='group', labels=['Entity'], summary='Short')
+    long_fact = 'x' * (MAX_SUMMARY_CHARS * 2)
+    edge = EntityEdge(
+        uuid='edge1',
+        group_id='group',
+        source_node_uuid=node.uuid,
+        target_node_uuid='other-uuid',
+        name='test_edge',
+        fact=long_fact,
+        created_at=utc_now(),
+    )
+
+    await _extract_entity_summaries_batch(
+        llm_client,
+        [node],
+        episode=_make_episode(),
+        previous_episodes=[],
+        should_summarize_node=None,
+        edges_by_node={node.uuid: [edge, edge]},
+        custom_extraction_instructions='Write every summary in Italian.',
+    )
+
+    assert captured_context['custom_extraction_instructions'] == 'Write every summary in Italian.'
+
+
+@pytest.mark.asyncio
+async def test_episode_summaries_pass_custom_instructions_to_prompt(monkeypatch):
+    """The skip_fact_appending path must receive custom_extraction_instructions too."""
+    captured_context = {}
+
+    def fake_episode_summaries(context):
+        captured_context.update(context)
+        return ['prompt']
+
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations.prompt_library.extract_nodes.extract_entity_summaries_from_episodes',
+        fake_episode_summaries,
+    )
+
+    llm_client = MagicMock()
+    llm_client.generate_response = AsyncMock(return_value={'summaries': []})
+
+    node = EntityNode(name='Test Node', group_id='group', labels=['Entity'], summary='Old')
+
+    await _extract_entity_summaries_batch(
+        llm_client,
+        [node],
+        episode=_make_episode(),
+        previous_episodes=[],
+        should_summarize_node=None,
+        edges_by_node={},
+        skip_fact_appending=True,
+        custom_extraction_instructions='Write every summary in Italian.',
+    )
+
+    assert captured_context['custom_extraction_instructions'] == 'Write every summary in Italian.'
+
+
+@pytest.mark.asyncio
+async def test_extract_attributes_from_nodes_passes_custom_instructions(monkeypatch):
+    """custom_extraction_instructions must flow through extract_attributes_from_nodes."""
+    clients, _ = _make_clients()
+    clients.llm_client.generate_response = AsyncMock(return_value={'summaries': []})
+    clients.embedder.create = AsyncMock(return_value=[0.1, 0.2, 0.3])
+    clients.embedder.create_batch = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+    captured = {}
+
+    async def fake_summaries_batch(
+        llm_client,
+        nodes,
+        episode,
+        previous_episodes,
+        should_summarize_node,
+        edges_by_node,
+        *,
+        skip_fact_appending=False,
+        entity_types=None,
+        custom_extraction_instructions=None,
+    ):
+        captured['custom_extraction_instructions'] = custom_extraction_instructions
+
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations._extract_entity_summaries_batch',
+        fake_summaries_batch,
+    )
+
+    node = EntityNode(name='Node1', group_id='group', labels=['Entity'], summary='Old')
+
+    await extract_attributes_from_nodes(
+        clients,
+        [node],
+        episode=_make_episode(),
+        previous_episodes=[],
+        entity_types=None,
+        custom_extraction_instructions='Write every summary in Italian.',
+    )
+
+    assert captured['custom_extraction_instructions'] == 'Write every summary in Italian.'


### PR DESCRIPTION
## Problem

`custom_extraction_instructions` is honored by the node and edge extraction prompts, but it never reaches the entity **summary** stage: `extract_attributes_from_nodes` and its summary helpers have no way to receive it, so the `extract_summaries_batch` / `extract_entity_summaries_from_episodes` prompts always run unconstrained.

Practical effect (how we hit this): with instructions like *"Perform all extraction in Italian"*, entity names and edge facts come back in Italian as expected, while freshly **composed** entity summaries come back in English — even when the source episode is entirely Italian. Summaries that are produced by the fact-appending shortcut look fine (the facts are already constrained), which makes the gap surface only intermittently, on summaries the LLM actually composes.

## Change

Thread the existing parameter through the summary path, mirroring how the extraction prompts already handle it:

- `extract_attributes_from_nodes(..., custom_extraction_instructions=None)` → `_extract_entity_summaries_batch` → `_process_summary_flight` → prompt context (`''` when unset).
- Interpolate `{context['custom_extraction_instructions']}` in both summary prompt templates (`extract_summaries_batch` and `extract_entity_summaries_from_episodes`), same bare-line pattern as `extract_message` / `extract_json` / `extract_text`.
- Pass the parameter at both call sites: `add_episode` and the bulk path (`_resolve_nodes_and_edges_bulk`, called by `add_episode_bulk`).
- Docstrings updated accordingly.

No behavior change when the parameter is unset (empty string interpolation, like the other prompts). The Go-mirrored system prompt (`_entity_episode_summary_system_prompt`) is intentionally untouched — the injection lands in the user message.

## Tests

Three unit tests in `tests/utils/maintenance/test_node_operations.py`, mirroring the existing custom-instructions plumbing tests in `test_bulk_utils.py`:

- batch summary prompt receives the instructions (long-summary LLM route),
- episode-prompt path (`skip_fact_appending=True`) receives them too,
- `extract_attributes_from_nodes` passes them through to the batch helper.

`tests/utils/maintenance/test_node_operations.py`: 36 passed (33 existing + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
