### PR TITLE
fix(azure): use max_completion_tokens and return token usage from structured responses

### DIFF
--- a/graphiti_core/llm_client/azure_openai_client.py
+++ b/graphiti_core/llm_client/azure_openai_client.py
@@ -95,7 +95,7 @@ class AzureOpenAILLMClient(BaseOpenAIClient):
             request_kwargs = {
                 'model': model,
                 'messages': messages,
-                'max_tokens': max_tokens,
+                'max_completion_tokens': max_tokens,
                 'response_format': response_model,  # Structured output
             }
 
@@ -118,7 +118,7 @@ class AzureOpenAILLMClient(BaseOpenAIClient):
         request_kwargs = {
             'model': model,
             'messages': messages,
-            'max_tokens': max_tokens,
+            'max_completion_tokens': max_tokens,
             'response_format': {'type': 'json_object'},
         }
 
@@ -128,33 +128,48 @@ class AzureOpenAILLMClient(BaseOpenAIClient):
 
         return await self.client.chat.completions.create(**request_kwargs)
 
-    def _handle_structured_response(self, response: Any) -> dict[str, Any]:
+    def _handle_structured_response(self, response: Any) -> tuple[dict[str, Any], int, int]:
         """Handle structured response parsing for both reasoning and non-reasoning models.
 
-        For reasoning models (responses.parse): uses response.output_text
-        For regular models (beta.chat.completions.parse): uses response.choices[0].message.parsed
+        For reasoning models (responses.parse): uses response.output_text and the
+        responses-API usage fields (input_tokens / output_tokens).
+        For regular models (beta.chat.completions.parse): uses
+        response.choices[0].message.parsed and the chat-completions usage fields
+        (prompt_tokens / completion_tokens).
+
+        Returns:
+            tuple: (parsed_response, input_tokens, output_tokens)
         """
-        # Check if this is a ParsedChatCompletion (from beta.chat.completions.parse)
+        from graphiti_core.llm_client.errors import RefusalError
+
+        # Standard ParsedChatCompletion format (beta.chat.completions.parse)
         if hasattr(response, 'choices') and response.choices:
-            # Standard ParsedChatCompletion format
+            input_tokens = 0
+            output_tokens = 0
+            if hasattr(response, 'usage') and response.usage:
+                input_tokens = getattr(response.usage, 'prompt_tokens', 0) or 0
+                output_tokens = getattr(response.usage, 'completion_tokens', 0) or 0
+
             message = response.choices[0].message
             if hasattr(message, 'parsed') and message.parsed:
                 # The parsed object is already a Pydantic model, convert to dict
-                return message.parsed.model_dump()
+                return message.parsed.model_dump(), input_tokens, output_tokens
             elif hasattr(message, 'refusal') and message.refusal:
-                from graphiti_core.llm_client.errors import RefusalError
-
                 raise RefusalError(message.refusal)
             else:
                 raise Exception(f'Invalid response from LLM: {response.model_dump()}')
+        # Reasoning model response format (responses.parse)
         elif hasattr(response, 'output_text'):
-            # Reasoning model response format (responses.parse)
+            input_tokens = 0
+            output_tokens = 0
+            if hasattr(response, 'usage') and response.usage:
+                input_tokens = getattr(response.usage, 'input_tokens', 0) or 0
+                output_tokens = getattr(response.usage, 'output_tokens', 0) or 0
+
             response_object = response.output_text
             if response_object:
-                return json.loads(response_object)
+                return json.loads(response_object), input_tokens, output_tokens
             elif hasattr(response, 'refusal') and response.refusal:
-                from graphiti_core.llm_client.errors import RefusalError
-
                 raise RefusalError(response.refusal)
             else:
                 raise Exception(f'Invalid response from LLM: {response.model_dump()}')

--- a/tests/llm_client/test_azure_openai_client.py
+++ b/tests/llm_client/test_azure_openai_client.py
@@ -81,7 +81,10 @@ async def test_structured_completion_strips_reasoning_for_unsupported_models():
     call_args = dummy_client.beta.chat.completions.parse_calls[0]
     assert call_args['model'] == 'gpt-4.1'
     assert call_args['messages'] == []
-    assert call_args['max_tokens'] == 64
+    # Newer Azure OpenAI API versions reject `max_tokens`; must use
+    # `max_completion_tokens` instead (issue #1496).
+    assert call_args['max_completion_tokens'] == 64
+    assert 'max_tokens' not in call_args
     assert call_args['response_format'] is DummyResponseModel
     assert call_args['temperature'] == 0.4
     # Reasoning and verbosity parameters should not be passed for non-reasoning models
@@ -124,3 +127,60 @@ async def test_reasoning_fields_forwarded_for_supported_models():
 
     create_args = dummy_client.chat.completions.create_calls[0]
     assert 'temperature' not in create_args
