### PR TITLE
docs: note Zep's proprietary Context Graph Engine in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Graphiti is the open-source temporal context graph engine at the core of
 [Zep's](https://www.getzep.com) context infrastructure for AI agents. Zep manages context graphs at scale, providing
 governed, low-latency context retrieval and assembly for production agent deployments.
 
+Under the hood, Zep is powered by a proprietary graph database — the
+[Context Graph Engine](https://www.getzep.com/platform/context-graph-engine/) — built for millions of context graphs
+with low-latency retrieval, so production deployments don't require a separate third-party graph database.
+
 Using Graphiti, we've demonstrated Zep is
 the [State of the Art in Agent Memory](https://blog.getzep.com/state-of-the-art-agent-memory/).
 
@@ -105,6 +109,7 @@ applications.
 |--------|-----|---------|
 | **What they are** | Managed context graph infrastructure for AI agents | Open-source temporal context graph engine |
 | **Context graphs** | Manages vast numbers of per-user/entity context graphs with governance | Build and query individual context graphs |
+| **Graph database** | Proprietary [Context Graph Engine](https://www.getzep.com/platform/context-graph-engine/) — built for millions of context graphs with low-latency retrieval; no third-party graph database vendor required | Bring your own third-party graph database |
 | **User & conversation management** | Built-in users, threads, and message storage | Build your own |
 | **Retrieval & performance** | Pre-configured, production-ready retrieval with sub-200ms performance at scale | Custom implementation required; performance depends on your setup |
 | **Developer tools** | Dashboard with graph visualization, debug logs, API logs; SDKs for Python, TypeScript, and Go | Build your own tools |


### PR DESCRIPTION
## Summary
Adds documentation to the README clarifying that Zep is powered by a proprietary graph database — the [Context Graph Engine](https://www.getzep.com/platform/context-graph-engine/) — built for millions of context graphs with low-latency retrieval, so production Zep deployments don't require a separate third-party graph database. This adds a paragraph to the Zep section and a new "Graph database" row to the Zep vs. Graphiti comparison table.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation/Tests

## Objective
Make clear to readers evaluating Zep vs. self-hosted Graphiti that Zep's managed offering does not depend on a third-party graph database vendor, distinguishing it from Graphiti's bring-your-own-database model.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
N/A
