### PR TITLE
fix(llm): avoid mutating caller messages

### DIFF
--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -371,6 +371,8 @@ class AnthropicClient(LLMClient):
             RefusalError: If the LLM refuses to respond.
             Exception: If an error occurs during the generation process.
         """
+        messages = self._clone_messages(messages)
+
         self._apply_attribute_extraction_preamble(messages, attribute_extraction)
         if max_tokens is None:
             max_tokens = self.max_tokens

--- a/graphiti_core/llm_client/client.py
+++ b/graphiti_core/llm_client/client.py
@@ -95,6 +95,9 @@ class LLMClient(ABC):
         """Set the tracer for this LLM client."""
         self.tracer = tracer
 
+    def _clone_messages(self, messages: list[Message]) -> list[Message]:
+        return [message.model_copy(deep=True) for message in messages]
+
     def _clean_input(self, input: str) -> str:
         """Clean input string of invalid unicode and control characters.
 
@@ -205,6 +208,8 @@ class LLMClient(ABC):
         *,
         attribute_extraction: bool = False,
     ) -> dict[str, typing.Any]:
+        messages = self._clone_messages(messages)
+
         if max_tokens is None:
             max_tokens = self.max_tokens
 

--- a/graphiti_core/llm_client/gemini_client.py
+++ b/graphiti_core/llm_client/gemini_client.py
@@ -389,6 +389,8 @@ class GeminiClient(LLMClient):
         Returns:
             dict[str, typing.Any]: The response from the language model.
         """
+        messages = self._clone_messages(messages)
+
         self._apply_attribute_extraction_preamble(messages, attribute_extraction)
         # Add multilingual extraction instructions
         messages[0].content += get_extraction_language_instruction(group_id)

--- a/graphiti_core/llm_client/gliner2_client.py
+++ b/graphiti_core/llm_client/gliner2_client.py
@@ -273,6 +273,8 @@ class GLiNER2Client(LLMClient):
                 attribute_extraction=attribute_extraction,
             )
 
+        messages = self._clone_messages(messages)
+
         if max_tokens is None:
             max_tokens = self.max_tokens
 

--- a/graphiti_core/llm_client/openai_base_client.py
+++ b/graphiti_core/llm_client/openai_base_client.py
@@ -255,6 +255,8 @@ class BaseOpenAIClient(LLMClient):
         framing to the system message so the strict "field descriptions are not values"
         instruction reaches the model on this provider's native-structured-output path.
         """
+        messages = self._clone_messages(messages)
+
         self._apply_attribute_extraction_preamble(messages, attribute_extraction)
         if max_tokens is None:
             max_tokens = self.max_tokens

--- a/graphiti_core/llm_client/openai_generic_client.py
+++ b/graphiti_core/llm_client/openai_generic_client.py
@@ -184,6 +184,8 @@ class OpenAIGenericClient(LLMClient):
         *,
         attribute_extraction: bool = False,
     ) -> dict[str, typing.Any]:
+        messages = self._clone_messages(messages)
+
         self._apply_attribute_extraction_preamble(messages, attribute_extraction)
         if max_tokens is None:
             max_tokens = self.max_tokens

--- a/tests/llm_client/test_anthropic_client.py
+++ b/tests/llm_client/test_anthropic_client.py
@@ -250,6 +250,50 @@ class TestAnthropicClientGenerateResponse:
         assert mock_async_anthropic.messages.create.call_count == 2
         assert result['test_field'] == 'correct_value'
 
+    @pytest.mark.asyncio
+    async def test_generate_response_retry_does_not_mutate_caller_messages(
+        self, anthropic_client, mock_async_anthropic
+    ):
+        """Test retry prompts are added only to the client's cloned messages."""
+        content_item1 = MagicMock()
+        content_item1.type = 'tool_use'
+        content_item1.input = {'wrong_field': 'wrong_value'}
+
+        content_item2 = MagicMock()
+        content_item2.type = 'tool_use'
+        content_item2.input = {'test_field': 'correct_value'}
+
+        mock_response1 = MagicMock()
+        mock_response1.content = [content_item1]
+
+        mock_response2 = MagicMock()
+        mock_response2.content = [content_item2]
+
+        mock_async_anthropic.messages.create.side_effect = [mock_response1, mock_response2]
+
+        messages = [
+            Message(role='system', content='System message'),
+            Message(role='user', content='User message'),
+        ]
+        original = [message.model_dump() for message in messages]
+
+        result = await anthropic_client.generate_response(
+            messages,
+            response_model=ResponseModel,
+            attribute_extraction=True,
+        )
+
+        assert result['test_field'] == 'correct_value'
+        assert [message.model_dump() for message in messages] == original
+        assert len(messages) == 2
+        first_call = mock_async_anthropic.messages.create.call_args_list[0].kwargs
+        second_call = mock_async_anthropic.messages.create.call_args_list[1].kwargs
+        assert 'ATTRIBUTE EXTRACTION:' in first_call['system']
+        assert first_call['messages'] == [{'role': 'user', 'content': 'User message'}]
+        assert len(second_call['messages']) == 2
+        assert second_call['messages'][0] == {'role': 'user', 'content': 'User message'}
+        assert 'The previous response was invalid' in second_call['messages'][1]['content']
+
 
 if __name__ == '__main__':
     pytest.main(['-v', 'test_anthropic_client.py'])

