### PR TITLE
fix(docker): avoid host PATH interpolation

### DIFF
--- a/mcp_server/docker/docker-compose-falkordb.yml
+++ b/mcp_server/docker/docker-compose-falkordb.yml
@@ -39,7 +39,6 @@ services:
       - GRAPHITI_GROUP_ID=${GRAPHITI_GROUP_ID:-main}
       - SEMAPHORE_LIMIT=${SEMAPHORE_LIMIT:-10}
       - CONFIG_PATH=/app/mcp/config/config.yaml
-      - PATH=/root/.local/bin:${PATH}
     volumes:
       - ../config/config-docker-falkordb.yaml:/app/mcp/config/config.yaml:ro
     ports:

--- a/mcp_server/docker/docker-compose-neo4j.yml
+++ b/mcp_server/docker/docker-compose-neo4j.yml
@@ -43,7 +43,6 @@ services:
       - GRAPHITI_GROUP_ID=${GRAPHITI_GROUP_ID:-main}
       - SEMAPHORE_LIMIT=${SEMAPHORE_LIMIT:-10}
       - CONFIG_PATH=/app/mcp/config/config.yaml
-      - PATH=/root/.local/bin:${PATH}
     volumes:
       - ../config/config-docker-neo4j.yaml:/app/mcp/config/config.yaml:ro
     ports:

--- a/mcp_server/docker/docker-compose.yml
+++ b/mcp_server/docker/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       - GRAPHITI_GROUP_ID=${GRAPHITI_GROUP_ID:-main}
       - SEMAPHORE_LIMIT=${SEMAPHORE_LIMIT:-10}
       - CONFIG_PATH=/app/mcp/config/config.yaml
-      - PATH=/root/.local/bin:${PATH}
     volumes:
       - falkordb_data:/var/lib/falkordb/data
       - mcp_logs:/var/log/graphiti


### PR DESCRIPTION
## Summary

Docker Compose no longer injects the host process `PATH` into the MCP server containers. This prevents Windows host paths from replacing the Linux image PATH that startup commands rely on.

The Dockerfiles already bake `/root/.local/bin` into the image PATH, so the compose-level override was redundant and could break startup when `${PATH}` expanded to something like `C:\Windows\system32;C:\Windows`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective

Fix the Docker Compose startup failure reported in #1623 without changing Dockerfile install behavior, service commands, or runtime configuration.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

Validation run:

- `PATH='C:\Windows\system32;C:\Windows' docker compose -f mcp_server/docker/docker-compose.yml config --quiet`
- `PATH='C:\Windows\system32;C:\Windows' docker compose -f mcp_server/docker/docker-compose-falkordb.yml config --quiet`
- `PATH='C:\Windows\system32;C:\Windows' docker compose -f mcp_server/docker/docker-compose-neo4j.yml config --quiet`
- `git diff --check upstream/main`

I also checked rendered config output for all three compose files with the same simulated Windows-style host PATH. After this change, the compose files no longer render a container `PATH` override.

Not run: full test suite / `make lint`. This change only removes compose-file PATH interpolation; no Python code changed. GitHub's `ruff` check is passing on the draft PR.

## Breaking Changes

- [ ] This PR contains breaking changes

## Scope

- Limited to the three MCP Docker Compose files named in #1623.
- No Dockerfile, Python, dependency, or documentation changes.
- Does not address the older rootless `/root/.local/bin` permission issue from #665 or the separate Dockerfile-focused PR #981.

## Caveats

- Validation covered Docker Compose rendering/configuration, not end-to-end container startup.
- No unit tests were added because this is compose-file interpolation behavior rather than Python runtime behavior.

## Checklist

- [ ] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues

Fixes #1623
