### PR TITLE
docs: fix incorrect LLM provider in gliner2 example comments and Pyth…

### DIFF
--- a/examples/gliner2/gliner2_neo4j.py
+++ b/examples/gliner2/gliner2_neo4j.py
@@ -83,8 +83,8 @@ entity_types: dict[str, type[BaseModel]] = {
 #################################################
 # GLiNER2 is a lightweight extraction model
 # (205M-340M params) that runs locally on CPU.
-# It handles entity extraction (NER), while an
-# OpenAI client handles edge/fact extraction,
+# It handles entity extraction (NER), while the
+# LLM client handles edge/fact extraction,
 # deduplication, summarization, and reasoning.
 #################################################
 
@@ -116,7 +116,7 @@ async def main():
     #################################################
     # Set up a hybrid LLM client: GLiNER2 handles
     # entity extraction locally using custom entity
-    # types as labels, while OpenAI handles edge/fact
+    # types as labels, while Gemini handles edge/fact
     # extraction, deduplication, and summarization.
     #################################################
 
@@ -161,7 +161,7 @@ async def main():
         # handled by GLiNER2 locally using the custom
         # entity types as labels. Edge/fact extraction,
         # deduplication, and summarization are delegated
-        # to OpenAI.
+        # to Gemini.
         #################################################
 
         episodes = [

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -11,7 +11,7 @@ This example demonstrates the basic functionality of Graphiti, including:
 
 ## Prerequisites
 
-- Python 3.9+  
+- Python 3.10+  
 - OpenAI API key (set as `OPENAI_API_KEY` environment variable)  
 - **For Neo4j**:
   - Neo4j Desktop installed and running  


### PR DESCRIPTION
While working through the gliner2 example I noticed the inline comments describe the reasoning stage as being handled by "an OpenAI client" in three places (gliner2_neo4j.py:87, :119, :164), but the example actually wires up Gemini (GeminiClient / GeminiEmbedder), and the example's README already says Gemini. GLiNER2Client requires an explicit llm_client and has no OpenAI default, so the comments are just stale — likely copied from an OpenAI-based example. I changed the two comments describing this example's concrete setup to say "Gemini" and left the general architecture note as "the LLM client" since GLiNER2Client accepts any provider.

While in the examples I also caught a small mismatch in the quickstart README, which lists Python 3.9+ even though pyproject.toml requires >=3.10 — so I bumped it to 3.10+. Both are doc-only fixes with no behavior change; nothing more than keeping the comments and prerequisites honest about what the code does.