### PR TITLE
fix(docker): drop procps so the combined FalkorDB image builds on trixie

### DIFF
--- a/mcp_server/docker/Dockerfile
+++ b/mcp_server/docker/Dockerfile
@@ -5,14 +5,15 @@
 FROM falkordb/falkordb:latest AS falkordb-base
 
 # Install Python and system dependencies
-# Note: Debian Bookworm (FalkorDB base) ships with Python 3.11
+# Note: Debian 13 "trixie" (FalkorDB base) ships with Python 3.13.
+# procps is omitted: its postinst runs update-rc.d (a perl script), and the
+# FalkorDB base image no longer ships perl (purged upstream for CVE reduction).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-dev \
     python3-pip \
     curl \
     ca-certificates \
-    procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv for Python package management


### PR DESCRIPTION
## Summary

`docker build -f mcp_server/docker/Dockerfile mcp_server/` currently fails on a pristine checkout of `main`, because the base image `falkordb/falkordb:latest` no longer ships perl.

The base image moved to Debian 13 "trixie" and upstream deliberately purged `perl-base` to reduce CVE surface (FalkorDB/falkordb#1800, merged 2026-04-05). `procps`'s post-installation script runs `update-rc.d`, which is a perl script (`#!/usr/bin/perl`), so the very first `RUN apt-get install ...` layer dies:

```
Setting up procps (2:4.0.4-9) ...
/var/lib/dpkg/info/procps.postinst: 41: update-rc.d: not found
dpkg: error processing package procps (--configure):
 installed procps package post-installation script subprocess returned error exit status 1
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

This blocks every from-source build of the combined FalkorDB + MCP image. It is also a latent release blocker: the `combined` matrix variant of `.github/workflows/release-mcp-server.yml` builds this exact Dockerfile against the same unpinned `:latest`, so the next `mcp-v*` tag push would hit the same failure (the last run of that workflow was `mcp-v1.0.2` on 2026-03-11, before the upstream change).

## Fix

Drop `procps` from the `apt-get install` list and update the stale "Debian Bookworm / Python 3.11" note (the base is now trixie with Python 3.13).

Why this over the alternatives:

- **Nothing uses it.** No script, healthcheck, compose file, workflow, or doc in the repo invokes `ps`/`pgrep`/`top`/etc. The container healthcheck uses `redis-cli ping`; `start-services.sh` uses `redis-server`, `redis-cli`, `node`, and `uv` only. The one in-container `ps aux` sighting I could find (a user debugging #1041) is still covered by `docker top <container>` from the host or `/proc` inside it.
- **Reinstalling `perl-base` also fixes the build** (verified — the apt layer then completes and `ps` works), but it partially undoes the base image's deliberate CVE-surface reduction just to keep a package nothing consumes. Happy to switch to that variant if you'd rather keep `ps` available for debugging the multi-process container.
- **Pinning the base tag doesn't help**: every `falkordb/falkordb` tag from v4.18.0 (2026-04-07) onward is built after the perl purge; only tags ≤ v4.16.9 (2026-04-03) still ship perl, and pinning that far back would freeze FalkorDB itself.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

All against `falkordb/falkordb:latest` at digest `sha256:2496643cabd67e87fd82458383400c049324daec1fe674ba0db4c5bdaca5d25f` (same digest as the issue report):

- Reproduced the failure with the unmodified `RUN` line — `apt-get` exits `100` with the `procps.postinst` error above.
- With `procps` removed, the same `apt-get` line completes with exit `0`.
- Control experiment: adding `perl-base` while keeping `procps` also builds cleanly (`ps from procps-ng 4.0.4`), confirming the failure is exactly the procps→update-rc.d→perl chain and nothing else in the layer.
- Full `docker build -f mcp_server/docker/Dockerfile mcp_server/` of this branch completes successfully end-to-end (including `uv lock` regeneration and `uv sync` on Python 3.13).

## Breaking Changes

None to the build interface. The image no longer contains `ps`/`top`/`free` (procps) — repo-wide search found zero consumers.

## Related Issues

Closes #1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)
