### PR TITLE
fix(search): make FalkorDB tie-breaking deterministic

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -218,7 +218,7 @@ class FalkorSearchOperations(SearchOperations):
             """
             + get_entity_node_return_query(GraphProvider.FALKORDB)
             + """
-            ORDER BY score DESC, uuid ASC
+            ORDER BY score DESC, n.uuid ASC
             LIMIT $limit
             """
         )
@@ -324,7 +324,7 @@ class FalkorSearchOperations(SearchOperations):
             """
             + get_entity_edge_return_query(GraphProvider.FALKORDB)
             + """
-            ORDER BY score DESC, uuid ASC
+            ORDER BY score DESC, e.uuid ASC
             LIMIT $limit
             """
         )
@@ -383,7 +383,7 @@ class FalkorSearchOperations(SearchOperations):
             """
             + get_entity_edge_return_query(GraphProvider.FALKORDB)
             + """
-            ORDER BY score DESC, uuid ASC
+            ORDER BY score DESC, e.uuid ASC
             LIMIT $limit
             """
         )
@@ -484,7 +484,7 @@ class FalkorSearchOperations(SearchOperations):
             """
             + EPISODIC_NODE_RETURN
             + """
-            ORDER BY score DESC, uuid ASC
+            ORDER BY score DESC, e.uuid ASC
             LIMIT $limit
             """
         )
@@ -528,7 +528,7 @@ class FalkorSearchOperations(SearchOperations):
             """
             + COMMUNITY_NODE_RETURN
             + """
-            ORDER BY score DESC, uuid ASC
+            ORDER BY score DESC, c.uuid ASC
             LIMIT $limit
             """
         )
@@ -569,7 +569,7 @@ class FalkorSearchOperations(SearchOperations):
             """
             + COMMUNITY_NODE_RETURN
             + """
-            ORDER BY score DESC, uuid ASC
+            ORDER BY score DESC, c.uuid ASC
             LIMIT $limit
             """
         )

--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -167,7 +167,7 @@ class FalkorSearchOperations(SearchOperations):
             + filter_query
             + """
             WITH n, score
-            ORDER BY score DESC
+            ORDER BY score DESC, n.uuid ASC
             LIMIT $limit
             RETURN
             """
@@ -218,7 +218,7 @@ class FalkorSearchOperations(SearchOperations):
             """
             + get_entity_node_return_query(GraphProvider.FALKORDB)
             + """
-            ORDER BY score DESC
+            ORDER BY score DESC, uuid ASC
             LIMIT $limit
             """
         )
@@ -324,7 +324,7 @@ class FalkorSearchOperations(SearchOperations):
             """
             + get_entity_edge_return_query(GraphProvider.FALKORDB)
             + """
-            ORDER BY score DESC
+            ORDER BY score DESC, uuid ASC
             LIMIT $limit
             """
         )
@@ -383,7 +383,7 @@ class FalkorSearchOperations(SearchOperations):
             """
             + get_entity_edge_return_query(GraphProvider.FALKORDB)
             + """
-            ORDER BY score DESC
+            ORDER BY score DESC, uuid ASC
             LIMIT $limit
             """
         )
@@ -484,7 +484,7 @@ class FalkorSearchOperations(SearchOperations):
             """
             + EPISODIC_NODE_RETURN
             + """
-            ORDER BY score DESC
+            ORDER BY score DESC, uuid ASC
             LIMIT $limit
             """
         )
@@ -528,7 +528,7 @@ class FalkorSearchOperations(SearchOperations):
             """
             + COMMUNITY_NODE_RETURN
             + """
-            ORDER BY score DESC
+            ORDER BY score DESC, uuid ASC
             LIMIT $limit
             """
         )
@@ -569,7 +569,7 @@ class FalkorSearchOperations(SearchOperations):
             """
             + COMMUNITY_NODE_RETURN
             + """
-            ORDER BY score DESC
+            ORDER BY score DESC, uuid ASC
             LIMIT $limit
             """
         )

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -279,7 +279,7 @@ async def edge_fulltext_search(
             """
             + get_entity_edge_return_query(driver.provider)
             + """
-            ORDER BY score DESC
+            ORDER BY score DESC, uuid ASC
             LIMIT $limit
             """
         )
@@ -426,7 +426,7 @@ async def edge_similarity_search(
             """
             + get_entity_edge_return_query(driver.provider)
             + """
-            ORDER BY score DESC
+            ORDER BY score DESC, uuid ASC
             LIMIT $limit
             """
         )