--- a/tests/llm_client/test_client.py
+++ b/tests/llm_client/test_client.py
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import pytest
+from pydantic import BaseModel
+
 from graphiti_core.llm_client.client import LLMClient
 from graphiti_core.llm_client.config import LLMConfig
 from graphiti_core.prompts.models import Message
@@ -22,8 +25,15 @@ from graphiti_core.prompts.models import Message
 class MockLLMClient(LLMClient):
     """Concrete implementation of LLMClient for testing"""
 
-    async def _generate_response(self, messages, response_model=None):
+    async def _generate_response(
+        self, messages, response_model=None, max_tokens=None, model_size=None
+    ):
+        self.last_messages = messages
         return {'content': 'test'}
+
+
+class ResponseModel(BaseModel):
+    fact: str
 
 
 def test_clean_input():
@@ -106,3 +116,49 @@ def test_attribute_extraction_preamble_handles_empty_messages():
     messages: list[Message] = []
     client._apply_attribute_extraction_preamble(messages, attribute_extraction=True)
     assert messages == []
+
+
+@pytest.mark.asyncio
+async def test_generate_response_does_not_mutate_caller_messages():
+    client = MockLLMClient(LLMConfig())
+    messages = [
+        Message(role='system', content='System message'),
+        Message(role='user', content='User message\x00'),
+    ]
+    original = [message.model_dump() for message in messages]
+
+    await client.generate_response(
+        messages,
+        response_model=ResponseModel,
+        group_id='test-group',
+        attribute_extraction=True,
+    )
+
+    assert [message.model_dump() for message in messages] == original
+    assert client.last_messages is not messages
+    assert client.last_messages[0] is not messages[0]
+    assert 'ATTRIBUTE EXTRACTION:' in client.last_messages[0].content
+    assert 'same language' in client.last_messages[0].content
+    assert 'Respond with a JSON object in the following format' in client.last_messages[-1].content
+    assert '\x00' not in client.last_messages[-1].content
+
+
+@pytest.mark.asyncio
+async def test_generate_response_preparation_is_idempotent_for_reused_messages():
+    client = MockLLMClient(LLMConfig())
+    messages = [
+        Message(role='system', content='System message'),
+        Message(role='user', content='User message'),
+    ]
+
+    await client.generate_response(
+        messages, response_model=ResponseModel, attribute_extraction=True
+    )
+    first_call = [message.model_dump() for message in client.last_messages]
+
+    await client.generate_response(
+        messages, response_model=ResponseModel, attribute_extraction=True
+    )
+    second_call = [message.model_dump() for message in client.last_messages]
+
+    assert second_call == first_call

--- a/tests/llm_client/test_gemini_client.py
+++ b/tests/llm_client/test_gemini_client.py
@@ -329,6 +329,48 @@ class TestGeminiClientGenerateResponse:
         assert result['test_field'] == 'correct_value'
 
     @pytest.mark.asyncio
