### PR TITLE
fix(search): keep edge_scores aligned with edges in episode_mentions reranker

### DIFF
--- a/graphiti_core/search/search.py
+++ b/graphiti_core/search/search.py
@@ -447,7 +447,17 @@ async def edge_search(
         reranked_edges = [edge_uuid_map[uuid] for uuid in reranked_uuids]
 
         if config.reranker == EdgeReranker.episode_mentions:
-            reranked_edges.sort(reverse=True, key=lambda edge: len(edge.episodes))
+            # Re-sort edges and their scores together so each returned edge keeps
+            # its own reranker score. Sorting only reranked_edges left edge_scores
+            # in the prior rrf order, so the parallel slices returned below paired
+            # every edge with a neighbour's score.
+            paired = sorted(
+                zip(reranked_edges, edge_scores, strict=True),
+                reverse=True,
+                key=lambda pair: len(pair[0].episodes),
+            )
+            reranked_edges = [edge for edge, _ in paired]
+            edge_scores = [score for _, score in paired]
 
         span.add_attributes(
             {

--- a/tests/utils/search/test_edge_search_reranker.py
+++ b/tests/utils/search/test_edge_search_reranker.py
@@ -1,0 +1,49 @@
+from types import SimpleNamespace
+
+import pytest
+
+from graphiti_core.search.search import edge_search
+from graphiti_core.search.search_config import (
+    EdgeReranker,
+    EdgeSearchConfig,
+    EdgeSearchMethod,
+)
+from graphiti_core.search.search_filters import SearchFilters
+
+
+@pytest.mark.asyncio
+async def test_edge_search_episode_mentions_keeps_scores_aligned(monkeypatch):
+    """The episode_mentions reranker re-sorts edges by episode count. Its scores
+    must be re-sorted in lockstep, otherwise the parallel (edges, scores) result
+    pairs every edge with a neighbour's score."""
+    # edge_b has more episodes, so episode_mentions ranks it first; rrf ranks
+    # edge_a first (higher score). The two orderings differ, exposing the bug.
+    edge_a = SimpleNamespace(uuid='uuid_a', episodes=['ep1'])
+    edge_b = SimpleNamespace(uuid='uuid_b', episodes=['ep1', 'ep2', 'ep3'])
+
+    async def fake_fulltext(*args, **kwargs):
+        return [edge_a, edge_b]
+
+    def fake_rrf(search_result_uuids, min_score=0, rank_const=1):
+        return ['uuid_a', 'uuid_b'], [0.9, 0.5]
+
+    monkeypatch.setattr('graphiti_core.search.search.edge_fulltext_search', fake_fulltext)
+    monkeypatch.setattr('graphiti_core.search.search.rrf', fake_rrf)
+
+    edges, scores = await edge_search(
+        driver=SimpleNamespace(),
+        cross_encoder=SimpleNamespace(),
+        query='q',
+        query_vector=[],
+        group_ids=None,
+        config=EdgeSearchConfig(
+            search_methods=[EdgeSearchMethod.bm25],
+            reranker=EdgeReranker.episode_mentions,
+        ),
+        search_filter=SearchFilters(),
+    )
+
+    # episode_mentions orders by descending episode count: edge_b first.
+    assert [edge.uuid for edge in edges] == ['uuid_b', 'uuid_a']
+    # Each edge must keep its own rrf score: edge_b -> 0.5, edge_a -> 0.9.
+    assert scores == [0.5, 0.9]


### PR DESCRIPTION
## Summary
`edge_search`'s `episode_mentions` reranker re-sorted the edges but not their scores, so the returned `(edges, scores)` paired every edge with a neighbour's reranker score.

## Type of Change
- [x] Bug fix

## Objective
For `EdgeReranker.episode_mentions`, `edge_search` builds `reranked_edges` aligned with the rrf-ordered `edge_scores`, then re-sorts **only** `reranked_edges` by `len(edge.episodes)` (`reranked_edges.sort(...)`), leaving `edge_scores` in rrf order. It returns them as parallel slices `reranked_edges[:limit], edge_scores[:limit]`, so after the re-sort each edge is paired with the wrong score. The sibling rerankers (rrf/mmr/cross_encoder/node_distance) keep uuids and scores in the same order. Fix: sort the edges and scores together so each edge keeps its own score.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

Added `tests/utils/search/test_edge_search_reranker.py`: drives `edge_search` with a mocked search method + `rrf` so the episode-count order differs from the rrf order, and asserts each returned edge keeps its own score. Fails before this change (scores stay in rrf order), passes after. `ruff` clean on changed files.

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (ruff passes on changed files)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed