### PR TITLE
fix: date filter parameters collide across OR clauses

### DIFF
--- a/graphiti_core/search/search_filters.py
+++ b/graphiti_core/search/search_filters.py
@@ -154,11 +154,11 @@ def edge_search_filter_query_constructor(
                     ComparisonOperator.is_null,
                     ComparisonOperator.is_not_null,
                 ]:
-                    filter_params['valid_at_' + str(j)] = date_filter.date
+                    filter_params[f'valid_at_{i}_{j}'] = date_filter.date
 
             and_filters = [
                 date_filter_query_constructor(
-                    'e.valid_at', f'$valid_at_{j}', date_filter.comparison_operator
+                    'e.valid_at', f'$valid_at_{i}_{j}', date_filter.comparison_operator
                 )
                 for j, date_filter in enumerate(or_list)
             ]
@@ -185,11 +185,11 @@ def edge_search_filter_query_constructor(
                     ComparisonOperator.is_null,
                     ComparisonOperator.is_not_null,
                 ]:
-                    filter_params['invalid_at_' + str(j)] = date_filter.date
+                    filter_params[f'invalid_at_{i}_{j}'] = date_filter.date
 
             and_filters = [
                 date_filter_query_constructor(
-                    'e.invalid_at', f'$invalid_at_{j}', date_filter.comparison_operator
+                    'e.invalid_at', f'$invalid_at_{i}_{j}', date_filter.comparison_operator
                 )
                 for j, date_filter in enumerate(or_list)
             ]
@@ -216,11 +216,11 @@ def edge_search_filter_query_constructor(
                     ComparisonOperator.is_null,
                     ComparisonOperator.is_not_null,
                 ]:
-                    filter_params['created_at_' + str(j)] = date_filter.date
+                    filter_params[f'created_at_{i}_{j}'] = date_filter.date
 
             and_filters = [
                 date_filter_query_constructor(
-                    'e.created_at', f'$created_at_{j}', date_filter.comparison_operator
+                    'e.created_at', f'$created_at_{i}_{j}', date_filter.comparison_operator
                 )
                 for j, date_filter in enumerate(or_list)
             ]
@@ -247,11 +247,11 @@ def edge_search_filter_query_constructor(
                     ComparisonOperator.is_null,
                     ComparisonOperator.is_not_null,
                 ]:
-                    filter_params['expired_at_' + str(j)] = date_filter.date
+                    filter_params[f'expired_at_{i}_{j}'] = date_filter.date
 
             and_filters = [
                 date_filter_query_constructor(
-                    'e.expired_at', f'$expired_at_{j}', date_filter.comparison_operator
+                    'e.expired_at', f'$expired_at_{i}_{j}', date_filter.comparison_operator
                 )
                 for j, date_filter in enumerate(or_list)
             ]


### PR DESCRIPTION
## What

In `build_edge_search_filter_query()`, date filter parameters are keyed by only the inner-loop index `j`, not by the outer OR-clause index `i`:

```python
for i, or_list in enumerate(filters.valid_at):
    for j, date_filter in enumerate(or_list):
        filter_params['valid_at_' + str(j)] = date_filter.date  # ← bug
```

When `filters.valid_at` has more than one OR clause, each clause resets `j` to 0. OR clause 1 overwrites OR clause 0's parameter values. The Cypher query then uses the wrong date values for all but the last OR clause.

## Why it matters

Any temporal filter with multiple OR conditions silently applies the last clause's dates to all clauses, producing incorrect query results without any error.

The same bug exists in all four date fields: `valid_at`, `invalid_at`, `created_at`, `expired_at`.

## Fix

Key by both `i` (OR-clause) and `j` (AND-condition within clause):

```python
filter_params[f'valid_at_{i}_{j}'] = date_filter.date
# query uses: f'$valid_at_{i}_{j}'
```

Applied to all four date fields.

## Reproducer

```python
from datetime import datetime
from graphiti_core.search.search_filters import EdgeSearchFilters, DateFilter
from graphiti_core.search.search_filters import ComparisonOperator, build_edge_search_filter_query

d1 = datetime(2024, 1, 1)
d2 = datetime(2025, 1, 1)

filters = EdgeSearchFilters(
    valid_at=[
        [DateFilter(date=d1, comparison_operator=ComparisonOperator.gt)],
        [DateFilter(date=d2, comparison_operator=ComparisonOperator.lt)],
    ]
)
_, params = build_edge_search_filter_query(filters, "neo4j")
# Before fix: params == {'valid_at_0': d2}   ← d1 lost
# After fix:  params == {'valid_at_0_0': d1, 'valid_at_1_0': d2}  ✓
```