+    async def test_retry_does_not_mutate_caller_messages(self, gemini_client, mock_gemini_client):
+        """Test retry prompts are added only to the client's cloned messages."""
+        mock_response1 = MagicMock()
+        mock_response1.text = 'Invalid JSON that cannot be parsed'
+        mock_response1.candidates = []
+        mock_response1.prompt_feedback = None
+
+        mock_response2 = MagicMock()
+        mock_response2.text = '{"test_field": "correct_value"}'
+        mock_response2.candidates = []
+        mock_response2.prompt_feedback = None
+
+        mock_gemini_client.aio.models.generate_content.side_effect = [
+            mock_response1,
+            mock_response2,
+        ]
+
+        messages = [
+            Message(role='system', content='System message'),
+            Message(role='user', content='User message'),
+        ]
+        original = [message.model_dump() for message in messages]
+
+        result = await gemini_client.generate_response(
+            messages,
+            response_model=ResponseModel,
+            attribute_extraction=True,
+        )
+
+        assert result['test_field'] == 'correct_value'
+        assert [message.model_dump() for message in messages] == original
+        assert len(messages) == 2
+        first_call = mock_gemini_client.aio.models.generate_content.call_args_list[0].kwargs
+        second_call = mock_gemini_client.aio.models.generate_content.call_args_list[1].kwargs
+        assert 'ATTRIBUTE EXTRACTION:' in first_call['config'].system_instruction
+        assert len(first_call['contents']) == 1
+        assert len(second_call['contents']) == 2
+        assert (
+            'The previous response attempt was invalid' in second_call['contents'][1].parts[0].text
+        )
+
+    @pytest.mark.asyncio
     async def test_max_retries_exceeded(self, gemini_client, mock_gemini_client):
         """Test behavior when max retries are exceeded."""
         # Setup mock to always return invalid JSON

--- a/tests/llm_client/test_openai_client.py
+++ b/tests/llm_client/test_openai_client.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 from graphiti_core.llm_client.config import LLMConfig
 from graphiti_core.llm_client.openai_base_client import DEFAULT_MODEL, DEFAULT_REASONING
 from graphiti_core.llm_client.openai_client import OpenAIClient
+from graphiti_core.prompts.models import Message
 
 
 class DummyResponses:
@@ -219,3 +220,26 @@ async def test_create_completion_keeps_temperature_for_non_reasoning_model():
 
     call_args = dummy.chat.completions.create_calls[0]
     assert call_args['temperature'] == 0.4
+
+
+@pytest.mark.asyncio
+async def test_generate_response_does_not_mutate_caller_messages():
+    dummy = DummyOpenAIClient()
+    client = OpenAIClient(config=LLMConfig(), client=dummy)
+    messages = [
+        Message(role='system', content='System message'),
+        Message(role='user', content='User message\x00'),
+    ]
+    original = [message.model_dump() for message in messages]
+
+    await client.generate_response(
+        messages,
+        group_id='test-group',
+        attribute_extraction=True,
+    )
+
+    assert [message.model_dump() for message in messages] == original
+    call_args = dummy.chat.completions.create_calls[0]
+    assert 'ATTRIBUTE EXTRACTION:' in call_args['messages'][0]['content']
+    assert 'same language' in call_args['messages'][0]['content']
+    assert '\x00' not in call_args['messages'][-1]['content']

--- a/tests/llm_client/test_openai_generic_client.py
+++ b/tests/llm_client/test_openai_generic_client.py
@@ -95,6 +95,26 @@ async def test_json_object_mode_uses_json_object_and_injects_schema():
 
 
 @pytest.mark.asyncio
+async def test_generate_response_does_not_mutate_caller_messages():
+    client, completions = _make_client(structured_output_mode='json_object')
+    messages = _messages()
+    original = [message.model_dump() for message in messages]
+
+    await client.generate_response(
+        messages,
+        response_model=ResponseModel,
+        group_id='test-group',
+        attribute_extraction=True,
+    )
+
+    assert [message.model_dump() for message in messages] == original
+    call = completions.create_calls[0]
+    assert 'ATTRIBUTE EXTRACTION:' in call['messages'][0]['content']
+    assert 'same language' in call['messages'][0]['content']
+    assert 'Respond with a JSON object in the following format' in call['messages'][-1]['content']
+
+
+@pytest.mark.asyncio
 async def test_no_response_model_uses_json_object_without_injection():
     client, completions = _make_client(content='{"any": "thing"}')
 


### PR DESCRIPTION
## Summary
- clone caller-provided message lists before public `generate_response` prompt preparation
- cover base, OpenAI/OpenAI-compatible, Anthropic, Gemini, and GLiNER2 response paths
- add regressions proving reused caller messages do not accumulate schema/language/preamble/retry prompt mutations

Closes #1629

## Tests
- `uv run pytest tests/llm_client/test_client.py tests/llm_client/test_openai_client.py tests/llm_client/test_openai_generic_client.py tests/llm_client/test_anthropic_client.py tests/llm_client/test_gemini_client.py -q`
  - 72 passed, 1 warning
- `make lint`
  - ruff passed
  - pyright passed with 0 errors
- `make test`
  - environment-blocked after 171 passed / 2 skipped / 10 deselected
  - failed in Neo4j-backed `tests/test_add_triplet.py` setup because no local Neo4j service was available at `localhost:7687`; interrupted after repeated `neo4j.exceptions.ServiceUnavailable` connection retries
