### PR TITLE
fix(llm_client): return token triple from AzureOpenAILLMClient._handle_structured_response

### DIFF
--- a/graphiti_core/llm_client/azure_openai_client.py
+++ b/graphiti_core/llm_client/azure_openai_client.py
@@ -128,11 +128,17 @@ class AzureOpenAILLMClient(BaseOpenAIClient):
 
         return await self.client.chat.completions.create(**request_kwargs)
 
-    def _handle_structured_response(self, response: Any) -> dict[str, Any]:
+    def _handle_structured_response(self, response: Any) -> tuple[dict[str, Any], int, int]:
         """Handle structured response parsing for both reasoning and non-reasoning models.
 
         For reasoning models (responses.parse): uses response.output_text
         For regular models (beta.chat.completions.parse): uses response.choices[0].message.parsed
+
+        Returns:
+            tuple: (parsed_response, input_tokens, output_tokens) — must match the
+            BaseOpenAIClient signature so the `_generate_response` caller can unpack
+            three values. The Azure override previously returned only the dict, which
+            raised "not enough values to unpack (expected 3, got 1)" (#1298).
         """
         # Check if this is a ParsedChatCompletion (from beta.chat.completions.parse)
         if hasattr(response, 'choices') and response.choices:
@@ -140,7 +146,10 @@ class AzureOpenAILLMClient(BaseOpenAIClient):
             message = response.choices[0].message
             if hasattr(message, 'parsed') and message.parsed:
                 # The parsed object is already a Pydantic model, convert to dict
-                return message.parsed.model_dump()
+                return (
+                    message.parsed.model_dump(),
+                    *self._extract_token_usage(response, prompt_field='prompt_tokens', completion_field='completion_tokens'),
+                )
             elif hasattr(message, 'refusal') and message.refusal:
                 from graphiti_core.llm_client.errors import RefusalError
 
@@ -151,7 +160,10 @@ class AzureOpenAILLMClient(BaseOpenAIClient):
             # Reasoning model response format (responses.parse)
             response_object = response.output_text
             if response_object:
-                return json.loads(response_object)
+                return (
+                    json.loads(response_object),
+                    *self._extract_token_usage(response, prompt_field='input_tokens', completion_field='output_tokens'),
+                )
             elif hasattr(response, 'refusal') and response.refusal:
                 from graphiti_core.llm_client.errors import RefusalError
 
@@ -160,6 +172,24 @@ class AzureOpenAILLMClient(BaseOpenAIClient):
                 raise Exception(f'Invalid response from LLM: {response.model_dump()}')
         else:
             raise Exception(f'Unknown response format: {type(response)}')
+
+    @staticmethod
+    def _extract_token_usage(
+        response: Any, *, prompt_field: str, completion_field: str
+    ) -> tuple[int, int]:
+        """Pull token usage from either response shape.
+
+        responses.parse surfaces ``input_tokens``/``output_tokens`` while
+        ``beta.chat.completions.parse`` surfaces ``prompt_tokens``/
+        ``completion_tokens``; both are absent on some empty/error bodies.
+        """
+        usage = getattr(response, 'usage', None)
+        if usage is None:
+            return 0, 0
+        return (
+            getattr(usage, prompt_field, 0) or 0,
+            getattr(usage, completion_field, 0) or 0,
+        )
 
     @staticmethod
     def _supports_reasoning_features(model: str) -> bool:

--- a/tests/llm_client/test_azure_openai_client.py
+++ b/tests/llm_client/test_azure_openai_client.py
@@ -124,3 +124,55 @@ async def test_reasoning_fields_forwarded_for_supported_models():
 
     create_args = dummy_client.chat.completions.create_calls[0]
     assert 'temperature' not in create_args
