### PR TITLE
fix(mcp): validate episode types before queueing

### DIFF
--- a/mcp_server/src/services/queue_service.py
+++ b/mcp_server/src/services/queue_service.py
@@ -6,6 +6,9 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from typing import Any
 
+from graphiti_core.helpers import validate_excluded_entity_types
+from graphiti_core.utils.ontology_utils.entity_types_utils import validate_entity_types
+
 logger = logging.getLogger(__name__)
 
 
@@ -148,6 +151,9 @@ class QueueService:
         """
         if self._graphiti_client is None:
             raise RuntimeError('Queue service not initialized. Call initialize() first.')
+
+        validate_entity_types(entity_types)
+        validate_excluded_entity_types(excluded_entity_types, entity_types)
 
         async def process_episode():
             """Process the episode using the graphiti client."""

--- a/mcp_server/tests/test_core_parity.py
+++ b/mcp_server/tests/test_core_parity.py
@@ -15,8 +15,10 @@ from unittest.mock import AsyncMock
 import pytest
 from graphiti_core import Graphiti
 from graphiti_core.edges import EntityEdge
+from graphiti_core.errors import EntityTypeValidationError
 from graphiti_core.nodes import EntityNode
 from graphiti_core.search.search_filters import ComparisonOperator, SearchFilters
+from pydantic import BaseModel
 
 # Add the src directory to the path (mirrors the other unit tests)
 sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
@@ -156,6 +158,32 @@ class TestQueueServiceThreading:
     """The queue service must forward every parity param to Graphiti.add_episode."""
 
     @pytest.mark.asyncio
+    async def test_add_episode_rejects_invalid_entity_type_before_queueing(self):
+        class DataObject(BaseModel):
+            attributes: str | None = None
+
+        client = AsyncMock(spec=Graphiti)
+        service = QueueService()
+        await service.initialize(client)
+
+        with pytest.raises(
+            EntityTypeValidationError,
+            match='attributes cannot be used as an attribute for DataObject',
+        ):
+            await service.add_episode(
+                group_id='g1',
+                name='ep',
+                content='This system has several attributes including age, status, and priority.',
+                source_description='desc',
+                episode_type='text',
+                entity_types={'DataObject': DataObject},
+                uuid=None,
+            )
+
+        assert 'g1' not in service._episode_queues
+        client.add_episode.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_add_episode_forwards_all_params(self):
         client = AsyncMock(spec=Graphiti)
         service = QueueService()
@@ -171,7 +199,10 @@ class TestQueueServiceThreading:
             content='body',
             source_description='desc',
             episode_type='text',
-            entity_types={'Preference': ENTITY_TYPES['Preference']},
+            entity_types={
+                'Preference': ENTITY_TYPES['Preference'],
+                'Object': ENTITY_TYPES['Object'],
+            },
             uuid='ep-uuid',
             reference_time=ref_time,
             edge_types=edge_types,


### PR DESCRIPTION
Addresses #1164

## Summary

This validates MCP episode type configuration before an episode is added to the background queue.

Previously, `add_memory` could return a queued-success response even when `Graphiti.add_episode` would immediately reject the configured entity types. The queue worker then logged the failure later, so callers only saw success while the episode was never processed.

This reuses Graphiti's existing entity-type and excluded-entity-type validators in `QueueService.add_episode`, before creating the background task. Invalid reserved fields such as `DataObject.attributes` now fail before queueing, so the MCP tool returns an error instead of a false success message.

## Validation

- Reproduced the current behavior locally: `QueueService.add_episode` returned a queue position, then the worker logged `attributes cannot be used as an attribute for DataObject as it is a protected attribute name.`
- Verified after the change that the same case raises before queue creation and the Graphiti client is not called.
- Verified `add_memory` now returns an error response for that case and does not create a queue.
- `uv run pytest tests/test_core_parity.py -q` from `mcp_server`: 28 passed.
- `uv run ruff check src/services/queue_service.py tests/test_core_parity.py`: passed.
- `uv run ruff format --check src/services/queue_service.py tests/test_core_parity.py`: passed.
- `uv run pyright src/services/queue_service.py`: 0 errors.

Note: I also tried MCP-wide `uv run pyright src tests`, but it currently reports existing unrelated MCP test/import typing issues, so I kept the pyright check scoped to the changed service file.
