### PR TITLE
fix: respect LLMConfig.max_tokens in OpenAIGenericClient (#763)

### DIFF
--- a/graphiti_core/llm_client/openai_generic_client.py
+++ b/graphiti_core/llm_client/openai_generic_client.py
@@ -62,7 +62,7 @@ class OpenAIGenericClient(LLMClient):
         config: LLMConfig | None = None,
         cache: bool = False,
         client: typing.Any = None,
-        max_tokens: int = 16384,
+        max_tokens: int | None = None,
         structured_output_mode: StructuredOutputMode = 'json_schema',
     ):
         """
@@ -72,7 +72,9 @@ class OpenAIGenericClient(LLMClient):
             config (LLMConfig | None): The configuration for the LLM client, including API key, model, base URL, temperature, and max tokens.
             cache (bool): Whether to use caching for responses. Defaults to False.
             client (Any | None): An optional async client instance to use. If not provided, a new AsyncOpenAI client is created.
-            max_tokens (int): The maximum number of tokens to generate. Defaults to 16384 (16K) for better compatibility with local models.
+            max_tokens (int | None): The maximum number of tokens to generate. When None (the default),
+                the value from ``config.max_tokens`` is used. Pass an explicit integer to override the
+                config value for this instance.
             structured_output_mode (StructuredOutputMode): Whether to request structured
                 output via native ``json_schema`` (the default, uses constrained decoding)
                 or to fall back to ``json_object``. Set to ``'json_object'`` for providers
@@ -90,8 +92,8 @@ class OpenAIGenericClient(LLMClient):
 
         super().__init__(config, cache)
 
-        # Override max_tokens to support higher limits for local models
-        self.max_tokens = max_tokens
+        # Resolve max_tokens: constructor arg takes precedence, then config, then default.
+        self.max_tokens = max_tokens if max_tokens is not None else config.max_tokens
         self.structured_output_mode: StructuredOutputMode = structured_output_mode
 
         if client is None:

--- a/tests/llm_client/test_openai_generic_client.py
+++ b/tests/llm_client/test_openai_generic_client.py
@@ -47,10 +47,15 @@ def _messages() -> list[Message]:
     ]
 
 
-def _make_client(content: str = '{"foo": "bar"}', error: Exception | None = None, **kwargs):
+def _make_client(
+    content: str = '{"foo": "bar"}',
+    error: Exception | None = None,
+    config: 'LLMConfig | None' = None,
+    **kwargs,
+):
     completions = DummyChatCompletions(content=content, error=error)
     client = OpenAIGenericClient(
-        config=LLMConfig(api_key='test', model='test-model'),
+        config=config or LLMConfig(api_key='test', model='test-model'),
         client=DummyClient(completions),
         **kwargs,
     )
@@ -168,3 +173,27 @@ async def test_non_retryable_error_is_not_retried():
         await client.generate_response(_messages(), response_model=ResponseModel)
 
     assert len(completions.create_calls) == 1
+
+
+def test_max_tokens_from_config_is_respected():
+    """LLMConfig.max_tokens must be used when no constructor override is given."""
+    config = LLMConfig(max_tokens=32000)
+    client, _ = _make_client(config=config)
+
+    assert client.max_tokens == 32000
+
+
+def test_constructor_max_tokens_overrides_config():
+    """An explicit max_tokens constructor arg takes precedence over config."""
+    config = LLMConfig(max_tokens=32000)
+    client, _ = _make_client(config=config, max_tokens=8192)
+
+    assert client.max_tokens == 8192
+
+
+def test_default_max_tokens_when_neither_is_set():
+    """When neither config nor constructor arg is specified, the config default is used."""
+    from graphiti_core.llm_client.config import DEFAULT_MAX_TOKENS
+
+    client, _ = _make_client()
+    assert client.max_tokens == DEFAULT_MAX_TOKENS


### PR DESCRIPTION
PR #764 fixed `BaseOpenAIClient`, but `OpenAIGenericClient` is a separate implementation that doesn't inherit from it — the fix doesn't reach it.

In `openai_generic_client.py`, the constructor parameter `max_tokens: int = 16384` was unconditionally assigned to `self.max_tokens`, so `LLMConfig.max_tokens` was always ignored. Users of Ollama, vLLM, LM Studio, or any other OpenAI-compatible backend were affected.

Closes #763

---

**Changes:**
- `graphiti_core/llm_client/openai_generic_client.py`: change `max_tokens` parameter to `int | None = None`; resolve as `constructor arg > config.max_tokens`
- `tests/llm_client/test_openai_generic_client.py`: three regression tests covering config respected, constructor override, and default case

**To verify:**
```python
from graphiti_core.llm_client.config import LLMConfig
from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient

client = OpenAIGenericClient(config=LLMConfig(max_tokens=32000))
assert client.max_tokens == 32000  # was 16384 before this fix
```