+
+
+@pytest.mark.asyncio
+async def test_create_completion_uses_max_completion_tokens():
+    """The plain JSON completion path must send `max_completion_tokens`, not the
+    `max_tokens` rejected by newer Azure OpenAI API versions (issue #1496)."""
+    dummy_client = DummyAzureClient()
+    client = AzureOpenAILLMClient(azure_client=dummy_client, config=LLMConfig())
+
+    await client._create_completion(
+        model='gpt-4.1',
+        messages=[],
+        temperature=0.4,
+        max_tokens=64,
+    )
+
+    create_args = dummy_client.chat.completions.create_calls[0]
+    assert create_args['max_completion_tokens'] == 64
+    assert 'max_tokens' not in create_args
+
+
+def _make_client() -> AzureOpenAILLMClient:
+    return AzureOpenAILLMClient(azure_client=DummyAzureClient(), config=LLMConfig())
+
+
+def test_handle_structured_response_returns_tuple_for_parsed_chat_completion():
+    """`beta.chat.completions.parse` results must unpack to
+    (parsed, input_tokens, output_tokens) — previously the override returned a
+    bare dict, causing 'not enough values to unpack (expected 3, got 1)' (issue #1496)."""
+    client = _make_client()
+    message = SimpleNamespace(parsed=DummyResponseModel(foo='bar'))
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=message)],
+        usage=SimpleNamespace(prompt_tokens=11, completion_tokens=7),
+    )
+
+    parsed, input_tokens, output_tokens = client._handle_structured_response(response)
+
+    assert parsed == {'foo': 'bar'}
+    assert input_tokens == 11
+    assert output_tokens == 7
+
+
+def test_handle_structured_response_returns_tuple_for_responses_parse():
+    """The reasoning-model (`responses.parse`) shape must also unpack to a 3-tuple,
+    reading the responses-API usage fields (input_tokens / output_tokens)."""
+    client = _make_client()
+    response = SimpleNamespace(
+        output_text='{"foo": "baz"}',
+        usage=SimpleNamespace(input_tokens=13, output_tokens=5),
+    )
+
+    parsed, input_tokens, output_tokens = client._handle_structured_response(response)
+
+    assert parsed == {'foo': 'baz'}
+    assert input_tokens == 13
+    assert output_tokens == 5


### PR DESCRIPTION
## Summary

Using Azure OpenAI with API version `2024-10-21` or later fails in two ways (issue #1496):

1. **`max_tokens` is rejected.** Newer Azure models return
   `Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.`
   `AzureOpenAILLMClient` sends `max_tokens` on its two `chat.completions` call sites.

2. **Structured responses fail to unpack.** `BaseOpenAIClient._handle_structured_response`
   returns `tuple[dict, int, int]` and `generate_response` unpacks
   `response, input_tokens, output_tokens = ...`, but the Azure subclass **overrides**
   `_handle_structured_response` and returns a bare `dict`, so any structured call raises
   `not enough values to unpack (expected 3, got 1)`.

**Fix:**

1. The two `chat.completions` call sites in `azure_openai_client.py` now send
   `max_completion_tokens`. The reasoning path (`responses.parse`) already correctly uses
   `max_output_tokens`, so it is unchanged.
2. The Azure `_handle_structured_response` override now returns `tuple[dict, int, int]`,
   matching the base contract. It uses the right token field names for each shape:
   `prompt_tokens` / `completion_tokens` for `beta.chat.completions.parse`, and
   `input_tokens` / `output_tokens` for `responses.parse`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
N/A — this is a bug fix (rationale covered in Summary), not a new feature or performance change.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

`tests/llm_client/test_azure_openai_client.py`:
- Updated the existing structured-completion test to assert `max_completion_tokens` (and no `max_tokens`).
- Added: `_create_completion` sends `max_completion_tokens`; `_handle_structured_response`
  returns a 3-tuple for **both** the `beta.chat.completions.parse` and `responses.parse` shapes.

```
tests/llm_client: 103 passed, 2 skipped   (no regressions)
ruff check + pyright: clean
```

Also verified live against an Azure OpenAI deployment (api-version `2024-10-21`): a model that
returns the reported 400 on `max_tokens` succeeds with `max_completion_tokens`, and a model that
previously accepted `max_tokens` also accepts `max_completion_tokens` — so the switch is
regression-free.

## Breaking Changes
- [ ] This PR contains breaking changes

None — `max_completion_tokens` is the drop-in replacement Azure now requires, and the
structured-response fix restores the documented `tuple[dict, int, int]` contract.

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary (no user-facing docs affected)
- [x] No secrets or sensitive information committed

## Related Issues
Closes #1496
