### PR TITLE
Allow tailnet host for Graphiti MCP HTTP transport

### DIFF
--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -20,6 +20,7 @@ from graphiti_core.nodes import EntityNode, EpisodeType, SagaNode
 from graphiti_core.search.search_filters import SearchFilters
 from graphiti_core.utils.maintenance.graph_data_operations import clear_data
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import BaseModel
 from starlette.responses import JSONResponse
 
@@ -171,6 +172,22 @@ server requires a configured database and valid API keys for language-model oper
 mcp = FastMCP(
     'Graphiti Agent Memory',
     instructions=GRAPHITI_MCP_INSTRUCTIONS,
+    transport_security=TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=[
+            '127.0.0.1:*',
+            'localhost:*',
+            '[::1]:*',
+            'choi138-ri.tail06f7ab.ts.net:*',
+        ],
+        allowed_origins=[
+            'http://127.0.0.1:*',
+            'http://localhost:*',
+            'http://[::1]:*',
+            'http://choi138-ri.tail06f7ab.ts.net:*',
+            'https://choi138-ri.tail06f7ab.ts.net:*',
+        ],
+    ),
 )
 
 # Global services


### PR DESCRIPTION
## Summary
- allow the choi138 tailnet hostname through MCP transport security host/origin validation
- keep localhost and loopback hosts allowed

## Test
- python3 -m py_compile mcp_server/src/graphiti_mcp_server.py