### PR TITLE
Add Socket Firewall enforcement to CI and releases

### DIFF
--- a/.github/actions/setup-socket-firewall/README.md
+++ b/.github/actions/setup-socket-firewall/README.md
@@ -1,0 +1,53 @@
+# Setup Socket Firewall wrapper
+
+Composite GitHub Action that installs Socket Firewall Enterprise (`sfw`) in
+wrapper mode and routes supported package-manager commands through it for later
+bash steps in the same job.
+
+## Usage
+
+```yaml
+- name: Setup Socket Firewall wrapper
+  uses: ./.github/actions/setup-socket-firewall
+  with:
+    socket-api-key: ${{ secrets.SOCKET_API_KEY }}
+```
+
+Call the action after checkout and before the first `uv sync`, `uv lock`,
+`uv pip`, or `pip install` step.
+
+The action:
+
+- downloads the Linux `sfw` binary when needed
+- exports `SOCKET_API_KEY` and `SFW_TELEMETRY_DISABLED=true`
+- configures `SFW_CUSTOM_REGISTRIES` with wrap hosts (including
+  `files.pythonhosted.org` for PyPI artifact downloads)
+- writes a `BASH_ENV` file with package-manager wrapper functions
+
+Wrapper functions apply only to later bash steps that source `BASH_ENV`. They
+do not affect third-party Actions or dependency installs inside Docker builds
+(those use BuildKit secrets — see repository Dockerfiles).
+
+## Fork PRs / missing secret
+
+Graphiti is a public repository. Fork pull requests do not receive repository
+secrets. When `socket-api-key` is empty, this action **soft-skips**: it prints a
+notice, sets `SOCKET_FIREWALL_ENABLED=false`, and leaves package managers
+unwrapped so CI still succeeds. Same-repo runs with `SOCKET_API_KEY` configured
+get full enforcement.
+
+## API key scopes
+
+`SOCKET_API_KEY` should include the Socket scopes required for Enterprise
+wrapper mode (`packages` and `entitlements:list`). Configure it as a repository
+Actions secret and in the `development` / `release` environments used by CI.
+
+## Docker builds
+
+Official release workflows pass `socket_api_key` as a BuildKit secret so image
+dependency fetches go through `sfw`. They also set the non-secret
+`SOCKET_FIREWALL_ENABLED=true` build argument, which separates enforced release
+layers from public fallback layers in the BuildKit cache. In enforced mode, a
+missing or empty `socket_api_key` fails the build. Dockerfiles default the
+argument to `false` and install directly so community `docker build` / Compose
+usage continues to work without a Socket key.

--- a/.github/actions/setup-socket-firewall/README.md
+++ b/.github/actions/setup-socket-firewall/README.md
@@ -51,3 +51,22 @@ layers from public fallback layers in the BuildKit cache. In enforced mode, a
 missing or empty `socket_api_key` fails the build. Dockerfiles default the
 argument to `false` and install directly so community `docker build` / Compose
 usage continues to work without a Socket key.
+
+### Cache bypass on enforced builds
+
+`sfw` inspects network requests, so anything served from cache is never
+scanned. Two caches would otherwise hide dependencies from an enforced release
+build:
+
+- the **BuildKit layer cache**, which skips the install step entirely when its
+  inputs are unchanged
+- the **`uv` cache mount**, which lets `uv` resolve wheels from disk without
+  contacting PyPI even when the step does run
+
+Enforced builds defeat both. Release workflows pass
+`SOCKET_SCAN_ID=<run_id>-<run_attempt>`, which is unique per run and invalidates
+the install layer, and the enforced branch exports `UV_NO_CACHE=1`. Without
+these, an image whose dependencies had not changed could ship a package that
+Socket flagged after the layer was first built. Community builds leave
+`SOCKET_SCAN_ID` empty and keep both caches, so unauthenticated builds stay
+fast.

