### PR TITLE
fix(falkordb): make default group_id valid and escape it for RediSearch (#1517)

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import logging
+import re
 from typing import Any
 
 from graphiti_core.driver.driver import GraphProvider
@@ -93,6 +94,17 @@ def _sanitize(query: str) -> str:
     return ' '.join(sanitized.split())
 
 
+def _escape_fulltext_group_id(group_id: str) -> str:
+    """Escape non-alphanumeric characters in a group_id for RediSearch fulltext.
+
+    RediSearch treats characters like '_' and '-' as token separators/operators,
+    so an unescaped group_id (e.g. the default '_') causes a parse error or fails
+    to match. group_ids are restricted to ``[a-zA-Z0-9_-]`` by ``validate_group_id``,
+    so escaping every non-alphanumeric char makes them match as literals.
+    """
+    return re.sub(r'([^a-zA-Z0-9])', r'\\\1', group_id)
+
+
 def _build_falkor_fulltext_query(
     query: str,
     group_ids: list[str] | None = None,
@@ -102,7 +114,7 @@ def _build_falkor_fulltext_query(
     if group_ids is None or len(group_ids) == 0:
         group_filter = ''
     else:
-        escaped_group_ids = [f'"{gid}"' for gid in group_ids]
+        escaped_group_ids = [f'"{_escape_fulltext_group_id(gid)}"' for gid in group_ids]
         group_values = '|'.join(escaped_group_ids)
         group_filter = f'(@group_id:{group_values})'
 

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -17,6 +17,7 @@ limitations under the License.
 import asyncio
 import datetime
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -109,7 +110,7 @@ class FalkorDriverSession(GraphDriverSession):
 
 class FalkorDriver(GraphDriver):
     provider = GraphProvider.FALKORDB
-    default_group_id: str = '\\_'
+    default_group_id: str = '_'
     fulltext_syntax: str = '@'  # FalkorDB uses a redisearch-like syntax for fulltext queries
     aoss_client: None = None
 
@@ -403,9 +404,14 @@ class FalkorDriver(GraphDriver):
         if group_ids is None or len(group_ids) == 0:
             group_filter = ''
         else:
-            # Escape group_ids with quotes to prevent RediSearch syntax errors
-            # with reserved words like "main" or special characters like hyphens
-            escaped_group_ids = [f'"{gid}"' for gid in group_ids]
+            # Quote group_ids and escape non-alphanumeric chars (e.g. '_' in the
+            # default group_id, or hyphens). RediSearch treats these as token
+            # separators/operators, which otherwise causes a syntax error or a
+            # failure to match. group_ids are restricted to [a-zA-Z0-9_-] by
+            # validate_group_ids above.
+            escaped_group_ids = [
+                '"' + re.sub(r'([^a-zA-Z0-9])', r'\\\1', gid) + '"' for gid in group_ids
+            ]
             group_values = '|'.join(escaped_group_ids)
             group_filter = f'(@group_id:{group_values})'
 

--- a/graphiti_core/helpers.py
+++ b/graphiti_core/helpers.py
@@ -71,7 +71,7 @@ def get_default_group_id(provider: GraphProvider) -> str:
     For most databases, the default group id is an empty string, while there are database types that require a specific default group id.
     """
     if provider == GraphProvider.FALKORDB:
-        return '\\_'
+        return '_'
     else:
         return ''
 

--- a/tests/utils/search/test_search_security.py
+++ b/tests/utils/search/test_search_security.py
@@ -5,8 +5,10 @@ import pytest
 from pydantic import ValidationError
 
 from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.falkordb.operations.search_ops import _build_falkor_fulltext_query
 from graphiti_core.driver.neo4j.operations.search_ops import _build_neo4j_fulltext_query
 from graphiti_core.errors import GroupIdValidationError, NodeLabelValidationError
+from graphiti_core.helpers import get_default_group_id, validate_group_id
 from graphiti_core.search.search import search
 from graphiti_core.search.search_config import SearchConfig
 from graphiti_core.search.search_filters import (
@@ -90,3 +92,20 @@ async def test_shared_search_rejects_invalid_group_ids():
             config=SearchConfig(),
             search_filter=SearchFilters(),
         )
+
+
+def test_falkordb_default_group_id_passes_validation():
+    # Regression: the FalkorDB default group_id must satisfy validate_group_id.
+    # Otherwise add_episode/search with the default group_id raises
+    # GroupIdValidationError once search re-validates the group_ids.
+    default = get_default_group_id(GraphProvider.FALKORDB)
+    assert validate_group_id(default) is True
+
+
+def test_falkordb_fulltext_query_escapes_default_group_id():
+    # The default group_id ('_') must be escaped for RediSearch (-> '\\_').
+    # An unescaped '_' produces a RediSearch fulltext syntax error.
+    default = get_default_group_id(GraphProvider.FALKORDB)
+    built = _build_falkor_fulltext_query('hello', [default])
+    assert '@group_id:"\\_"' in built
+    assert '@group_id:"_"' not in built


### PR DESCRIPTION
## Summary

Fixes #1517

The FalkorDB default group_id was backslash-underscore, but validate_group_id (added to harden search against injection) rejects backslashes. As a result, add_episode/search with the default group_id failed with GroupIdValidationError, breaking the FalkorDB quickstart out of the box.

## Changes

- **graphiti_core/driver/falkordb_driver.py**: Changed default_group_id from `\\_` to `_`; added import re; escape non-alphanumeric chars in RediSearch fulltext queries
- **graphiti_core/driver/falkordb/operations/search_ops.py**: Added _escape_fulltext_group_id helper
- **graphiti_core/helpers.py**: get_default_group_id for FALKORDB returns `_` instead of `\\_`
- **tests/utils/search/test_search_security.py**: Added regression tests

## Verification

The new default group_id (_) passes validate_group_id (allows [a-zA-Z0-9_-]). In RediSearch fulltext queries, _ is escaped to \_ so it is treated as a literal character rather than a token separator.