### PR TITLE
fix(embedder): support embedding_dim in AzureOpenAIEmbedderClient

### DIFF
--- a/graphiti_core/embedder/azure_openai.py
+++ b/graphiti_core/embedder/azure_openai.py
@@ -34,9 +34,15 @@ class AzureOpenAIEmbedderClient(EmbedderClient):
         self,
         azure_client: AsyncAzureOpenAI | AsyncOpenAI,
         model: str = 'text-embedding-3-small',
+        embedding_dim: int | None = None,
     ):
         self.azure_client = azure_client
         self.model = model
+        # When set, embeddings are truncated to ``embedding_dim`` so this client
+        # matches the dimensionality produced by ``OpenAIEmbedder``/``VoyageAIEmbedder``
+        # (which truncate to ``config.embedding_dim``). Left as ``None`` by default
+        # to preserve the previous behaviour of returning the model's full output.
+        self.embedding_dim = embedding_dim
 
     async def create(self, input_data: str | list[str] | Any) -> list[float]:
         """Create embeddings using Azure OpenAI client."""
@@ -53,7 +59,8 @@ class AzureOpenAIEmbedderClient(EmbedderClient):
             response = await self.azure_client.embeddings.create(model=self.model, input=text_input)
 
             # Return the first embedding as a list of floats
-            return response.data[0].embedding
+            embedding = response.data[0].embedding
+            return embedding[: self.embedding_dim] if self.embedding_dim is not None else embedding
         except Exception as e:
             logger.error(f'Error in Azure OpenAI embedding: {e}')
             raise
@@ -65,7 +72,14 @@ class AzureOpenAIEmbedderClient(EmbedderClient):
                 model=self.model, input=input_data_list
             )
 
-            return [embedding.embedding for embedding in response.data]
+            return [
+                (
+                    item.embedding[: self.embedding_dim]
+                    if self.embedding_dim is not None
+                    else item.embedding
+                )
+                for item in response.data
+            ]
         except Exception as e:
             logger.error(f'Error in Azure OpenAI batch embedding: {e}')
             raise

--- a/tests/embedder/test_azure_openai.py
+++ b/tests/embedder/test_azure_openai.py
@@ -1,0 +1,76 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from graphiti_core.embedder.azure_openai import AzureOpenAIEmbedderClient
+from tests.embedder.embedder_fixtures import create_embedding_values
+
+
+def _mock_embedding(multiplier: float = 0.1, dimension: int = 1536) -> MagicMock:
+    mock_embedding = MagicMock()
+    mock_embedding.embedding = create_embedding_values(multiplier, dimension)
+    return mock_embedding
+
+
+def _mock_azure_client(data: list[Any]) -> Any:
+    """Build a mocked Azure client whose embeddings.create returns ``data``."""
+    response = MagicMock()
+    response.data = data
+    client = MagicMock()
+    client.embeddings = MagicMock()
+    client.embeddings.create = AsyncMock(return_value=response)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_create_truncates_to_embedding_dim() -> None:
+    """When ``embedding_dim`` is set, ``create`` truncates the embedding to it,
+    matching OpenAIEmbedder / VoyageAIEmbedder behavior."""
+    client = _mock_azure_client([_mock_embedding(dimension=1536)])
+    embedder = AzureOpenAIEmbedderClient(azure_client=client, embedding_dim=384)
+
+    result = await embedder.create('hello world')
+
+    assert len(result) == 384
+
+
+@pytest.mark.asyncio
+async def test_create_without_embedding_dim_returns_full_output() -> None:
+    """Default (``embedding_dim=None``) preserves the model's full output dimension."""
+    client = _mock_azure_client([_mock_embedding(dimension=1536)])
+    embedder = AzureOpenAIEmbedderClient(azure_client=client)
+
+    result = await embedder.create('hello world')
+
+    assert len(result) == 1536
+
+
+@pytest.mark.asyncio
+async def test_create_batch_truncates_each_to_embedding_dim() -> None:
+    """``create_batch`` truncates every embedding to ``embedding_dim`` when set."""
+    client = _mock_azure_client(
+        [_mock_embedding(0.1, 1536), _mock_embedding(0.2, 1536), _mock_embedding(0.3, 1536)]
+    )
+    embedder = AzureOpenAIEmbedderClient(azure_client=client, embedding_dim=256)
+
+    result = await embedder.create_batch(['a', 'b', 'c'])
+
+    assert len(result) == 3
+    assert all(len(embedding) == 256 for embedding in result)


### PR DESCRIPTION
## Summary
`AzureOpenAIEmbedderClient` returned the model's full embedding with no way to constrain it to `embedding_dim`, unlike `OpenAIEmbedder` / `VoyageAIEmbedder` (which truncate to `config.embedding_dim`) and `GeminiEmbedder` (which requests `output_dimensionality`). This adds an optional `embedding_dim` parameter and truncates `create()` / `create_batch()` output to it, matching the other embedders.

## Type of Change
- [x] Bug fix

## Objective
Keep embedding dimensionality consistent across embedders. When an index/store is built for a given `embedding_dim`, the Azure embedder previously produced mismatched-length vectors (e.g. 1536 from `text-embedding-3-small` vs a configured 1024), which can break vector storage/search. With this change the Azure client can match the dimensionality the rest of the system expects.

## Testing
- [x] Unit tests added/updated
- [x] All existing tests pass

Added `tests/embedder/test_azure_openai.py` (the Azure embedder was previously untested): asserts `create`/`create_batch` truncate to `embedding_dim` when set, and that the default (`embedding_dim=None`) returns the model's full output. Fails before the change, passes after; `ruff` clean.

## Breaking Changes
- [ ] This PR contains breaking changes

`embedding_dim` defaults to `None`, preserving the previous behaviour (full-length output) for existing users — truncation happens only when it is explicitly set.

## Checklist
- [x] Code follows project style guidelines (`ruff` passes)
- [x] Self-review completed
- [x] No secrets or sensitive information committed