--- a/.github/actions/setup-socket-firewall/action.yml
+++ b/.github/actions/setup-socket-firewall/action.yml
@@ -1,0 +1,133 @@
+name: Setup Socket Firewall wrapper
+description: >
+  Installs Socket Firewall Enterprise wrapper mode and routes supported package
+  manager commands through sfw for subsequent bash steps. Soft-skips when no
+  API key is provided (fork PRs / public contributors).
+
+inputs:
+  socket-api-key:
+    description: >
+      Socket API key with packages and entitlements:list scopes. When empty
+      (typical for fork PRs), the action prints a notice and leaves package
+      managers unwrapped so the job still succeeds.
+    required: false
+    default: ''
+  sfw-download-url:
+    description: Download URL for the Linux sfw binary used by CI runners.
+    required: false
+    default: https://github.com/SocketDev/firewall-release/releases/latest/download/sfw-linux-x86_64
+
+runs:
+  using: composite
+  steps:
+    - name: Install sfw
+      shell: bash
+      env:
+        SFW_DOWNLOAD_URL: ${{ inputs['sfw-download-url'] }}
+        SOCKET_API_KEY_INPUT: ${{ inputs['socket-api-key'] }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "$SOCKET_API_KEY_INPUT" ]; then
+          echo "SOCKET_FIREWALL_ENABLED=false" >> "$GITHUB_ENV"
+          echo "::notice::Socket Firewall skipped: socket-api-key is empty (fork PR or missing secret)."
+          exit 0
+        fi
+
+        echo "SOCKET_FIREWALL_ENABLED=true" >> "$GITHUB_ENV"
+
+        if ! command -v sfw >/dev/null 2>&1; then
+          mkdir -p "$RUNNER_TEMP/socket-firewall"
+          curl -fsSL "$SFW_DOWNLOAD_URL" -o "$RUNNER_TEMP/socket-firewall/sfw"
+          chmod +x "$RUNNER_TEMP/socket-firewall/sfw"
+          echo "$RUNNER_TEMP/socket-firewall" >> "$GITHUB_PATH"
+        fi
+
+    - name: Export Socket Firewall environment
+      shell: bash
+      env:
+        SOCKET_API_KEY_INPUT: ${{ inputs['socket-api-key'] }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "$SOCKET_API_KEY_INPUT" ]; then
+          exit 0
+        fi
+
+        {
+          echo "SOCKET_API_KEY<<EOF"
+          echo "$SOCKET_API_KEY_INPUT"
+          echo "EOF"
+          echo "CARGO_NET_GIT_FETCH_WITH_CLI=true"
+          echo "SFW_TELEMETRY_DISABLED=true"
+        } >> "$GITHUB_ENV"
+        # Auxiliary hosts package managers contact that sfw doesn't treat as
+        # registries by default (wrap = TLS-terminated passthrough, no package
+        # inspection). Keep in sync with zep-proprietary setup-socket-firewall.
+        #   storage.googleapis.com   - Go module zips served via proxy.golang.org
+        #   classic.yarnpkg.com      - Yarn classic version-check / metadata host
+        #   files.pythonhosted.org   - Python package files served by PyPI
+        extra="wrap:storage.googleapis.com,wrap:classic.yarnpkg.com,wrap:files.pythonhosted.org"
+        if [ -n "${SFW_CUSTOM_REGISTRIES:-}" ]; then
+          echo "SFW_CUSTOM_REGISTRIES=${SFW_CUSTOM_REGISTRIES},${extra}" >> "$GITHUB_ENV"
+        else
+          echo "SFW_CUSTOM_REGISTRIES=${extra}" >> "$GITHUB_ENV"
+        fi
+
+    - name: Configure bash wrapper functions
+      shell: bash
+      env:
+        SOCKET_API_KEY_INPUT: ${{ inputs['socket-api-key'] }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "$SOCKET_API_KEY_INPUT" ]; then
+          exit 0
+        fi
+
+        mkdir -p "$RUNNER_TEMP/socket-firewall"
+        wrapper_file="$RUNNER_TEMP/socket-firewall/bash_env"
+        cat > "$wrapper_file" <<'EOF'
+        if command -v sfw >/dev/null 2>&1; then
+          npm() {
+            case "${1:-}" in
+              ci|install|i|add|update|view|pack) command sfw npm "$@" ;;
+              *) command npm "$@" ;;
+            esac
+          }
+          yarn() {
+            case "${1:-}" in
+              add|import|install|remove|upgrade|upgrade-interactive) command sfw yarn "$@" ;;
+              *) command yarn "$@" ;;
+            esac
+          }
+          pnpm() {
+            case "${1:-}" in
+              add|fetch|install|remove|update) command sfw pnpm "$@" ;;
+              *) command pnpm "$@" ;;
+            esac
+          }
+          pip() { command sfw pip "$@"; }
+          pip3() { command sfw pip3 "$@"; }
+          uv() {
+            case "${1:-}" in
+              add|build|export|lock|pip|remove|sync|tool) command sfw uv "$@" ;;
+              *) command uv "$@" ;;
+            esac
+          }
+          cargo() { command sfw cargo "$@"; }
+          go() {
+            case "${1:-}:${2:-}" in
+              get:*|install:*|mod:download|mod:tidy|work:sync) command sfw go "$@" ;;
+              *) command go "$@" ;;
+            esac
+          }
+          mvn() { command sfw mvn "$@"; }
+          gradle() { command sfw gradle "$@"; }
+          gem() { command sfw gem "$@"; }
+          bundle() { command sfw bundle "$@"; }
+          dotnet() { command sfw dotnet "$@"; }
+        fi
+        EOF
+
+        echo "BASH_ENV=$wrapper_file" >> "$GITHUB_ENV"

--- a/.github/workflows/mcp-server-tests.yml
+++ b/.github/workflows/mcp-server-tests.yml
@@ -34,6 +34,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup Socket Firewall wrapper
+        uses: ./.github/actions/setup-socket-firewall
+        with:
+          socket-api-key: ${{ secrets.SOCKET_API_KEY }}
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/.github/workflows/release-graphiti-core.yml
+++ b/.github/workflows/release-graphiti-core.yml
@@ -15,6 +15,10 @@ jobs:
       url: https://pypi.org/p/zep-cloud
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup Socket Firewall wrapper
+        uses: ./.github/actions/setup-socket-firewall
+        with:
+          socket-api-key: ${{ secrets.SOCKET_API_KEY }}
       - name: Set up Python 3.11
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -23,6 +27,10 @@ jobs:
         uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
         with:
           version: "latest"
