### PR TITLE
feat(mcp): use a provider-matched cross-encoder to avoid a hard OpenAI dependency

### DIFF
--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -37,7 +37,12 @@ from models.response_types import (
     SuccessResponse,
     TripletResponse,
 )
-from services.factories import DatabaseDriverFactory, EmbedderFactory, LLMClientFactory
+from services.factories import (
+    CrossEncoderFactory,
+    DatabaseDriverFactory,
+    EmbedderFactory,
+    LLMClientFactory,
+)
 from services.queue_service import QueueService
 from utils.formatting import format_fact_result, to_edge_result, to_node_result
 from utils.type_config import (
@@ -213,6 +218,15 @@ class GraphitiService:
             except Exception as e:
                 logger.warning(f'Failed to create embedder client: {e}')
 
+            # Create cross-encoder (reranker) client matched to the configured provider.
+            # Without this, graphiti-core defaults to OpenAIRerankerClient(), which requires
+            # OPENAI_API_KEY even when the LLM and embedder are non-OpenAI providers.
+            cross_encoder_client = None
+            try:
+                cross_encoder_client = CrossEncoderFactory.create(self.config.llm)
+            except Exception as e:
+                logger.warning(f'Failed to create cross-encoder client: {e}')
+
             # Get database configuration
             db_config = DatabaseDriverFactory.create_config(self.config.database)
 
@@ -240,6 +254,7 @@ class GraphitiService:
                         graph_driver=falkor_driver,
                         llm_client=llm_client,
                         embedder=embedder_client,
+                        cross_encoder=cross_encoder_client,
                         max_coroutines=self.semaphore_limit,
                     )
                 else:
@@ -250,6 +265,7 @@ class GraphitiService:
                         password=db_config['password'],
                         llm_client=llm_client,
                         embedder=embedder_client,
+                        cross_encoder=cross_encoder_client,
                         max_coroutines=self.semaphore_limit,
                     )
             except Exception as db_error:

--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -65,6 +65,13 @@ try:
 except ImportError:
     HAS_GROQ = False
 
+try:
+    from graphiti_core.cross_encoder.gemini_reranker_client import GeminiRerankerClient
+
+    HAS_GEMINI_RERANKER = True
+except ImportError:
+    HAS_GEMINI_RERANKER = False
+
 
 def _validate_api_key(provider_name: str, api_key: str | None, logger) -> str:
     """Validate API key is present.
@@ -291,6 +298,50 @@ class LLMClientFactory:
 
             case _:
                 raise ValueError(f'Unsupported LLM provider: {provider}')
+
+
+class CrossEncoderFactory:
+    """Factory for creating CrossEncoder (reranker) clients based on the LLM provider.
+
+    When no ``cross_encoder`` is passed to ``Graphiti()``, graphiti-core falls back to
+    ``OpenAIRerankerClient()``, which requires ``OPENAI_API_KEY`` — even when the LLM and
+    embedder are both configured for another provider. This factory returns a reranker that
+    matches the configured provider so a non-OpenAI stack (e.g. all-Gemini) does not pull in a
+    hard OpenAI dependency. Providers without a dedicated reranker return ``None``, which
+    preserves the existing default behavior.
+    """
+
+    @staticmethod
+    def create(config: LLMConfig):
+        """Create a cross-encoder client for the configured LLM provider, or None."""
+        import logging
+
+        logger = logging.getLogger(__name__)
+
+        provider = config.provider.lower()
+
+        match provider:
+            case 'gemini':
+                if not HAS_GEMINI_RERANKER:
+                    logger.warning(
+                        'Gemini reranker not available in current graphiti-core version; '
+                        'falling back to the default cross-encoder'
+                    )
+                    return None
+                if not config.providers.gemini:
+                    raise ValueError('Gemini provider configuration not found')
+
+                api_key = config.providers.gemini.api_key
+                _validate_api_key('Gemini reranker', api_key, logger)
+
+                # Reuse the fast/cheap default reranker model from graphiti-core.
+                reranker_config = GraphitiLLMConfig(api_key=api_key)
+                return GeminiRerankerClient(config=reranker_config)
+
+            case _:
+                # No dedicated reranker for this provider — return None so graphiti-core
+                # applies its existing default (OpenAIRerankerClient).
+                return None
 
 
 class EmbedderFactory:


### PR DESCRIPTION
## Problem

The MCP server builds an LLM client and an embedder client from config, but never passes a `cross_encoder` to `Graphiti()`. When `Graphiti()` receives no cross-encoder it hard-defaults to `OpenAIRerankerClient()`, which requires `OPENAI_API_KEY`.

The result: a deployment configured entirely for a non-OpenAI provider (e.g. Gemini LLM + Gemini embedder) still fails to start without an OpenAI key, purely because of the reranker default.

## Fix

Add a `CrossEncoderFactory` that mirrors the existing `LLMClientFactory` / `EmbedderFactory`:

- for the `gemini` provider it returns a `GeminiRerankerClient` (already shipped in `graphiti-core`) built from the configured Gemini API key;
- every other provider returns `None`, which preserves the current default (`graphiti-core` applies `OpenAIRerankerClient()`).

The result is wired into both the FalkorDB and Neo4j `Graphiti()` constructors.

## Compatibility

No behavior change for existing OpenAI users: unmatched providers return `None`, so `graphiti-core` keeps applying its `OpenAIRerankerClient()` default exactly as before. An all-Gemini deployment can now start without an `OPENAI_API_KEY`.

## Verification

- Both changed files byte-compile.
- Imports resolve in the `providers` extra (`HAS_GEMINI_RERANKER = True`).
- `gemini` → constructs a `GeminiRerankerClient`; `anthropic`/other → returns `None` (default preserved).

## Scope

Two files, additive:

- `mcp_server/src/services/factories.py` — new `CrossEncoderFactory` + a guarded `GeminiRerankerClient` import.
- `mcp_server/src/graphiti_mcp_server.py` — build the cross-encoder via the factory and pass it into both `Graphiti()` constructors.
