### PR TITLE
fix: copy SearchConfig before mutating .limit to prevent shared-state clobber

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -1568,7 +1568,7 @@ class Graphiti:
         """
         search_config = (
             EDGE_HYBRID_SEARCH_RRF if center_node_uuid is None else EDGE_HYBRID_SEARCH_NODE_DISTANCE
-        )
+        ).model_copy(deep=True)
         search_config.limit = num_results
 
         edges = (


### PR DESCRIPTION
## What

`search_recall()` assigned one of the module-level `SearchConfig` constants directly to a local variable and then mutated `.limit` on it:

```python
search_config = EDGE_HYBRID_SEARCH_RRF  # reference, not copy
search_config.limit = num_results        # mutates the global constant
```

## Why it matters

This is a **concurrency hazard**. Every concurrent call to `search_recall()` races to set `limit` on the same shared object. One request can silently cap another request's result count to whatever was set most recently.

Even in a single-threaded context, the module-level constant is permanently modified after the first call — subsequent calls that rely on the default `limit` will get the last caller's value instead.

## Fix

Call `.model_copy(deep=True)` before mutation so each invocation works on its own independent copy:

```python
search_config = (
    EDGE_HYBRID_SEARCH_RRF if center_node_uuid is None else EDGE_HYBRID_SEARCH_NODE_DISTANCE
).model_copy(deep=True)
search_config.limit = num_results
```