+      # Resolve the project environment explicitly through the sfw wrapper.
+      # `uv run` below then uses the already-synced environment.
+      - name: Install dependencies
+        run: uv sync --frozen
       - name: Compare pyproject version with tag
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/}

--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -138,10 +138,15 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           build-args: |
+            SOCKET_FIREWALL_ENABLED=true
             MCP_SERVER_VERSION=${{ steps.version.outputs.version }}
             GRAPHITI_CORE_VERSION=${{ steps.graphiti.outputs.graphiti_version }}
             BUILD_DATE=${{ steps.meta.outputs.build_date }}
             VCS_REF=${{ steps.version.outputs.version }}
+          # Socket Firewall API key as a BuildKit secret (not a build-arg/ENV)
+          # so it is never baked into an image layer.
+          secrets: |
+            socket_api_key=${{ secrets.SOCKET_API_KEY }}
 
       - name: Create release summary
         run: |

--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -139,6 +139,7 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           build-args: |
             SOCKET_FIREWALL_ENABLED=true
+            SOCKET_SCAN_ID=${{ github.run_id }}-${{ github.run_attempt }}
             MCP_SERVER_VERSION=${{ steps.version.outputs.version }}
             GRAPHITI_CORE_VERSION=${{ steps.graphiti.outputs.graphiti_version }}
             BUILD_DATE=${{ steps.meta.outputs.build_date }}

--- a/.github/workflows/release-server-container.yml
+++ b/.github/workflows/release-server-container.yml
@@ -140,6 +140,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             SOCKET_FIREWALL_ENABLED=true
+            SOCKET_SCAN_ID=${{ github.run_id }}-${{ github.run_attempt }}
             GRAPHITI_VERSION=${{ steps.version.outputs.version }}
             BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             VCS_REF=${{ github.sha }}

--- a/.github/workflows/release-server-container.yml
+++ b/.github/workflows/release-server-container.yml
@@ -36,11 +36,6 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
-        with:
-          version: "latest"
-
       - name: Extract version
         id: version
         run: |
@@ -54,7 +49,7 @@ jobs:
 
             if [ -z "$VERSION" ]; then
               # Fallback: check pyproject.toml version
-              VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+              VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
               echo "Version from pyproject.toml: $VERSION"
             else
               echo "Version from git tag: $VERSION"
@@ -144,9 +139,14 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
+            SOCKET_FIREWALL_ENABLED=true
             GRAPHITI_VERSION=${{ steps.version.outputs.version }}
             BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             VCS_REF=${{ github.sha }}