+
+
+def test_handle_structured_response_returns_token_triple_for_parsed_chat_completion():
+    """``_handle_structured_response`` must return ``(dict, input_tokens, output_tokens)``
+    to match ``BaseOpenAIClient._generate_response``'s unpack site (#1298). The
+    ``beta.chat.completions.parse`` path exposes ``prompt_tokens``/``completion_tokens``.
+    """
+    client = AzureOpenAILLMClient.__new__(AzureOpenAILLMClient)
+
+    class ParsedModel:
+        @staticmethod
+        def model_dump():
+            return {'foo': 'bar'}
+
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(parsed=ParsedModel()))],
+        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=20),
+    )
+
+    parsed, input_tokens, output_tokens = client._handle_structured_response(response)
+    assert parsed == {'foo': 'bar'}
+    assert input_tokens == 10
+    assert output_tokens == 20
+
+
+def test_handle_structured_response_returns_token_triple_for_responses_parse():
+    """The reasoning-model path (``responses.parse``) exposes token usage as
+    ``input_tokens``/``output_tokens`` and must also return the 3-tuple (#1298)."""
+    client = AzureOpenAILLMClient.__new__(AzureOpenAILLMClient)
+
+    response = SimpleNamespace(
+        output_text='{"foo": "bar"}',
+        usage=SimpleNamespace(input_tokens=15, output_tokens=25),
+    )
+
+    parsed, input_tokens, output_tokens = client._handle_structured_response(response)
+    assert parsed == {'foo': 'bar'}
+    assert input_tokens == 15
+    assert output_tokens == 25
+
+
+def test_handle_structured_response_tolerates_missing_usage():
+    """When the upstream body omits ``usage`` (some empty/error responses do),
+    token counts fall back to 0 instead of raising."""
+    client = AzureOpenAILLMClient.__new__(AzureOpenAILLMClient)
+
+    response = SimpleNamespace(output_text='{"foo": "bar"}')
+
+    parsed, input_tokens, output_tokens = client._handle_structured_response(response)
+    assert parsed == {'foo': 'bar'}
+    assert input_tokens == 0
+    assert output_tokens == 0


### PR DESCRIPTION
## What Problem This Solves

Running `azure_openai_neo4j.py` (and any other Graphiti path that uses `AzureOpenAILLMClient` for structured output) fails with `not enough values to unpack (expected 3, got 1)` after the retry loop exhausts itself. Reported in #1298.

## Root Cause

`BaseOpenAIClient._handle_structured_response` returns `tuple[dict[str, Any], int, int]` and the base-class caller at `graphiti_core/llm_client/openai_base_client.py:211` unpacks three values:

```python
return self._handle_structured_response(response)   # caller unpacks 3
```

The Azure override at `graphiti_core/llm_client/azure_openai_client.py:131` declared `-> dict[str, Any]` and returned only the parsed dict — so the unpack site raised `ValueError` on every structured call. Both code paths in the Azure override (the `beta.chat.completions.parse` branch for non-reasoning models and the `responses.parse` branch for reasoning models) had the same defect.

## Why This Change Was Made

Align the Azure override's signature and return shape with the base class so the unpack works. Token usage is already on the response object — it just wasn't being propagated. The two response shapes use different field names, so a small helper handles both:

- `responses.parse` usage: `input_tokens` / `output_tokens`
- `beta.chat.completions.parse` usage: `prompt_tokens` / `completion_tokens`

Both default to `0` when `response.usage` is absent (some empty/error bodies omit it).

## User Impact

Azure OpenAI users running Graphiti for structured extraction (the default code path for any `response_model=` call) will stop seeing the unpack failure. Token accounting via the existing `token_tracker` will now reflect Azure usage instead of silently recording zeros.

## Evidence

**Reproduction before fix** (mimics the unpack site in `_generate_response`):

```python
from types import SimpleNamespace
from graphiti_core.llm_client.azure_openai_client import AzureOpenAILLMClient

class ParsedModel:
    def model_dump(self): return {'foo': 'bar'}

fake = SimpleNamespace(
    choices=[SimpleNamespace(message=SimpleNamespace(parsed=ParsedModel()))],
    usage=SimpleNamespace(prompt_tokens=10, completion_tokens=20),
)
client = AzureOpenAILLMClient.__new__(AzureOpenAILLMClient)
response, input_tokens, output_tokens = client._handle_structured_response(fake)
#  before: ValueError: not enough values to unpack (expected 3, got 1)
```

**After fix:** all three branches (`ParsedChatCompletion`, `responses.parse`, missing `usage`) return the expected triple. New unit tests cover each path.

```
$ uv run pytest tests/llm_client/test_azure_openai_client.py -v
tests/llm_client/test_azure_openai_client.py::test_structured_completion_strips_reasoning_for_unsupported_models PASSED [ 20%]
tests/llm_client/test_azure_openai_client.py::test_reasoning_fields_forwarded_for_supported_models PASSED [ 40%]
tests/llm_client/test_azure_openai_client.py::test_handle_structured_response_returns_token_triple_for_parsed_chat_completion PASSED [ 60%]
tests/llm_client/test_azure_openai_client.py::test_handle_structured_response_returns_token_triple_for_responses_parse PASSED [ 80%]
tests/llm_client/test_azure_openai_client.py::test_handle_structured_response_tolerates_missing_usage PASSED [100%]

========================= 5 passed, 1 warning in 0.86s =========================
```

Closes #1298.
