### PR TITLE
docs: add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,26 @@ Author tests alongside features under `tests/`, naming files `test_<feature>.py`
 
 ## Commit & Pull Request Guidelines
 Commits use an imperative, present-tense summary (for example, `add async cache invalidation`) optionally suffixed with the PR number as seen in history (`(#927)`). Squash fixups and keep unrelated changes isolated. Pull requests should include: a concise description, linked tracking issue, notes about schema or API impacts, and screenshots or logs when behavior changes. Confirm `make lint` and `make test` pass locally, and update docs or examples when public interfaces shift.
+
+## Cursor Cloud specific instructions
+
+Dependencies are installed by the startup update script (`uv sync` in the repo root, `server/`, and `mcp_server/`). `uv` lives at `~/.local/bin`; if it is not on `PATH`, prefix commands with `PATH="$HOME/.local/bin:$PATH"`. Set `GRAPHITI_TELEMETRY_ENABLED=false` when running anything to avoid PostHog network calls.
+
+### Graph databases (Neo4j + FalkorDB via Docker)
+Docker has no systemd here — start the daemon manually once per VM: `sudo dockerd > /tmp/dockerd.log 2>&1 &`. Then start the DBs on the host network exactly as CI does (see `.github/workflows/unit_tests.yml`):
+- `sudo docker run -d --name falkordb --network host falkordb/falkordb:latest` (port 6379)
+- `sudo docker run -d --name neo4j --network host -e NEO4J_AUTH=neo4j/testpass -e NEO4J_PLUGINS='["apoc"]' neo4j:5.26-community` (bolt 7687, http 7474)
+
+### Tests (non-obvious)
+- `make test` does NOT set `DISABLE_NEO4J`, so the `graph_driver` fixture stays parametrized on Neo4j and the suite REQUIRES a reachable Neo4j at `bolt://localhost:7687`. With no Neo4j, those tests hang on the driver's connection retry (not an env bug). Run it as `NEO4J_PASSWORD=testpass make test`.
+- `tests/test_add_triplet.py` has pre-existing failures (its mock embedder doesn't stub `create_batch`, so `zip(strict=True)` raises). CI never runs this file, so ignore those 11 failures — they are unrelated to environment setup.
+- The authoritative, fully-green no-DB unit gate is the CI command in `.github/workflows/unit_tests.yml` (`DISABLE_NEO4J=1 DISABLE_FALKORDB=1 DISABLE_KUZU=1 DISABLE_NEPTUNE=1` plus the `--ignore` list). The DB-backed unit tests are the `database-integration-tests` job in the same file (needs Neo4j + FalkorDB, uses mock LLMs, no API key).
+- `server/` and `mcp_server/` test suites are live end-to-end tests marked `integration`; they self-skip with exit code 5 when `OPENAI_API_KEY` is unset. This skip is expected, not a failure.
+
+### Running the services (dev mode)
+All three run without a valid OpenAI key for startup/health only; real ingest/search (LLM extraction + embeddings) needs a real `OPENAI_API_KEY`.
+- REST API (`server/`): `OPENAI_API_KEY=<placeholder-or-real> DB_BACKEND=falkordb FALKORDB_HOST=localhost FALKORDB_PORT=6379 uv run uvicorn graph_service.main:app --reload --port 8000`. Health at `/healthcheck`, Swagger at `/docs`. `Settings` requires `OPENAI_API_KEY` to be present (any value) or startup fails.
+- MCP server (`mcp_server/`): `OPENAI_API_KEY=<...> FALKORDB_URI=redis://localhost:6379 uv run python main.py --transport http --host 0.0.0.0 --port 8001 --database-provider falkordb`. Serves streamable HTTP MCP at `/mcp/` (use port 8001 if 8000 is taken by the REST server).
+
+### Backend gotcha
+The FalkorDB async driver drops the connection ("Connection closed by server") when Graphiti issues concurrent queries on one connection (e.g. the gather inside `Graphiti.search`). For local hybrid-search work, prefer the Neo4j backend, which handles concurrent queries reliably.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up and validates the full development environment for the Graphiti monorepo (core library, FastAPI REST server, MCP server) in the Cursor Cloud VM, and documents the durable, non-obvious setup/run caveats in `AGENTS.md`. The only code change is an added `## Cursor Cloud specific instructions` section in `AGENTS.md`; a startup update script (`uv sync` across the three projects) was registered separately.

## Type of Change
- [x] Documentation/Tests

## Objective
Make the repo reliably runnable/testable for future cloud agents: install `uv`, sync deps for all three projects, and capture the non-obvious gotchas that aren't in the README (e.g. `make test` requiring a live Neo4j, pre-existing `test_add_triplet.py` failures that CI never runs, and a FalkorDB async concurrency limitation).

## What was set up & verified

Dependencies: installed `uv`, ran `uv sync --extra dev` (root), `uv sync --extra dev` (`server/`), `uv sync` (`mcp_server/`). Installed Docker and started Neo4j (`neo4j:5.26-community`) + FalkorDB on the host network (matching CI).

| Component | Lint | Tests | Run (dev) |
|-----------|------|-------|-----------|
| `graphiti-core` (root) | `make lint` — pass | CI unit cmd: 348 passed, 11 skipped; DB-backed job (Neo4j+FalkorDB, mock LLM): 76 passed | Hello-world builds a temporal graph + hybrid search on Neo4j |
| `server/` (FastAPI) | `make lint` — pass | Live E2E `test_live_falkordb_int.py -m integration`: **2 passed** (real OpenAI) | `uvicorn ... --reload` on :8000; real ingest→search verified |
| `mcp_server/` | ruff/pyright available | Live E2E `test_live_falkordb_int.py -m integration`: **2 passed** (real OpenAI) | `main.py --transport http --port 8001`; MCP `initialize` OK |

Note: `make test` (documented command) keeps Neo4j enabled and requires a live Neo4j at `bolt://localhost:7687`; with it running, 407 passed and the only 11 failures are in `tests/test_add_triplet.py`, a pre-existing mock bug (`create_batch` unstubbed) that CI never executes.

### Hello-world (core engine, no API key)
Built entities + episode + a temporal fact edge on Neo4j with a deterministic mock embedder, read them back, and ran hybrid retrieval:
```
[2] Saved 2 entities, 1 episode, and 1 temporal fact edge.
[3] Read back fact: "Alice mentors Bob at work"
[4] Hybrid search returned 1 fact(s): - Alice mentors Bob at work (edge=MENTORS)
HELLO-WORLD SUCCESS: core graph build + hybrid retrieval verified.
```

### Real live REST API E2E (with provided OPENAI_API_KEY)
Ingested a message via `POST /messages` (202), the real LLM extracted temporal facts, and `POST /search` returned them:
```
POST /search "What does Kendra like?" -> 200
  - "Kendra loves Adidas shoes"                              (LOVES)
  - "Kendra bought a new pair of Adidas shoes in March 2026" (BOUGHT, valid_at=2026-03-01)
```
[graphiti_rest_api_real_ingest_search_demo.mp4](https://cursor.com/agents/bc-68d4bc05-dc2e-4284-8542-480de10a78b8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgraphiti_rest_api_real_ingest_search_demo.mp4)
[POST /messages 202](https://cursor.com/agents/bc-68d4bc05-dc2e-4284-8542-480de10a78b8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frest_api_messages_202.webp)
[POST /search facts 200](https://cursor.com/agents/bc-68d4bc05-dc2e-4284-8542-480de10a78b8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frest_api_search_facts_200.webp)

## Testing
- [x] All existing tests pass (CI unit suite, DB-backed suite, and both live server/MCP E2E suites with the real key; see note on `test_add_triplet.py`)

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68d4bc05-dc2e-4284-8542-480de10a78b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68d4bc05-dc2e-4284-8542-480de10a78b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