+          # Socket Firewall API key as a BuildKit secret (not a build-arg/ENV)
+          # so it is never baked into an image layer.
+          secrets: |
+            socket_api_key=${{ secrets.SOCKET_API_KEY }}
 
       - name: Summary
         if: steps.version.outputs.skip != 'true'

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -36,6 +36,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup Socket Firewall wrapper
+        uses: ./.github/actions/setup-socket-firewall
+        with:
+          socket-api-key: ${{ secrets.SOCKET_API_KEY }}
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/.github/workflows/socket-firewall-connectivity.yml
+++ b/.github/workflows/socket-firewall-connectivity.yml
@@ -1,0 +1,138 @@
+name: Socket Firewall Wrapper Check
+
+# Validates that the local composite action can install Socket Firewall
+# Enterprise wrapper mode and that supported package-manager commands are
+# routed through sfw in subsequent bash steps. Also verifies the conditional
+# Docker BuildKit-secret path (enforce when present, fallback when absent).
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/setup-socket-firewall/**"
+      - "**/Dockerfile"
+      - "**/Dockerfile.*"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/setup-socket-firewall/**"
+      - "**/Dockerfile"
+      - "**/Dockerfile.*"
+
+permissions:
+  contents: read
+
+jobs:
+  connectivity:
+    # Fork PRs do not receive SOCKET_API_KEY; skip rather than soft-skip so the
+    # smoke assertions (which require sfw routing) are not vacuously skipped.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: depot-ubuntu-22.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Socket Firewall wrapper
+        uses: ./.github/actions/setup-socket-firewall
+        with:
+          socket-api-key: ${{ secrets.SOCKET_API_KEY }}
+
+      - name: Require Socket Firewall to be enabled
+        run: |
+          set -euo pipefail
+          if [ "${SOCKET_FIREWALL_ENABLED:-}" != "true" ]; then
+            echo "::error::SOCKET_API_KEY missing; cannot validate wrapper routing on a same-repo run."
+            exit 1
+          fi
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+        with:
+          version: "latest"
+
+      - name: Check uv is routed through sfw
+        run: |
+          set -euo pipefail
+          type uv
+          type uv | grep -F 'sfw uv'
+
+      - name: Prove a real install is brokered by sfw
+        run: |
+          set -euo pipefail
+          work="$(mktemp -d)"
+          # The BASH_ENV wrapper rewrites `uv pip` to `sfw uv pip`, so a
+          # successful install here proves sfw actually brokered the package
+          # download — not merely that the wrapper function is defined.
+          uv pip install --system --target "$work" \
+            --python-platform x86_64-manylinux_2_28 six==1.17.0
+          test -f "$work/six.py"
+
+  docker-guard:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: depot-ubuntu-22.04
+    steps:
+      - name: Verify conditional Socket Firewall Docker install paths
+        env:
+          SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${SOCKET_API_KEY:-}" ]; then
+            echo "::error::SOCKET_API_KEY missing; cannot validate Docker sfw paths on a same-repo run."
+            exit 1
+          fi
+
+          work="$(mktemp -d)"
+          cat > "$work/Dockerfile" <<'EOF'
+          # syntax=docker/dockerfile:1.9
+          FROM python:3.12-slim
+          RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+              && rm -rf /var/lib/apt/lists/*
+          ARG TARGETARCH
+          RUN set -eux; \
+              case "${TARGETARCH:-amd64}" in \
+                amd64) SFW_ARCH=x86_64 ;; \
+                arm64) SFW_ARCH=arm64 ;; \
+                *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+              esac; \
+              curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+                "https://github.com/SocketDev/firewall-release/releases/latest/download/sfw-linux-${SFW_ARCH}" \
+                -o /usr/local/bin/sfw; \
+              chmod +x /usr/local/bin/sfw
+          ADD https://astral.sh/uv/install.sh /uv-installer.sh
+          RUN sh /uv-installer.sh && rm /uv-installer.sh
+          ENV PATH="/root/.local/bin:$PATH"
+          ARG SOCKET_FIREWALL_ENABLED=false
+          # Mirrors Graphiti's conditional enforcement: sfw when secret present,
+          # direct install when absent (public OSS builds).
+          RUN --mount=type=secret,id=socket_api_key \
+              set -eu; \
+              export SFW_TELEMETRY_DISABLED=true; \
+              export SFW_CUSTOM_REGISTRIES="wrap:files.pythonhosted.org"; \
+              if [ "$SOCKET_FIREWALL_ENABLED" = "true" ]; then \
+                if [ ! -s /run/secrets/socket_api_key ]; then \
+                  echo "ERROR: SOCKET_FIREWALL_ENABLED=true but socket_api_key is missing" >&2; \
+                  exit 1; \
+                fi; \
+                export SOCKET_API_KEY="$(cat /run/secrets/socket_api_key)"; \
+                sfw uv pip install --system six==1.17.0; \
+              else \
+                echo "socket_api_key absent; installing without Socket Firewall"; \
+                uv pip install --system six==1.17.0; \
+              fi
+          EOF
+
+          # --no-cache on both: a secret mount's cache key does not depend on
+          # whether the secret was supplied, so without it the second build
+          # could reuse the first's cached layer.
+          echo "== WITH the secret: build must succeed via sfw =="
+          DOCKER_BUILDKIT=1 docker build --no-cache \
+            --build-arg SOCKET_FIREWALL_ENABLED=true \
+            --secret id=socket_api_key,env=SOCKET_API_KEY \
+            -t sfw-guard-ok "$work"
+
+          echo "== WITHOUT the secret: public fallback must still succeed =="
+          DOCKER_BUILDKIT=1 docker build --no-cache \
+            -t sfw-guard-fallback "$work"
+
+          echo "Conditional Socket Firewall Docker paths verified in both directions"

--- a/.github/workflows/socket-firewall-connectivity.yml
+++ b/.github/workflows/socket-firewall-connectivity.yml
@@ -82,7 +82,9 @@ jobs:
             exit 1
           fi
 
-          work="$(mktemp -d)"
+          # Stable path so the cache-bust step below reuses this exact context.
+          work="$RUNNER_TEMP/sfw-guard"
+          mkdir -p "$work"
           cat > "$work/Dockerfile" <<'EOF'
           # syntax=docker/dockerfile:1.9
           FROM python:3.12-slim
@@ -103,9 +105,12 @@ jobs:
           RUN sh /uv-installer.sh && rm /uv-installer.sh
           ENV PATH="/root/.local/bin:$PATH"
           ARG SOCKET_FIREWALL_ENABLED=false
+          ARG SOCKET_SCAN_ID=
           # Mirrors Graphiti's conditional enforcement: sfw when secret present,
-          # direct install when absent (public OSS builds).
-          RUN --mount=type=secret,id=socket_api_key \
+          # direct install when absent (public OSS builds). SOCKET_SCAN_ID and
+          # UV_NO_CACHE mirror the release cache-bypass so sfw sees every fetch.
+          RUN --mount=type=cache,target=/root/.cache/uv \
+              --mount=type=secret,id=socket_api_key \
               set -eu; \
               export SFW_TELEMETRY_DISABLED=true; \
               export SFW_CUSTOM_REGISTRIES="wrap:files.pythonhosted.org"; \
@@ -115,11 +120,14 @@ jobs:
                   exit 1; \
                 fi; \
                 export SOCKET_API_KEY="$(cat /run/secrets/socket_api_key)"; \
+                export UV_NO_CACHE=1; \
+                echo "Socket Firewall enforced (scan id: ${SOCKET_SCAN_ID})"; \
                 sfw uv pip install --system six==1.17.0; \
               else \
                 echo "socket_api_key absent; installing without Socket Firewall"; \
                 uv pip install --system six==1.17.0; \
-              fi
+              fi; \
+              date +%s%N > /socket-scan-stamp
           EOF
 
           # --no-cache on both: a secret mount's cache key does not depend on
@@ -136,3 +144,43 @@ jobs:
             -t sfw-guard-fallback "$work"
 
           echo "Conditional Socket Firewall Docker paths verified in both directions"
+
+      - name: Verify a new scan id defeats the layer cache
+        env:
+          SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }}
+        run: |
+          set -euo pipefail
+          work="$RUNNER_TEMP/sfw-guard"
+
+          # Deliberately no --no-cache here: the point is to prove that changing
+          # SOCKET_SCAN_ID alone re-runs the install layer. If it did not, a
+          # release could reuse a layer built before a package was flagged.
+          build() {
+            DOCKER_BUILDKIT=1 docker build \
+              --build-arg SOCKET_FIREWALL_ENABLED=true \
+              --build-arg "SOCKET_SCAN_ID=$1" \
+              --secret id=socket_api_key,env=SOCKET_API_KEY \
+              -t "sfw-cachebust:$1" "$work"
+          }
+
+          # Compare a stamp written during the install layer rather than reading
+          # the build log: BuildKit echoes the instruction text even for CACHED
+          # steps, so grepping the log would pass whether or not it re-ran.
+          stamp() { docker run --rm "sfw-cachebust:$1" cat /socket-scan-stamp; }
+
+          build scan-a; first="$(stamp scan-a)"
+          build scan-a; repeat="$(stamp scan-a)"
+          build scan-b; changed="$(stamp scan-b)"
+
+          # Positive control: without it, a build that never caches would make
+          # the assertion below pass vacuously.
+          if [ "$first" != "$repeat" ]; then
+            echo "::error::install layer re-ran for an unchanged SOCKET_SCAN_ID; the cache-bust test proves nothing."
+            exit 1
+          fi
+
+          if [ "$first" = "$changed" ]; then
+            echo "::error::install layer was served from cache despite a new SOCKET_SCAN_ID; sfw would not have seen these downloads."
+            exit 1
+          fi
+          echo "Changing SOCKET_SCAN_ID re-runs the sfw-brokered install layer"

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -15,6 +15,10 @@ jobs:
     environment: development
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup Socket Firewall wrapper
+        uses: ./.github/actions/setup-socket-firewall
+        with:
+          socket-api-key: ${{ secrets.SOCKET_API_KEY }}
       - name: Set up Python
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: depot-ubuntu-22.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup Socket Firewall wrapper
+        uses: ./.github/actions/setup-socket-firewall
+        with:
+          socket-api-key: ${{ secrets.SOCKET_API_KEY }}
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -48,6 +52,10 @@ jobs:
     runs-on: depot-ubuntu-22.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup Socket Firewall wrapper
+        uses: ./.github/actions/setup-socket-firewall
+        with:
+          socket-api-key: ${{ secrets.SOCKET_API_KEY }}
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,14 @@ COPY ./server/graph_service ./graph_service
 # This prevents the stale lockfile from pinning an old graphiti-core version
 # When socket_api_key is mounted (official releases), route through sfw;
 # otherwise install directly so public docker builds keep working.
+#
+# sfw can only inspect packages that are actually downloaded, so an enforced
+# build must defeat both caches or a newly flagged package would ship unscanned:
+# SOCKET_SCAN_ID (unique per release run) invalidates this layer, and
+# UV_NO_CACHE stops uv serving wheels from the cache mount below.
 ARG INSTALL_FALKORDB=false
 ARG SOCKET_FIREWALL_ENABLED=false
+ARG SOCKET_SCAN_ID=
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=secret,id=socket_api_key \
     set -eu; \
@@ -73,6 +79,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         exit 1; \
       fi; \
       export SOCKET_API_KEY="$(cat /run/secrets/socket_api_key)"; \
+      export UV_NO_CACHE=1; \
+      echo "Socket Firewall enforced (scan id: ${SOCKET_SCAN_ID})"; \
       UV_CMD="sfw uv"; \
     else \
       echo "socket_api_key absent; installing without Socket Firewall"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,21 @@ ADD https://astral.sh/uv/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh
 ENV PATH="/root/.local/bin:$PATH"
 
+# Install Socket Firewall (sfw) for dependency fetches when SOCKET_API_KEY is
+# provided as a BuildKit secret. Community builds without the secret fall back
+# to direct installs (see the RUN --mount below).
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+      amd64) SFW_ARCH=x86_64 ;; \
+      arm64) SFW_ARCH=arm64 ;; \
+      *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+      "https://github.com/SocketDev/firewall-release/releases/latest/download/sfw-linux-${SFW_ARCH}" \
+      -o /usr/local/bin/sfw; \
+    chmod +x /usr/local/bin/sfw
+
 # Configure uv for runtime
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
@@ -43,20 +58,38 @@ COPY ./server/graph_service ./graph_service
 # Install server dependencies (without graphiti-core from lockfile)
 # Then install graphiti-core from PyPI at the desired version
 # This prevents the stale lockfile from pinning an old graphiti-core version
+# When socket_api_key is mounted (official releases), route through sfw;
+# otherwise install directly so public docker builds keep working.
 ARG INSTALL_FALKORDB=false
+ARG SOCKET_FIREWALL_ENABLED=false
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev && \
+    --mount=type=secret,id=socket_api_key \
+    set -eu; \
+    export SFW_TELEMETRY_DISABLED=true; \
+    export SFW_CUSTOM_REGISTRIES="wrap:storage.googleapis.com,wrap:classic.yarnpkg.com,wrap:files.pythonhosted.org"; \
+    if [ "$SOCKET_FIREWALL_ENABLED" = "true" ]; then \
+      if [ ! -s /run/secrets/socket_api_key ]; then \
+        echo "ERROR: SOCKET_FIREWALL_ENABLED=true but socket_api_key is missing" >&2; \
+        exit 1; \
+      fi; \
+      export SOCKET_API_KEY="$(cat /run/secrets/socket_api_key)"; \
+      UV_CMD="sfw uv"; \
+    else \
+      echo "socket_api_key absent; installing without Socket Firewall"; \
+      UV_CMD="uv"; \
+    fi; \
+    $UV_CMD sync --frozen --no-dev; \
     if [ -n "$GRAPHITI_VERSION" ]; then \
         if [ "$INSTALL_FALKORDB" = "true" ]; then \
-            uv pip install --upgrade "graphiti-core[falkordb]==$GRAPHITI_VERSION"; \
+            $UV_CMD pip install --upgrade "graphiti-core[falkordb]==$GRAPHITI_VERSION"; \
         else \
-            uv pip install --upgrade "graphiti-core==$GRAPHITI_VERSION"; \
+            $UV_CMD pip install --upgrade "graphiti-core==$GRAPHITI_VERSION"; \
         fi; \
     else \
         if [ "$INSTALL_FALKORDB" = "true" ]; then \
-            uv pip install --upgrade "graphiti-core[falkordb]"; \
+            $UV_CMD pip install --upgrade "graphiti-core[falkordb]"; \
         else \
-            uv pip install --upgrade graphiti-core; \
+            $UV_CMD pip install --upgrade graphiti-core; \
         fi; \
     fi
 

--- a/mcp_server/docker/Dockerfile
+++ b/mcp_server/docker/Dockerfile
@@ -51,6 +51,9 @@ WORKDIR /app/mcp
 # Accept graphiti-core version as build argument
 ARG GRAPHITI_CORE_VERSION=0.29.1
 ARG SOCKET_FIREWALL_ENABLED=false
+# Unique per release run so enforced builds re-resolve and re-download instead
+# of reusing cached layers, which sfw would never see.
+ARG SOCKET_SCAN_ID=
 
 # Copy project files for dependency installation
 COPY pyproject.toml uv.lock ./
@@ -68,6 +71,8 @@ RUN --mount=type=secret,id=socket_api_key \
         exit 1; \
       fi; \
       export SOCKET_API_KEY="$(cat /run/secrets/socket_api_key)"; \
+      export UV_NO_CACHE=1; \
+      echo "Socket Firewall enforced (scan id: ${SOCKET_SCAN_ID})"; \
       UV_CMD="sfw uv"; \
     else \
       echo "socket_api_key absent; installing without Socket Firewall"; \
@@ -95,6 +100,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         exit 1; \
       fi; \
       export SOCKET_API_KEY="$(cat /run/secrets/socket_api_key)"; \
+      export UV_NO_CACHE=1; \
+      echo "Socket Firewall enforced (scan id: ${SOCKET_SCAN_ID})"; \
       UV_CMD="sfw uv"; \
     else \
       echo "socket_api_key absent; installing without Socket Firewall"; \

--- a/mcp_server/docker/Dockerfile
+++ b/mcp_server/docker/Dockerfile
@@ -23,6 +23,21 @@ RUN sh /uv-installer.sh && rm /uv-installer.sh
 # Add uv to PATH
 ENV PATH="/root/.local/bin:${PATH}"
 
+# Install Socket Firewall (sfw) for dependency fetches when SOCKET_API_KEY is
+# provided as a BuildKit secret. Community builds without the secret fall back
+# to direct installs.
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+      amd64) SFW_ARCH=x86_64 ;; \
+      arm64) SFW_ARCH=arm64 ;; \
+      *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+      "https://github.com/SocketDev/firewall-release/releases/latest/download/sfw-linux-${SFW_ARCH}" \
+      -o /usr/local/bin/sfw; \
+    chmod +x /usr/local/bin/sfw
+
 # Configure uv for optimal Docker usage
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
@@ -35,25 +50,57 @@ WORKDIR /app/mcp
 
 # Accept graphiti-core version as build argument
 ARG GRAPHITI_CORE_VERSION=0.29.1
+ARG SOCKET_FIREWALL_ENABLED=false
 
 # Copy project files for dependency installation
 COPY pyproject.toml uv.lock ./
 
 # Remove the local path override for graphiti-core in Docker builds
-# and regenerate lock file to match the PyPI version
-RUN sed -i '/\[tool\.uv\.sources\]/,/graphiti-core/d' pyproject.toml && \
+# and regenerate lock file to match the PyPI version.
+# When socket_api_key is mounted (official releases), route through sfw.
+RUN --mount=type=secret,id=socket_api_key \
+    set -eu; \
+    export SFW_TELEMETRY_DISABLED=true; \
+    export SFW_CUSTOM_REGISTRIES="wrap:storage.googleapis.com,wrap:classic.yarnpkg.com,wrap:files.pythonhosted.org"; \
+    if [ "$SOCKET_FIREWALL_ENABLED" = "true" ]; then \
+      if [ ! -s /run/secrets/socket_api_key ]; then \
+        echo "ERROR: SOCKET_FIREWALL_ENABLED=true but socket_api_key is missing" >&2; \
+        exit 1; \
+      fi; \
+      export SOCKET_API_KEY="$(cat /run/secrets/socket_api_key)"; \
+      UV_CMD="sfw uv"; \
+    else \
+      echo "socket_api_key absent; installing without Socket Firewall"; \
+      UV_CMD="uv"; \
+    fi; \
+    sed -i '/\[tool\.uv\.sources\]/,/graphiti-core/d' pyproject.toml; \
     if [ -n "${GRAPHITI_CORE_VERSION}" ]; then \
       sed -i "s/graphiti-core\[falkordb\][>=]\+[0-9]\+\.[0-9]\+\.[0-9]\+/graphiti-core[falkordb]==${GRAPHITI_CORE_VERSION}/" pyproject.toml; \
-    fi && \
-    echo "Regenerating lock file for PyPI graphiti-core..." && \
-    rm -f uv.lock && \
-    uv lock
+    fi; \
+    echo "Regenerating lock file for PyPI graphiti-core..."; \
+    rm -f uv.lock; \
+    $UV_CMD lock
 
 # Install Python dependencies (exclude dev dependency group)
 # Include optional provider extras so the image matches the providers
 # advertised by the MCP server configuration and docs.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --no-group dev --extra providers --extra azure
+    --mount=type=secret,id=socket_api_key \
+    set -eu; \
+    export SFW_TELEMETRY_DISABLED=true; \
+    export SFW_CUSTOM_REGISTRIES="wrap:storage.googleapis.com,wrap:classic.yarnpkg.com,wrap:files.pythonhosted.org"; \
+    if [ "$SOCKET_FIREWALL_ENABLED" = "true" ]; then \
+      if [ ! -s /run/secrets/socket_api_key ]; then \
+        echo "ERROR: SOCKET_FIREWALL_ENABLED=true but socket_api_key is missing" >&2; \
+        exit 1; \
+      fi; \
+      export SOCKET_API_KEY="$(cat /run/secrets/socket_api_key)"; \
+      UV_CMD="sfw uv"; \
+    else \
+      echo "socket_api_key absent; installing without Socket Firewall"; \
+      UV_CMD="uv"; \
+    fi; \
+    $UV_CMD sync --no-group dev --extra providers --extra azure
 
 # Store graphiti-core version
 RUN echo "${GRAPHITI_CORE_VERSION}" > /app/mcp/.graphiti-core-version

--- a/mcp_server/docker/Dockerfile.standalone
+++ b/mcp_server/docker/Dockerfile.standalone
@@ -45,6 +45,9 @@ WORKDIR /app/mcp
 # Accept graphiti-core version as build argument
 ARG GRAPHITI_CORE_VERSION=0.29.1
 ARG SOCKET_FIREWALL_ENABLED=false
+# Unique per release run so enforced builds re-resolve and re-download instead
+# of reusing cached layers, which sfw would never see.
+ARG SOCKET_SCAN_ID=
 
 # Copy project files for dependency installation
 COPY pyproject.toml uv.lock ./
@@ -63,6 +66,8 @@ RUN --mount=type=secret,id=socket_api_key \
         exit 1; \
       fi; \
       export SOCKET_API_KEY="$(cat /run/secrets/socket_api_key)"; \
+      export UV_NO_CACHE=1; \
+      echo "Socket Firewall enforced (scan id: ${SOCKET_SCAN_ID})"; \
       UV_CMD="sfw uv"; \
     else \
       echo "socket_api_key absent; installing without Socket Firewall"; \
@@ -88,6 +93,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         exit 1; \
       fi; \
       export SOCKET_API_KEY="$(cat /run/secrets/socket_api_key)"; \
+      export UV_NO_CACHE=1; \
+      echo "Socket Firewall enforced (scan id: ${SOCKET_SCAN_ID})"; \
       UV_CMD="sfw uv"; \
     else \
       echo "socket_api_key absent; installing without Socket Firewall"; \

--- a/mcp_server/docker/Dockerfile.standalone
+++ b/mcp_server/docker/Dockerfile.standalone
@@ -17,6 +17,21 @@ RUN sh /uv-installer.sh && rm /uv-installer.sh
 # Add uv to PATH
 ENV PATH="/root/.local/bin:${PATH}"
 
+# Install Socket Firewall (sfw) for dependency fetches when SOCKET_API_KEY is
+# provided as a BuildKit secret. Community builds without the secret fall back
+# to direct installs.
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+      amd64) SFW_ARCH=x86_64 ;; \
+      arm64) SFW_ARCH=arm64 ;; \
+      *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+      "https://github.com/SocketDev/firewall-release/releases/latest/download/sfw-linux-${SFW_ARCH}" \
+      -o /usr/local/bin/sfw; \
+    chmod +x /usr/local/bin/sfw
+
 # Configure uv for optimal Docker usage
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
@@ -29,24 +44,56 @@ WORKDIR /app/mcp
 
 # Accept graphiti-core version as build argument
 ARG GRAPHITI_CORE_VERSION=0.29.1
+ARG SOCKET_FIREWALL_ENABLED=false
 
 # Copy project files for dependency installation
 COPY pyproject.toml uv.lock ./
 
 # Remove the local path override for graphiti-core in Docker builds
 # Install with BOTH neo4j and falkordb extras for maximum flexibility
-# and regenerate lock file to match the PyPI version
-RUN sed -i '/\[tool\.uv\.sources\]/,/graphiti-core/d' pyproject.toml && \
-    sed -i "s/graphiti-core\[falkordb\][>=]\+[0-9]\+\.[0-9]\+\.[0-9]\+/graphiti-core[neo4j,falkordb]==${GRAPHITI_CORE_VERSION}/" pyproject.toml && \
-    echo "Regenerating lock file for PyPI graphiti-core..." && \
-    rm -f uv.lock && \
-    uv lock
+# and regenerate lock file to match the PyPI version.
+# When socket_api_key is mounted (official releases), route through sfw.
+RUN --mount=type=secret,id=socket_api_key \
+    set -eu; \
+    export SFW_TELEMETRY_DISABLED=true; \
+    export SFW_CUSTOM_REGISTRIES="wrap:storage.googleapis.com,wrap:classic.yarnpkg.com,wrap:files.pythonhosted.org"; \
+    if [ "$SOCKET_FIREWALL_ENABLED" = "true" ]; then \
+      if [ ! -s /run/secrets/socket_api_key ]; then \
+        echo "ERROR: SOCKET_FIREWALL_ENABLED=true but socket_api_key is missing" >&2; \
+        exit 1; \
+      fi; \
+      export SOCKET_API_KEY="$(cat /run/secrets/socket_api_key)"; \
+      UV_CMD="sfw uv"; \
+    else \
+      echo "socket_api_key absent; installing without Socket Firewall"; \
+      UV_CMD="uv"; \
+    fi; \
+    sed -i '/\[tool\.uv\.sources\]/,/graphiti-core/d' pyproject.toml; \
+    sed -i "s/graphiti-core\[falkordb\][>=]\+[0-9]\+\.[0-9]\+\.[0-9]\+/graphiti-core[neo4j,falkordb]==${GRAPHITI_CORE_VERSION}/" pyproject.toml; \
+    echo "Regenerating lock file for PyPI graphiti-core..."; \
+    rm -f uv.lock; \
+    $UV_CMD lock
 
 # Install Python dependencies (exclude dev dependency group)
 # Include optional provider extras so the image matches the providers
 # advertised by the MCP server configuration and docs.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --no-group dev --extra providers --extra azure
+    --mount=type=secret,id=socket_api_key \
+    set -eu; \
+    export SFW_TELEMETRY_DISABLED=true; \
+    export SFW_CUSTOM_REGISTRIES="wrap:storage.googleapis.com,wrap:classic.yarnpkg.com,wrap:files.pythonhosted.org"; \
+    if [ "$SOCKET_FIREWALL_ENABLED" = "true" ]; then \
+      if [ ! -s /run/secrets/socket_api_key ]; then \
+        echo "ERROR: SOCKET_FIREWALL_ENABLED=true but socket_api_key is missing" >&2; \
+        exit 1; \
+      fi; \
+      export SOCKET_API_KEY="$(cat /run/secrets/socket_api_key)"; \
+      UV_CMD="sfw uv"; \
+    else \
+      echo "socket_api_key absent; installing without Socket Firewall"; \
+      UV_CMD="uv"; \
+    fi; \
+    $UV_CMD sync --no-group dev --extra providers --extra azure
 
 # Store graphiti-core version
 RUN echo "${GRAPHITI_CORE_VERSION}" > /app/mcp/.graphiti-core-version


### PR DESCRIPTION
## Summary
- add a reusable Socket Firewall wrapper action and apply it to Python dependency installs in CI
- enforce Socket scanning in official server and MCP Docker image releases using BuildKit secrets
- preserve fork PRs and public Docker builds through explicit no-secret fallback paths
- add a connectivity workflow covering wrapper routing and enforced/fallback Docker behavior

## Motivation
Graphiti dependency downloads should use the same Socket policy enforcement as Zep's internal repositories without breaking outside contributors or public image builds that do not have access to Socket credentials.

## Impact
Same-repository CI and official release builds use `SOCKET_API_KEY`. Fork PRs soft-skip the wrapper, while Docker builds default to direct installs unless release workflows explicitly enable enforcement. The enforcement build argument separates public and release paths in the BuildKit cache.

## Testing
- [x] Parsed all modified workflow and action YAML
- [x] Ran `actionlint` on modified workflows
- [x] Ran Dockerfile static checks for all three images
- [x] Completed a root Docker build without a Socket secret
- [x] Verified enforced Docker mode rejects a missing secret
- [x] Verified the Python package-install command used by the connectivity check
- [ ] Confirm the connectivity workflow passes in GitHub Actions with the configured Socket secret

## Risks / follow-ups
`SOCKET_API_KEY` must remain configured as a repository secret and in the `development` and `release` environments. Fork PRs intentionally run without Socket enforcement because GitHub does not expose secrets to forks.

Made with [Cursor](https://cursor.com)