### PR TITLE
fix(nodes): split Neptune episode entity_edges on the delimiter it was saved with

### DIFF
--- a/graphiti_core/models/nodes/node_db_queries.py
+++ b/graphiti_core/models/nodes/node_db_queries.py
@@ -130,7 +130,7 @@ EPISODIC_NODE_RETURN_NEPTUNE = """
     e.group_id AS group_id,
     e.source_description AS source_description,
     e.source AS source,
-    split(e.entity_edges, ",") AS entity_edges
+    split(e.entity_edges, "|") AS entity_edges
 """
 
 

--- a/tests/test_node_db_queries.py
+++ b/tests/test_node_db_queries.py
@@ -1,0 +1,24 @@
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.models.nodes.node_db_queries import (
+    EPISODIC_NODE_RETURN_NEPTUNE,
+    get_episode_node_save_bulk_query,
+    get_episode_node_save_query,
+)
+
+
+def test_neptune_episodic_entity_edges_read_matches_write_delimiter():
+    """On Neptune, EpisodicNode.entity_edges is serialized to a delimiter-joined
+    string on save and split back into a list on read; the two delimiters must
+    match, otherwise a multi-edge list round-trips into a single mashed element
+    (e.g. ['uuid1|uuid2|uuid3']). The save side joins on '|', so the read query
+    must split on '|', not ','."""
+    save = get_episode_node_save_query(GraphProvider.NEPTUNE)
+    bulk = get_episode_node_save_bulk_query(GraphProvider.NEPTUNE)
+
+    # Save side joins entity_edges with '|'.
+    assert "], '|')" in save
+    assert "], '|')" in bulk
+
+    # Read side must split on the same '|' delimiter, not ','.
+    assert 'split(e.entity_edges, "|")' in EPISODIC_NODE_RETURN_NEPTUNE
+    assert 'split(e.entity_edges, ",")' not in EPISODIC_NODE_RETURN_NEPTUNE


### PR DESCRIPTION
## Summary
On Neptune, an `EpisodicNode` with 2+ `entity_edges` is corrupted on read-back: the field is saved as a `'|'`-joined string but the read query splits it on `','`.

## Type of Change
- [x] Bug fix

## Objective
`get_episode_node_save_query` and `get_episode_node_save_bulk_query` serialize `entity_edges` for Neptune with `join([...], '|')`, but `EPISODIC_NODE_RETURN_NEPTUNE` reads it back with `split(e.entity_edges, ",")`. So a node saved with edges `['a','b','c']` round-trips into a single mashed element `['a|b|c']`, corrupting every Neptune read path (`get_by_uuid`/`get_by_uuids`/`get_by_group_ids`/`get_by_entity_node_uuid`/search) and breaking `remove_episode` edge cleanup. The other providers store a native list and are unaffected. Fix: split on `'|'` to match the save-side join.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

Added `tests/test_node_db_queries.py`: asserts the Neptune episode read query splits `entity_edges` on the same `'|'` delimiter the save queries join with (fails before this change, passes after). `ruff` clean on changed files.

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (ruff passes on changed files)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed