### PR TITLE
fix: lucene_sanitize corrupts all words containing O/R/N/T/A/D

### DIFF
--- a/graphiti_core/helpers.py
+++ b/graphiti_core/helpers.py
@@ -100,16 +100,15 @@ def lucene_sanitize(query: str) -> str:
             ':': r'\:',
             '\\': r'\\',
             '/': r'\/',
-            'O': r'\O',
-            'R': r'\R',
-            'N': r'\N',
-            'T': r'\T',
-            'A': r'\A',
-            'D': r'\D',
         }
     )
 
     sanitized = query.translate(escape_map)
+    # Lowercase bare Lucene boolean keywords so they are treated as literal
+    # words rather than operators.  The previous approach of escaping the
+    # individual letters O/R/N/T/A/D corrupted every word containing those
+    # characters (e.g. "Robot" → "\R\ob\ot").
+    sanitized = re.sub(r'\b(AND|OR|NOT)\b', lambda m: m.group(0).lower(), sanitized)
     return sanitized
 
 


### PR DESCRIPTION
## What

`lucene_sanitize()` added individual uppercase letters `O`, `R`, `N`, `T`, `A`, `D` to the character escape map in an attempt to neutralise Lucene's boolean operators (`AND`, `OR`, `NOT`). This corrupted every word containing those letters:

```python
lucene_sanitize("Robot")    # "\R\ob\ot"
lucene_sanitize("Toronto")  # "\T\or\on\t\o"
lucene_sanitize("ORANGE")   # "\O\R\A\N\GE"
lucene_sanitize("NOT")      # "\N\O\T"  (this part worked, sort of)
```

## Why it matters

Any full-text search query containing common English words with capital letters returns corrupted Lucene syntax, producing no results or query parse errors.

## Fix

Remove the letter entries from the escape map. Add a word-boundary regex substitution that lowercases only the standalone boolean keywords `AND`, `OR`, `NOT`. Lowercase `and`/`or`/`not` are not Lucene operators and are indexed as literal words:

```python
sanitized = re.sub(r'\b(AND|OR|NOT)\b', lambda m: m.group(0).lower(), sanitized)
```

```python
lucene_sanitize("Robot")          # "Robot"    ✓
lucene_sanitize("Toronto")        # "Toronto"  ✓
lucene_sanitize("status OR error") # "status or error"  ✓ (OR neutralised)
lucene_sanitize("foo AND bar")    # "foo and bar"  ✓
```

`re` is already imported in `helpers.py`.