### PR TITLE
fix(falkordb): guard clone() against empty graph names

### DIFF
--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -230,8 +230,8 @@ class FalkorDriver(GraphDriver):
         return self._graph_ops
 
     def _get_graph(self, graph_name: str | None) -> FalkorGraph:
-        # FalkorDB requires a non-None database name for multi-tenant graphs; the default is "default_db"
-        if graph_name is None:
+        # FalkorDB requires a non-empty database name for multi-tenant graphs; the default is "default_db"
+        if not graph_name:
             graph_name = self._database
         return self.client.select_graph(graph_name)
 
@@ -325,6 +325,13 @@ class FalkorDriver(GraphDriver):
         Returns a shallow copy of this driver with a different default database.
         Reuses the same connection (e.g. FalkorDB, Neo4j).
         """
+        # An empty group_id must not become an empty graph name: falkordb-py's
+        # select_graph('') raises a misleading TypeError ("Expected a string
+        # parameter, but received <class 'str'>"). Fall back to the current
+        # database instead. See #1650.
+        if not database:
+            database = self._database
+
         if database == self._database:
             cloned = self
         elif database == self.default_group_id:

--- a/tests/driver/test_falkordb_driver.py
+++ b/tests/driver/test_falkordb_driver.py
@@ -92,6 +92,17 @@ class TestFalkorDriver:
         self.mock_client.select_graph.assert_called_once_with('default_db')
         assert result is mock_graph
 
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def test_get_graph_with_empty_name_defaults_to_default_database(self):
+        """Test _get_graph with an empty name defaults to default_db."""
+        mock_graph = MagicMock()
+        self.mock_client.select_graph.return_value = mock_graph
+
+        result = self.driver._get_graph('')
+
+        self.mock_client.select_graph.assert_called_once_with('default_db')
+        assert result is mock_graph
+
     @pytest.mark.asyncio
     @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
     async def test_execute_query_success(self):
@@ -235,6 +246,50 @@ class TestFalkorDriver:
             await self.driver.delete_all_indexes()
 
             mock_execute.assert_called_once_with('CALL db.indexes()')
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def test_clone_with_empty_database_falls_back_to_current_database(self):
+        """Test clone with an empty database falls back to the current database."""
+        cloned = self.driver.clone('')
+
+        assert cloned is self.driver
+        assert cloned._database == self.driver._database
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_clone_with_empty_database_never_selects_empty_graph(self):
+        """Test that a query on a clone('') driver never calls select_graph('')."""
+        mock_graph = MagicMock()
+        mock_result = MagicMock()
+        mock_result.header = []
+        mock_result.result_set = []
+        mock_graph.query = AsyncMock(return_value=mock_result)
+        self.mock_client.select_graph.return_value = mock_graph
+
+        cloned = self.driver.clone('')
+        await cloned.execute_query('MATCH (n) RETURN n')
+
+        self.mock_client.select_graph.assert_called_once_with('default_db')
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def test_clone_with_database_creates_new_driver(self):
+        """Test clone with a specific database creates a new driver on that database."""
+        cloned = self.driver.clone('group')
+
+        assert cloned is not self.driver
+        assert isinstance(cloned, FalkorDriver)
+        assert cloned.client is self.mock_client
+        assert cloned._database == 'group'
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def test_clone_with_default_group_id_uses_default_database(self):
+        """Test clone with the default group id creates a new driver on the default database."""
+        cloned = self.driver.clone(self.driver.default_group_id)
+
+        assert cloned is not self.driver
+        assert isinstance(cloned, FalkorDriver)
+        assert cloned.client is self.mock_client
+        assert cloned._database == 'default_db'
 
 
 class TestFalkorDriverSession:


### PR DESCRIPTION
## Summary
Fixes #1650: an empty `group_id` crashes the FalkorDB driver with the misleading TypeError `Expected a string parameter, but received <class 'str'>`.

Mechanism: `validate_group_id()` deliberately lets `''` through — the empty string is the default case for other providers — so the guard belongs in the FalkorDB driver, not in the validator. The empty string flows into `FalkorDriver.clone(database='')`, which builds a driver bound to an empty graph name. Because `select_graph()` is lazy, nothing fails at clone time; the crash only surfaces on the first query on the clone, when falkordb-py's `select_graph('')` raises the TypeError above (misleading, since the value *is* a string — reported by us as FalkorDB/falkordb-py#244).

The fix is minimal and local to `falkordb_driver.py`:
- `clone()`: a falsy `database` now falls back to `self._database`, so `clone('')` returns the driver itself (bound to its current database) instead of a broken clone.
- `_get_graph()`: the existing `is None` guard is widened to falsy (`if not graph_name:`) as defense in depth, matching the two fix locations suggested in #1650.

Production context: in our deployment this was triggered by a replayed queue entry without a `group_id`; the delayed crash (first query, not clone time) made it hard to trace back to the empty `group_id`.

Relation to #1572: complementary, not conflicting. That PR memoizes `clone()`; this PR normalizes the `database` argument before the existing branch chain. If both land, the falsy guard simply runs before (or inside) the memoized lookup.

We are the reporters of both getzep/graphiti#1650 and FalkorDB/falkordb-py#244.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
N/A (bug fix).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

New tests in `tests/driver/test_falkordb_driver.py` (existing mock pattern, skipped when falkordb is not installed):
- `test_clone_with_empty_database_falls_back_to_current_database` — `clone('')` returns the source driver with its database intact.
- `test_clone_with_empty_database_never_selects_empty_graph` — a query on a `clone('')` driver never calls `select_graph('')` (asserted on the mock client).
- `test_clone_with_database_creates_new_driver` — `clone('group')` behavior unchanged.
- `test_clone_with_default_group_id_uses_default_database` — the `default_group_id` (`'_'`) branch stays intact.
- `test_get_graph_with_empty_name_defaults_to_default_database` — `_get_graph('')` falls back to the default database.

`ruff format --check` / `ruff check` pass; `pytest tests/driver/test_falkordb_driver.py -m "not integration"`: 30 passed, 1 skipped. The three empty-name tests fail on unpatched main, confirming they cover the bug.

## Breaking Changes
- [ ] This PR contains breaking changes

No. `clone('')` previously produced a driver that was guaranteed to crash on first use, so no working behavior changes.

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Closes #1650
