### PR TITLE
fix: Edge.__eq__ checks isinstance(other, Edge) not Node

### DIFF
--- a/graphiti_core/edges.py
+++ b/graphiti_core/edges.py
@@ -132,7 +132,7 @@ class Edge(BaseModel, ABC):
         return hash(self.uuid)
 
     def __eq__(self, other):
-        if isinstance(other, Node):
+        if isinstance(other, Edge):
             return self.uuid == other.uuid
         return False
 


### PR DESCRIPTION
## What

`Edge.__eq__` compared the other object against `Node` instead of `Edge`, making edge equality always return `False` when comparing two edges.

## Why it matters

Any code that deduplicates, checks membership in a set, or compares edges directly silently fails. For example:

```python
edge_a = EntityEdge(uuid="abc", ...)
edge_b = EntityEdge(uuid="abc", ...)
edge_a == edge_b  # False — wrong, same UUID
{edge_a} == {edge_b}  # False
```

## Fix

One character: `Node` → `Edge` in the `isinstance` check.

## Test

```python
from graphiti_core.edges import EntityEdge

e1 = EntityEdge.__new__(EntityEdge)
e1.uuid = "test-uuid"
e2 = EntityEdge.__new__(EntityEdge)
e2.uuid = "test-uuid"
assert e1 == e2          # was False, now True
assert not (e1 == "x")  # still False for non-Edge
```