@@ -649,7 +649,7 @@ async def node_fulltext_search(
             + filter_query
             + """
             WITH n, score
-            ORDER BY score DESC
+            ORDER BY score DESC, n.uuid ASC
             LIMIT $limit
             RETURN
             """
@@ -768,7 +768,7 @@ async def node_similarity_search(
             """
             + get_entity_node_return_query(driver.provider)
             + """
-            ORDER BY score DESC
+            ORDER BY score DESC, uuid ASC
             LIMIT $limit
             """
         )
@@ -955,7 +955,7 @@ async def episode_fulltext_search(
             """
             + EPISODIC_NODE_RETURN
             + """
-            ORDER BY score DESC
+            ORDER BY score DESC, uuid ASC
             LIMIT $limit
             """
         )
@@ -1044,7 +1044,7 @@ async def community_fulltext_search(
             """
             + COMMUNITY_NODE_RETURN
             + """
-            ORDER BY score DESC
+            ORDER BY score DESC, uuid ASC
             LIMIT $limit
             """
         )
@@ -1157,7 +1157,7 @@ async def community_similarity_search(
             """
             + COMMUNITY_NODE_RETURN
             + """
-            ORDER BY score DESC
+            ORDER BY score DESC, uuid ASC
             LIMIT $limit
             """
         )
@@ -1785,8 +1785,8 @@ def rrf(
         for i, uuid in enumerate(result):
             scores[uuid] += 1 / (i + rank_const)
 
-    scored_uuids = [term for term in scores.items()]
-    scored_uuids.sort(reverse=True, key=lambda term: term[1])
+    scored_uuids = list(scores.items())
+    scored_uuids.sort(key=lambda term: (-term[1], term[0]))
 
     sorted_uuids = [term[0] for term in scored_uuids]
 

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -279,7 +279,7 @@ async def edge_fulltext_search(
             """
             + get_entity_edge_return_query(driver.provider)
             + """
-            ORDER BY score DESC, uuid ASC
+            ORDER BY score DESC, e.uuid ASC
             LIMIT $limit
             """
         )
@@ -426,7 +426,7 @@ async def edge_similarity_search(
             """
             + get_entity_edge_return_query(driver.provider)
             + """
-            ORDER BY score DESC, uuid ASC
+            ORDER BY score DESC, e.uuid ASC
             LIMIT $limit
             """
         )
@@ -768,7 +768,7 @@ async def node_similarity_search(
             """
             + get_entity_node_return_query(driver.provider)
             + """
-            ORDER BY score DESC, uuid ASC
+            ORDER BY score DESC, n.uuid ASC
             LIMIT $limit
             """
         )
@@ -955,7 +955,7 @@ async def episode_fulltext_search(
             """
             + EPISODIC_NODE_RETURN
             + """
-            ORDER BY score DESC, uuid ASC
+            ORDER BY score DESC, e.uuid ASC
             LIMIT $limit
             """
         )
@@ -1044,7 +1044,7 @@ async def community_fulltext_search(
             """
             + COMMUNITY_NODE_RETURN
             + """
-            ORDER BY score DESC, uuid ASC
+            ORDER BY score DESC, c.uuid ASC
             LIMIT $limit
             """
         )
@@ -1157,7 +1157,7 @@ async def community_similarity_search(
             """
             + COMMUNITY_NODE_RETURN
             + """
-            ORDER BY score DESC, uuid ASC
+            ORDER BY score DESC, c.uuid ASC
             LIMIT $limit
             """
         )

--- a/tests/utils/search/deterministic_tie_breaks_test.py
+++ b/tests/utils/search/deterministic_tie_breaks_test.py
@@ -118,13 +118,13 @@ async def _ops_community_similarity(
 @pytest.mark.parametrize(
     ("search_call", "expected_order"),
     [
-        (_legacy_edge_fulltext, "ORDER BY score DESC, uuid ASC"),
-        (_legacy_edge_similarity, "ORDER BY score DESC, uuid ASC"),
+        (_legacy_edge_fulltext, "ORDER BY score DESC, e.uuid ASC"),
+        (_legacy_edge_similarity, "ORDER BY score DESC, e.uuid ASC"),
         (_legacy_node_fulltext, "ORDER BY score DESC, n.uuid ASC"),
-        (_legacy_node_similarity, "ORDER BY score DESC, uuid ASC"),
-        (_legacy_episode_fulltext, "ORDER BY score DESC, uuid ASC"),
-        (_legacy_community_fulltext, "ORDER BY score DESC, uuid ASC"),
-        (_legacy_community_similarity, "ORDER BY score DESC, uuid ASC"),
+        (_legacy_node_similarity, "ORDER BY score DESC, n.uuid ASC"),
+        (_legacy_episode_fulltext, "ORDER BY score DESC, e.uuid ASC"),
+        (_legacy_community_fulltext, "ORDER BY score DESC, c.uuid ASC"),
+        (_legacy_community_similarity, "ORDER BY score DESC, c.uuid ASC"),
     ],
 )
 async def test_legacy_falkor_search_orders_equal_scores_by_uuid(
@@ -143,12 +143,12 @@ async def test_legacy_falkor_search_orders_equal_scores_by_uuid(
     ("search_call", "expected_order"),
     [
         (_ops_node_fulltext, "ORDER BY score DESC, n.uuid ASC"),
-        (_ops_node_similarity, "ORDER BY score DESC, uuid ASC"),
-        (_ops_edge_fulltext, "ORDER BY score DESC, uuid ASC"),
-        (_ops_edge_similarity, "ORDER BY score DESC, uuid ASC"),
-        (_ops_episode_fulltext, "ORDER BY score DESC, uuid ASC"),
-        (_ops_community_fulltext, "ORDER BY score DESC, uuid ASC"),
-        (_ops_community_similarity, "ORDER BY score DESC, uuid ASC"),
+        (_ops_node_similarity, "ORDER BY score DESC, n.uuid ASC"),
+        (_ops_edge_fulltext, "ORDER BY score DESC, e.uuid ASC"),
+        (_ops_edge_similarity, "ORDER BY score DESC, e.uuid ASC"),
+        (_ops_episode_fulltext, "ORDER BY score DESC, e.uuid ASC"),
+        (_ops_community_fulltext, "ORDER BY score DESC, c.uuid ASC"),
+        (_ops_community_similarity, "ORDER BY score DESC, c.uuid ASC"),
     ],
 )
 async def test_falkor_search_operations_order_equal_scores_by_uuid(

--- a/tests/utils/search/deterministic_tie_breaks_test.py
+++ b/tests/utils/search/deterministic_tie_breaks_test.py
@@ -1,0 +1,170 @@
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import pytest
+
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.falkordb.operations.search_ops import FalkorSearchOperations
+from graphiti_core.search.search_filters import SearchFilters
+from graphiti_core.search.search_utils import (
+    community_fulltext_search,
+    community_similarity_search,
+    edge_fulltext_search,
+    edge_similarity_search,
+    episode_fulltext_search,
+    node_fulltext_search,
+    node_similarity_search,
+    rrf,
+)
+
+
+class _CapturingExecutor:
+    provider = GraphProvider.FALKORDB
+    search_interface = None
+
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    def build_fulltext_query(
+        self,
+        query: str,
+        group_ids: list[str] | None = None,
+        max_query_length: int = 128,
+    ) -> str:
+        return query
+
+    async def execute_query(self, cypher_query_: str, **kwargs: Any) -> tuple[list, list, None]:
+        self.queries.append(cypher_query_)
+        return [], [], None
+
+
+LegacySearchCall = Callable[[_CapturingExecutor, SearchFilters], Awaitable[list]]
+OperationsSearchCall = Callable[
+    [FalkorSearchOperations, _CapturingExecutor, SearchFilters], Awaitable[list]
+]
+
+
+async def _legacy_edge_fulltext(driver: _CapturingExecutor, filters: SearchFilters) -> list:
+    return await edge_fulltext_search(driver, "query", filters)
+
+
+async def _legacy_edge_similarity(driver: _CapturingExecutor, filters: SearchFilters) -> list:
+    return await edge_similarity_search(driver, [1.0], None, None, filters)
+
+
+async def _legacy_node_fulltext(driver: _CapturingExecutor, filters: SearchFilters) -> list:
+    return await node_fulltext_search(driver, "query", filters)
+
+
+async def _legacy_node_similarity(driver: _CapturingExecutor, filters: SearchFilters) -> list:
+    return await node_similarity_search(driver, [1.0], filters)
+
+
+async def _legacy_episode_fulltext(driver: _CapturingExecutor, filters: SearchFilters) -> list:
+    return await episode_fulltext_search(driver, "query", filters)
+
+
+async def _legacy_community_fulltext(driver: _CapturingExecutor, filters: SearchFilters) -> list:
+    return await community_fulltext_search(driver, "query")
+
+
+async def _legacy_community_similarity(driver: _CapturingExecutor, filters: SearchFilters) -> list:
+    return await community_similarity_search(driver, [1.0])
+
+
+async def _ops_node_fulltext(
+    operations: FalkorSearchOperations, executor: _CapturingExecutor, filters: SearchFilters
+) -> list:
+    return await operations.node_fulltext_search(executor, "query", filters)
+
+
+async def _ops_node_similarity(
+    operations: FalkorSearchOperations, executor: _CapturingExecutor, filters: SearchFilters
+) -> list:
+    return await operations.node_similarity_search(executor, [1.0], filters)
+
+
+async def _ops_edge_fulltext(
+    operations: FalkorSearchOperations, executor: _CapturingExecutor, filters: SearchFilters
+) -> list:
+    return await operations.edge_fulltext_search(executor, "query", filters)
+
+
+async def _ops_edge_similarity(
+    operations: FalkorSearchOperations, executor: _CapturingExecutor, filters: SearchFilters
+) -> list:
+    return await operations.edge_similarity_search(executor, [1.0], None, None, filters)
+
+
+async def _ops_episode_fulltext(
+    operations: FalkorSearchOperations, executor: _CapturingExecutor, filters: SearchFilters
+) -> list:
+    return await operations.episode_fulltext_search(executor, "query", filters)
+
+
+async def _ops_community_fulltext(
+    operations: FalkorSearchOperations, executor: _CapturingExecutor, filters: SearchFilters
+) -> list:
+    return await operations.community_fulltext_search(executor, "query")
+
+
+async def _ops_community_similarity(
+    operations: FalkorSearchOperations, executor: _CapturingExecutor, filters: SearchFilters
+) -> list:
+    return await operations.community_similarity_search(executor, [1.0])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("search_call", "expected_order"),
+    [
+        (_legacy_edge_fulltext, "ORDER BY score DESC, uuid ASC"),
+        (_legacy_edge_similarity, "ORDER BY score DESC, uuid ASC"),
+        (_legacy_node_fulltext, "ORDER BY score DESC, n.uuid ASC"),
+        (_legacy_node_similarity, "ORDER BY score DESC, uuid ASC"),
+        (_legacy_episode_fulltext, "ORDER BY score DESC, uuid ASC"),
+        (_legacy_community_fulltext, "ORDER BY score DESC, uuid ASC"),
+        (_legacy_community_similarity, "ORDER BY score DESC, uuid ASC"),
+    ],
+)
+async def test_legacy_falkor_search_orders_equal_scores_by_uuid(
+    search_call: LegacySearchCall, expected_order: str
+) -> None:
+    driver = _CapturingExecutor()
+
+    await search_call(driver, SearchFilters())
+
+    assert len(driver.queries) == 1
+    assert expected_order in driver.queries[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("search_call", "expected_order"),
+    [
+        (_ops_node_fulltext, "ORDER BY score DESC, n.uuid ASC"),
+        (_ops_node_similarity, "ORDER BY score DESC, uuid ASC"),
+        (_ops_edge_fulltext, "ORDER BY score DESC, uuid ASC"),
+        (_ops_edge_similarity, "ORDER BY score DESC, uuid ASC"),
+        (_ops_episode_fulltext, "ORDER BY score DESC, uuid ASC"),
+        (_ops_community_fulltext, "ORDER BY score DESC, uuid ASC"),
+        (_ops_community_similarity, "ORDER BY score DESC, uuid ASC"),
+    ],
+)
+async def test_falkor_search_operations_order_equal_scores_by_uuid(
+    search_call: OperationsSearchCall, expected_order: str
+) -> None:
+    operations = FalkorSearchOperations()
+    executor = _CapturingExecutor()
+
+    await search_call(operations, executor, SearchFilters())
+
+    assert len(executor.queries) == 1
+    assert expected_order in executor.queries[0]
+
+
+def test_rrf_orders_equal_scores_by_uuid() -> None:
+    ranked_uuids, scores = rrf([["uuid-b"], ["uuid-a"]])
+
+    assert ranked_uuids == ["uuid-a", "uuid-b"]
+    assert scores == [1.0, 1.0]


### PR DESCRIPTION
## Summary
- add UUID ascending as the secondary order for all seven score-ranked FalkorDB search primitives
- make reciprocal rank fusion break equal scores by UUID
- mirror query ordering in the FalkorDB SearchOperations implementation

This prevents database iteration order and input insertion order from changing capped search results when scores tie.

## Tests
- added focused query-rendering coverage for the legacy and SearchOperations paths
- added an equal-score RRF regression test
- `pytest --confcutdir tests/utils/search tests/utils/search/deterministic_tie_breaks_test.py tests/utils/search/search_utils_test.py -q` (20 passed)
