### PR TITLE
Return entity edge reference time

### DIFF
--- a/graphiti_core/models/edges/edge_db_queries.py
+++ b/graphiti_core/models/edges/edge_db_queries.py
@@ -202,6 +202,7 @@ def get_entity_edge_return_query(provider: GraphProvider) -> str:
         e.expired_at AS expired_at,
         e.valid_at AS valid_at,
         e.invalid_at AS invalid_at,
+        e.reference_time AS reference_time,
         properties(e) AS attributes
     """
 
@@ -217,6 +218,7 @@ def get_entity_edge_return_query(provider: GraphProvider) -> str:
         e.expired_at AS expired_at,
         e.valid_at AS valid_at,
         e.invalid_at AS invalid_at,
+        e.reference_time AS reference_time,
     """ + (
         'e.attributes AS attributes'
         if provider == GraphProvider.KUZU

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -253,6 +253,7 @@ async def edge_fulltext_search(
                     e.expired_at AS expired_at,
                     e.valid_at AS valid_at,
                     e.invalid_at AS invalid_at,
+                    e.reference_time AS reference_time,
                     properties(e) AS attributes
                 ORDER BY score DESC LIMIT $limit
                             """
@@ -398,6 +399,7 @@ async def edge_similarity_search(
                     r.expired_at AS expired_at,
                     r.valid_at AS valid_at,
                     r.invalid_at AS invalid_at,
+                    r.reference_time AS reference_time,
                     properties(r) AS attributes
                 ORDER BY i.score DESC
                 LIMIT $limit
@@ -540,6 +542,7 @@ async def edge_bfs_search(
                     e.expired_at AS expired_at,
                     e.valid_at AS valid_at,
                     e.invalid_at AS invalid_at,
+                    e.reference_time AS reference_time,
                     properties(e) AS attributes
                 LIMIT $limit
                 """

--- a/tests/test_edge_reference_time.py
+++ b/tests/test_edge_reference_time.py
@@ -1,0 +1,46 @@
+"""Regression tests for preserving EntityEdge.reference_time on reads."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.record_parsers import entity_edge_from_record
+from graphiti_core.edges import get_entity_edge_from_record
+from graphiti_core.models.edges.edge_db_queries import get_entity_edge_return_query
+
+
+REFERENCE_TIME = datetime(2024, 12, 9, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize('provider', list(GraphProvider))
+def test_entity_edge_return_query_selects_reference_time(provider: GraphProvider):
+    query = get_entity_edge_return_query(provider)
+
+    assert 'e.reference_time AS reference_time' in query
+
+
+@pytest.mark.parametrize('parser', [get_entity_edge_from_record, entity_edge_from_record])
+def test_entity_edge_parser_preserves_reference_time(parser):
+    record = {
+        'uuid': 'edge-uuid',
+        'source_node_uuid': 'source-uuid',
+        'target_node_uuid': 'target-uuid',
+        'fact': 'Source relates to target',
+        'name': 'relates to',
+        'group_id': 'test',
+        'episodes': [],
+        'created_at': REFERENCE_TIME,
+        'expired_at': None,
+        'valid_at': None,
+        'invalid_at': None,
+        'reference_time': REFERENCE_TIME,
+        'attributes': {},
+    }
+
+    if parser is get_entity_edge_from_record:
+        edge = parser(record, GraphProvider.NEO4J)
+    else:
+        edge = parser(record)
+
+    assert edge.reference_time == REFERENCE_TIME


### PR DESCRIPTION
 ## Summary
  Fixes `EntityEdge.reference_time` being lost when edges are read from the database.

  Although `reference_time` is persisted on entity edges, it was omitted from the
  Cypher return projections. As a result, edge hydration always received a missing
  value and set `reference_time` to `None`.

  This PR:

  - Adds `reference_time` to the shared entity-edge return projection.
  - Adds it to the standalone Neptune full-text, similarity, and BFS search
  projections.
  - Adds regression tests for query projection and edge hydration.

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Performance improvement
  - [ ] Documentation/Tests

  ## Objective

  Ensure persisted `EntityEdge.reference_time` values are preserved across standard
  edge reads and search results.

  ## Testing

  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [ ] All existing tests pass

  Regression tests verify that:

  - Entity-edge return queries select `reference_time` for every graph provider.
  - Both entity-edge hydration paths preserve the returned timestamp.

  The full test suite was not run locally due to environment limitations.

  ## Breaking Changes

  - [ ] This PR contains breaking changes

  No breaking changes.

  ## Checklist

  - [ ] Code follows project style guidelines (`make lint` passes)
  - [x] Self-review completed
  - [x] Documentation updated where necessary
  - [x] No secrets or sensitive information committed

  No documentation changes were necessary because this restores the existing model
  field’s expected read behavior.

  ## Related Issues

  Closes #1661