### PR TITLE
fix(cross-encoder): don't crash OpenAI reranker when a response lacks logprobs

### DIFF
--- a/graphiti_core/cross_encoder/openai_reranker_client.py
+++ b/graphiti_core/cross_encoder/openai_reranker_client.py
@@ -103,17 +103,22 @@ class OpenAIRerankerClient(CrossEncoderClient):
                 else []
                 for response in responses
             ]
-            scores: list[float] = []
-            for top_logprobs in responses_top_logprobs:
+            results: list[tuple[str, float]] = []
+            for passage, top_logprobs in zip(passages, responses_top_logprobs, strict=True):
                 if len(top_logprobs) == 0:
+                    # No usable logprobs for this passage (e.g. an empty or
+                    # truncated response). Skip it, pairing each passage with its
+                    # own response so the lists can't fall out of sync — the
+                    # previous code collected scores separately and then did
+                    # ``zip(passages, scores, strict=True)``, which raised
+                    # ValueError whenever any response was skipped here.
                     continue
                 norm_logprobs = np.exp(top_logprobs[0].logprob)
                 if top_logprobs[0].token.strip().split(' ')[0].lower() == 'true':
-                    scores.append(norm_logprobs)
+                    results.append((passage, norm_logprobs))
                 else:
-                    scores.append(1 - norm_logprobs)
+                    results.append((passage, 1 - norm_logprobs))
 
-            results = [(passage, score) for passage, score in zip(passages, scores, strict=True)]
             results.sort(reverse=True, key=lambda x: x[1])
             return results
         except openai.RateLimitError as e:

--- a/tests/cross_encoder/test_openai_reranker_client.py
+++ b/tests/cross_encoder/test_openai_reranker_client.py
@@ -1,0 +1,91 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# Running tests: pytest -xvs tests/cross_encoder/test_openai_reranker_client.py
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient
+from graphiti_core.llm_client import LLMConfig
+
+
+def _scored_response(token: str, logprob: float) -> MagicMock:
+    """A chat-completion response carrying a single top-logprob token."""
+    tl = MagicMock()
+    tl.token = token
+    tl.logprob = logprob
+    content_item = MagicMock()
+    content_item.top_logprobs = [tl]
+    logprobs = MagicMock()
+    logprobs.content = [content_item]
+    choice = MagicMock()
+    choice.logprobs = logprobs
+    resp = MagicMock()
+    resp.choices = [choice]
+    return resp
+
+
+def _empty_logprobs_response() -> MagicMock:
+    """A response with no logprobs (e.g. an empty/truncated completion)."""
+    choice = MagicMock()
+    choice.logprobs = None
+    resp = MagicMock()
+    resp.choices = [choice]
+    return resp
+
+
+def _make_reranker(responses: list) -> OpenAIRerankerClient:
+    reranker = OpenAIRerankerClient(config=LLMConfig(api_key='test', model='m'))
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(side_effect=responses)
+    reranker.client = mock_client
+    return reranker
+
+
+@pytest.mark.asyncio
+async def test_rank_skips_passage_with_empty_logprobs_without_crashing() -> None:
+    """A response missing top_logprobs must be skipped gracefully, not crash the
+    whole rank() via a passage/score length mismatch in a strict zip."""
+    reranker = _make_reranker(
+        [
+            _scored_response('true', -0.1),
+            _empty_logprobs_response(),  # previously desynced scores -> strict-zip ValueError
+            _scored_response('false', -0.2),
+        ]
+    )
+
+    results = await reranker.rank('query', ['p0', 'p1', 'p2'])
+
+    assert {p for p, _ in results} == {'p0', 'p2'}
+    assert all(0.0 <= s <= 1.0 for _, s in results)
+
+
+@pytest.mark.asyncio
+async def test_rank_scores_all_passages_when_logprobs_present() -> None:
+    reranker = _make_reranker(
+        [
+            _scored_response('true', -0.05),
+            _scored_response('false', -0.05),
+        ]
+    )
+
+    results = await reranker.rank('query', ['relevant', 'irrelevant'])
+
+    assert {p for p, _ in results} == {'relevant', 'irrelevant'}
+    # 'true' (relevant) should outrank 'false' (irrelevant).
+    assert results[0][0] == 'relevant'


### PR DESCRIPTION
## Summary
`OpenAIRerankerClient.rank()` crashes with `ValueError: zip() argument 2 is shorter than argument 1` when any passage's chat-completion response has no usable `top_logprobs`. It collected scores in a separate list, `continue`-ing past empty-logprob responses, then re-paired them with `zip(passages, scores, strict=True)` — so a single skipped response desyncs the two lists and the strict zip raises, failing the **entire** rerank instead of just dropping the one unscoreable passage.

## Type of Change
- [x] Bug fix

## Objective
A single empty/truncated reranker response (possible with `max_tokens=1` + `logit_bias`) shouldn't take down the whole reranking. Pair each passage with its own response while iterating so the lists can't desync — keeping the existing "skip the unscoreable passage" behaviour, without the crash.

## Testing
- [x] Unit tests added/updated
- [x] All existing tests pass

Added `tests/cross_encoder/test_openai_reranker_client.py` (the OpenAI reranker was previously untested): one test feeds an empty-logprobs response in the middle and asserts the other passages still rank (fails before the change with the strict-zip `ValueError`, passes after); one covers the normal all-scored path. `ruff` clean.

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`ruff` passes)
- [x] Self-review completed
- [x] No secrets or sensitive information committed
