### PR TITLE
fix(dedupe): default entity_resolutions to [] so a malformed LLM reply degrades instead of dropping the episode

### DIFF
--- a/graphiti_core/prompts/dedupe_nodes.py
+++ b/graphiti_core/prompts/dedupe_nodes.py
@@ -35,7 +35,16 @@ class NodeDuplicate(BaseModel):
 
 
 class NodeResolutions(BaseModel):
-    entity_resolutions: list[NodeDuplicate] = Field(..., description='List of resolved nodes')
+    # default_factory=list, NOT Field(...): the dedupe LLM intermittently returns a bare
+    # NodeDuplicate instead of {'entity_resolutions': [...]}. Required-field validation turned
+    # that into a dropped episode (measured in production: 2 of 8 episodes lost, no retry).
+    # Defaulting to an empty list lets the episode through — node_operations already diffs the
+    # returned ids against the expected ones and logs 'LLM did not return resolutions for IDs',
+    # so an empty list just means "resolve nothing this round". A skipped dedup round is
+    # recoverable; a dropped episode is not.
+    entity_resolutions: list[NodeDuplicate] = Field(
+        default_factory=list, description='List of resolved nodes'
+    )
 
 
 class Prompt(Protocol):

--- a/mcp_server/tests/test_noderes_degrade.py
+++ b/mcp_server/tests/test_noderes_degrade.py
@@ -1,0 +1,53 @@
+"""NodeResolutions must degrade, not drop.
+
+The dedupe LLM intermittently answers with a bare NodeDuplicate rather than the wrapper object.
+With `entity_resolutions` required that raised inside add_episode and the episode was lost with no
+retry (measured 2026-07-16: 2 of 8 episodes gone). Losing a dedup round is recoverable; losing the
+episode is not.
+"""
+
+import pytest
+from graphiti_core.prompts.dedupe_nodes import NodeDuplicate, NodeResolutions
+from pydantic import ValidationError
+
+
+def test_bare_node_duplicate_response_does_not_raise():
+    """The exact shape that was killing episodes in production."""
+    llm_response = {'id': 0, 'name': 'concurrent worker test', 'duplicate_candidate_id': -1}
+
+    resolutions = NodeResolutions(**llm_response)
+
+    assert resolutions.entity_resolutions == [], 'omitted resolutions must mean "resolve nothing"'
+
+
+def test_empty_response_does_not_raise():
+    assert NodeResolutions().entity_resolutions == []
+    assert NodeResolutions(**{}).entity_resolutions == []
+
+
+def test_well_formed_response_still_parses():
+    """Relaxing the field must not weaken the happy path."""
+    llm_response = {
+        'entity_resolutions': [
+            {'id': 0, 'name': 'Jizo', 'duplicate_candidate_id': -1},
+            {'id': 1, 'name': 'ChaiKlang', 'duplicate_candidate_id': 3},
+        ]
+    }
+
+    resolutions = NodeResolutions(**llm_response)
+
+    assert len(resolutions.entity_resolutions) == 2
+    assert resolutions.entity_resolutions[0].name == 'Jizo'
+    assert resolutions.entity_resolutions[1].duplicate_candidate_id == 3
+
+
+def test_malformed_resolution_entries_still_rejected():
+    """Only the wrapper is relaxed — a resolution missing its own required fields is still a bug
+    we want to hear about, not silently coerce."""
+    with pytest.raises(ValidationError):
+        NodeResolutions(entity_resolutions=[{'id': 0}])  # no name / duplicate_candidate_id
+
+
+def test_node_duplicate_fields_unchanged():
+    nd = NodeDuplicate(id=2, name='SomTor', duplicate_candidate_id=-1)
+    assert (nd.id, nd.name, nd.duplicate_candidate_id) == (2, 'SomTor', -1)


### PR DESCRIPTION
## Problem

The dedupe LLM intermittently answers with a bare NodeDuplicate object instead of the expected wrapper:

```
1 validation error for NodeResolutions
entity_resolutions
  Field required [type=missing, input_value={"id": 0, "name": "...", "duplicate_candidate_id": -1}]
```

Because `entity_resolutions` is required, this raises inside `add_episode` and the whole episode is dropped with no retry. Measured in production (FalkorDB + an OpenAI-compatible model): 2 of 8 episodes silently lost in one batch.

## Fix

`entity_resolutions: list[NodeDuplicate] = Field(default_factory=list, ...)`

A missing/omitted wrapper now degrades to "resolve nothing this round": `node_operations` already diffs returned ids against expected ones and warns `LLM did not return resolutions for IDs`, so entities still land and only that round of dedup is skipped. A skipped dedup round is recoverable; a dropped episode is not.

Malformed entries inside a well-formed list still raise, and the happy path is unchanged — both covered by the added tests (5, all passing; the two failure-shape tests fail against current main with the exact production error above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NKXrjmB9He73iZoCQ3L4X
