### PR TITLE
add opt-in fixed Falkor record routing

### DIFF
--- a/graphiti_core/decorators.py
+++ b/graphiti_core/decorators.py
@@ -60,7 +60,7 @@ def handle_multiple_group_ids(func: F) -> F:
         if is_falkor and group_ids and len(group_ids) == 1:
             gid = group_ids[0]
             driver = self.clients.driver
-            if gid != getattr(driver, '_database', None):
+            if driver.should_route_group_id_to_database(gid):
                 return await func(
                     self,
                     *args,
@@ -72,6 +72,11 @@ def handle_multiple_group_ids(func: F) -> F:
         if is_falkor and group_ids and len(group_ids) > 1:
             # Execute for each group_id concurrently
             driver = self.clients.driver
+            routed_group_ids = [
+                gid for gid in group_ids if driver.should_route_group_id_to_database(gid)
+            ]
+            if not routed_group_ids:
+                return await func(self, *args, **kwargs)
 
             async def execute_for_group(gid: str):
                 # Remove group_ids from args if it was passed positionally

--- a/graphiti_core/driver/driver.py
+++ b/graphiti_core/driver/driver.py
@@ -132,6 +132,10 @@ class GraphDriver(QueryExecutor, ABC):
         """Clone the driver with a different database or graph name."""
         return self
 
+    def should_route_group_id_to_database(self, group_id: str) -> bool:  # noqa: ARG002
+        """Return true when a group_id should select a physical database/graph."""
+        return False
+
     def build_fulltext_query(
         self, query: str, group_ids: list[str] | None = None, max_query_length: int = 128
     ) -> str:

--- a/graphiti_core/driver/falkordb/operations/community_edge_ops.py
+++ b/graphiti_core/driver/falkordb/operations/community_edge_ops.py
@@ -17,7 +17,10 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.falkordb.operations.group_routing import (
+    should_route_group_ids_to_databases,
+)
 from graphiti_core.driver.operations.community_edge_ops import CommunityEdgeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.edges import CommunityEdge
@@ -141,11 +144,7 @@ class FalkorCommunityEdgeOperations(CommunityEdgeOperations):
         # namespace/ops path receives the base driver (default_db), so a
         # single-group read must be cloned to the group's graph or it queries
         # an empty default database and returns nothing.
-        if (
-            isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
-            and group_ids
-        ):
+        if should_route_group_ids_to_databases(executor, group_ids):
             if len(group_ids) == 1:
                 executor = executor.clone(database=group_ids[0])
             else:

--- a/graphiti_core/driver/falkordb/operations/community_node_ops.py
+++ b/graphiti_core/driver/falkordb/operations/community_node_ops.py
@@ -17,7 +17,10 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.falkordb.operations.group_routing import (
+    should_route_group_ids_to_databases,
+)
 from graphiti_core.driver.operations.community_node_ops import CommunityNodeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.driver.record_parsers import community_node_from_record
@@ -163,11 +166,7 @@ class FalkorCommunityNodeOperations(CommunityNodeOperations):
         # namespace/ops path receives the base driver (default_db), so a
         # single-group read must be cloned to the group's graph or it queries
         # an empty default database and returns nothing.
-        if (
-            isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
-            and group_ids
-        ):
+        if should_route_group_ids_to_databases(executor, group_ids):
             if len(group_ids) == 1:
                 executor = executor.clone(database=group_ids[0])
             else:

--- a/graphiti_core/driver/falkordb/operations/entity_edge_ops.py
+++ b/graphiti_core/driver/falkordb/operations/entity_edge_ops.py
@@ -17,7 +17,10 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.falkordb.operations.group_routing import (
+    should_route_group_ids_to_databases,
+)
 from graphiti_core.driver.operations.entity_edge_ops import EntityEdgeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.driver.record_parsers import entity_edge_from_record
@@ -169,11 +172,7 @@ class FalkorEntityEdgeOperations(EntityEdgeOperations):
         # namespace/ops path receives the base driver (default_db), so a
         # single-group read must be cloned to the group's graph or it queries
         # an empty default database and returns nothing.
-        if (
-            isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
-            and group_ids
-        ):
+        if should_route_group_ids_to_databases(executor, group_ids):
             if len(group_ids) == 1:
                 executor = executor.clone(database=group_ids[0])
             else:

--- a/graphiti_core/driver/falkordb/operations/entity_node_ops.py
+++ b/graphiti_core/driver/falkordb/operations/entity_node_ops.py
@@ -17,7 +17,10 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.falkordb.operations.group_routing import (
+    should_route_group_ids_to_databases,
+)
 from graphiti_core.driver.operations.entity_node_ops import EntityNodeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.driver.record_parsers import entity_node_from_record
@@ -184,11 +187,7 @@ class FalkorEntityNodeOperations(EntityNodeOperations):
         # namespace/ops path receives the base driver (default_db), so a
         # single-group read must be cloned to the group's graph or it queries
         # an empty default database and returns nothing.
-        if (
-            isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
-            and group_ids
-        ):
+        if should_route_group_ids_to_databases(executor, group_ids):
             if len(group_ids) == 1:
                 executor = executor.clone(database=group_ids[0])
             else:

--- a/graphiti_core/driver/falkordb/operations/episode_node_ops.py
+++ b/graphiti_core/driver/falkordb/operations/episode_node_ops.py
@@ -18,7 +18,10 @@ import logging
 from datetime import datetime
 from typing import Any
 
-from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.falkordb.operations.group_routing import (
+    should_route_group_ids_to_databases,
+)
 from graphiti_core.driver.operations.episode_node_ops import EpisodeNodeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.driver.record_parsers import episodic_node_from_record
@@ -178,11 +181,7 @@ class FalkorEpisodeNodeOperations(EpisodeNodeOperations):
         # namespace/ops path receives the base driver (default_db), so a
         # single-group read must be cloned to the group's graph or it queries
         # an empty default database and returns nothing.
-        if (
-            isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
-            and group_ids
-        ):
+        if should_route_group_ids_to_databases(executor, group_ids):
             if len(group_ids) == 1:
                 executor = executor.clone(database=group_ids[0])
             else:

--- a/graphiti_core/driver/falkordb/operations/episodic_edge_ops.py
+++ b/graphiti_core/driver/falkordb/operations/episodic_edge_ops.py
@@ -17,7 +17,10 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.falkordb.operations.group_routing import (
+    should_route_group_ids_to_databases,
+)
 from graphiti_core.driver.operations.episodic_edge_ops import EpisodicEdgeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.edges import EpisodicEdge
@@ -155,11 +158,7 @@ class FalkorEpisodicEdgeOperations(EpisodicEdgeOperations):
         # namespace/ops path receives the base driver (default_db), so a
         # single-group read must be cloned to the group's graph or it queries
         # an empty default database and returns nothing.
-        if (
-            isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
-            and group_ids
-        ):
+        if should_route_group_ids_to_databases(executor, group_ids):
             if len(group_ids) == 1:
                 executor = executor.clone(database=group_ids[0])
             else:

--- a/graphiti_core/driver/falkordb/operations/group_routing.py
+++ b/graphiti_core/driver/falkordb/operations/group_routing.py
@@ -1,0 +1,31 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import TypeGuard
+
+from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.driver.query_executor import QueryExecutor
+
+
+def should_route_group_ids_to_databases(
+    executor: QueryExecutor,
+    group_ids: list[str] | None,
+) -> TypeGuard[GraphDriver]:
+    if not isinstance(executor, GraphDriver):
+        return False
+    if executor.provider != GraphProvider.FALKORDB or not group_ids:
+        return False
+    return any(executor.should_route_group_id_to_database(group_id) for group_id in group_ids)

--- a/graphiti_core/driver/falkordb/operations/has_episode_edge_ops.py
+++ b/graphiti_core/driver/falkordb/operations/has_episode_edge_ops.py
@@ -17,7 +17,9 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.driver.falkordb.operations.group_routing import (
+    should_route_group_ids_to_databases,
+)
 from graphiti_core.driver.operations.has_episode_edge_ops import HasEpisodeEdgeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.edges import HasEpisodeEdge
@@ -150,11 +152,7 @@ class FalkorHasEpisodeEdgeOperations(HasEpisodeEdgeOperations):
         # namespace/ops path receives the base driver (default_db), so a
         # single-group read must be cloned to the group's graph or it queries
         # an empty default database and returns nothing.
-        if (
-            isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
-            and group_ids
-        ):
+        if should_route_group_ids_to_databases(executor, group_ids):
             if len(group_ids) == 1:
                 executor = executor.clone(database=group_ids[0])
             else:

--- a/graphiti_core/driver/falkordb/operations/next_episode_edge_ops.py
+++ b/graphiti_core/driver/falkordb/operations/next_episode_edge_ops.py
@@ -17,7 +17,9 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.driver.falkordb.operations.group_routing import (
+    should_route_group_ids_to_databases,
+)
 from graphiti_core.driver.operations.next_episode_edge_ops import NextEpisodeEdgeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.edges import NextEpisodeEdge
@@ -150,11 +152,7 @@ class FalkorNextEpisodeEdgeOperations(NextEpisodeEdgeOperations):
         # namespace/ops path receives the base driver (default_db), so a
         # single-group read must be cloned to the group's graph or it queries
         # an empty default database and returns nothing.
-        if (
-            isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
-            and group_ids
-        ):
+        if should_route_group_ids_to_databases(executor, group_ids):
             if len(group_ids) == 1:
                 executor = executor.clone(database=group_ids[0])
             else:

--- a/graphiti_core/driver/falkordb/operations/saga_node_ops.py
+++ b/graphiti_core/driver/falkordb/operations/saga_node_ops.py
@@ -17,7 +17,10 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.falkordb.operations.group_routing import (
+    should_route_group_ids_to_databases,
+)
 from graphiti_core.driver.operations.saga_node_ops import SagaNodeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.errors import NodeNotFoundError
@@ -163,11 +166,7 @@ class FalkorSagaNodeOperations(SagaNodeOperations):
         # namespace/ops path receives the base driver (default_db), so a
         # single-group read must be cloned to the group's graph or it queries
         # an empty default database and returns nothing.
-        if (
-            isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
-            and group_ids
-        ):
+        if should_route_group_ids_to_databases(executor, group_ids):
             if len(group_ids) == 1:
                 executor = executor.clone(database=group_ids[0])
             else:

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -136,6 +136,7 @@ class FalkorDriver(GraphDriver):
         password: str | None = None,
         falkor_db: FalkorDB | None = None,
         database: str = 'default_db',
+        group_routing: str = 'database',
     ):
         """
         Initialize the FalkorDB driver.
@@ -151,9 +152,15 @@ class FalkorDriver(GraphDriver):
         password (str | None): The password for authentication (if required).
         falkor_db (FalkorDB | None): An existing FalkorDB instance to use instead of creating a new one.
         database (str): The name of the database to connect to. Defaults to 'default_db'.
+        group_routing (str): How FalkorDB maps group_id values. ``database`` preserves
+            the upstream graph-per-group behavior. ``record`` keeps the configured
+            database fixed and treats group_id as a record-level scope.
         """
         super().__init__()
+        if group_routing not in {'database', 'record'}:
+            raise ValueError("group_routing must be either 'database' or 'record'")
         self._database = database
+        self.group_routing = group_routing
         if falkor_db is not None:
             # If a FalkorDB instance is provided, use it directly
             self.client = falkor_db
@@ -328,12 +335,19 @@ class FalkorDriver(GraphDriver):
         if database == self._database:
             cloned = self
         elif database == self.default_group_id:
-            cloned = FalkorDriver(falkor_db=self.client)
+            cloned = FalkorDriver(falkor_db=self.client, group_routing=self.group_routing)
         else:
             # Create a new instance of FalkorDriver with the same connection but a different database
-            cloned = FalkorDriver(falkor_db=self.client, database=database)
+            cloned = FalkorDriver(
+                falkor_db=self.client,
+                database=database,
+                group_routing=self.group_routing,
+            )
 
         return cloned
+
+    def should_route_group_id_to_database(self, group_id: str) -> bool:
+        return self.group_routing == 'database' and group_id != self._database
 
     async def health_check(self) -> None:
         """Check FalkorDB connectivity by running a simple query."""

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -311,6 +311,17 @@ class Graphiti:
         else:
             return 'unknown'
 
+    def _resolve_group_id_for_write(self, group_id: str | None) -> str:
+        if group_id is None:
+            return get_default_group_id(self.driver.provider)
+
+        validate_group_id(group_id)
+        if self.driver.should_route_group_id_to_database(group_id):
+            self.driver = self.driver.clone(database=group_id)
+            self.clients.driver = self.driver
+
+        return group_id
+
     async def close(self):
         """
         Close the connection to the Neo4j database.
@@ -1070,16 +1081,7 @@ class Graphiti:
         validate_entity_types(entity_types)
         validate_excluded_entity_types(excluded_entity_types, entity_types)
 
-        if group_id is None:
-            # if group_id is None, use the default group id by the provider
-            # and the preset database name will be used
-            group_id = get_default_group_id(self.driver.provider)
-        else:
-            validate_group_id(group_id)
-            if group_id != self.driver._database:
-                # if group_id is provided, use it as the database name
-                self.driver = self.driver.clone(database=group_id)
-                self.clients.driver = self.driver
+        group_id = self._resolve_group_id_for_write(group_id)
 
         with self.tracer.start_span('add_episode') as span:
             try:
@@ -1299,15 +1301,7 @@ class Graphiti:
                 start = time()
                 now = utc_now()
 
-                # if group_id is None, use the default group id by the provider
-                if group_id is None:
-                    group_id = get_default_group_id(self.driver.provider)
-                else:
-                    validate_group_id(group_id)
-                    if group_id != self.driver._database:
-                        # if group_id is provided, use it as the database name
-                        self.driver = self.driver.clone(database=group_id)
-                        self.clients.driver = self.driver
+                group_id = self._resolve_group_id_for_write(group_id)
 
                 # Create default edge type map
                 edge_type_map_default = (

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -324,12 +324,40 @@ Or use the FalkorDB configuration file:
 uv run main.py --config config/config-docker-falkordb.yaml
 ```
 
+#### FalkorDB Group Routing
+
+By default, FalkorDB keeps the existing Graphiti behavior: a non-default
+`group_id` selects a physical Falkor graph with the same name. For deployments
+that already use one shared Falkor graph and want project or tenant isolation by
+record property, opt in to fixed-graph routing:
+
+```yaml
+database:
+  providers:
+    falkordb:
+      database: graphiti_personal
+      group_routing: record
+```
+
+With `group_routing: record`, episode writes, searches, retrievals, and
+group-scoped cleanup stay inside the configured Falkor graph and continue to use
+`group_id` as the record-level scope/filter. The default `group_routing:
+database` remains graph-per-group for upstream compatibility.
+
+Equivalent direct run:
+
+```bash
+FALKORDB_DATABASE=graphiti_personal FALKORDB_GROUP_ROUTING=record \
+  uv run main.py --database-provider falkordb --falkordb-group-routing record
+```
+
 ### Available Command-Line Arguments
 
 - `--config`: Path to YAML configuration file (default: config.yaml)
 - `--llm-provider`: LLM provider to use (openai, anthropic, gemini, groq, azure_openai)
 - `--embedder-provider`: Embedder provider to use (openai, azure_openai, gemini, voyage)
 - `--database-provider`: Database provider to use (falkordb, neo4j) - default: falkordb
+- `--falkordb-group-routing`: FalkorDB group routing mode (`database` or `record`) - default: database
 - `--model`: Model name to use with the LLM client
 - `--temperature`: Temperature setting for the LLM (0.0-2.0)
 - `--transport`: Choose the transport method (http or stdio, default: http)

--- a/mcp_server/config/config-docker-falkordb.yaml
+++ b/mcp_server/config/config-docker-falkordb.yaml
@@ -75,6 +75,7 @@ database:
       uri: ${FALKORDB_URI:redis://falkordb:6379}
       password: ${FALKORDB_PASSWORD:}
       database: ${FALKORDB_DATABASE:default_db}
+      group_routing: ${FALKORDB_GROUP_ROUTING:database}
 
 graphiti:
   group_id: ${GRAPHITI_GROUP_ID:main}

--- a/mcp_server/config/config.yaml
+++ b/mcp_server/config/config.yaml
@@ -78,6 +78,7 @@ database:
       uri: ${FALKORDB_URI:redis://localhost:6379}
       password: ${FALKORDB_PASSWORD:}
       database: ${FALKORDB_DATABASE:default_db}
+      group_routing: ${FALKORDB_GROUP_ROUTING:database}
 
     neo4j:
       uri: ${NEO4J_URI:bolt://localhost:7687}

--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, Field
@@ -190,6 +190,13 @@ class FalkorDBProviderConfig(BaseModel):
     username: str | None = None
     password: str | None = None
     database: str = 'default_db'
+    group_routing: Literal['database', 'record'] = Field(
+        default='database',
+        description=(
+            'FalkorDB group routing mode: database maps each group_id to its own graph; '
+            'record keeps database fixed and filters records by group_id.'
+        ),
+    )
 
 
 class DatabaseProvidersConfig(BaseModel):
@@ -324,6 +331,10 @@ class GraphitiConfig(BaseSettings):
         # Override database settings
         if hasattr(args, 'database_provider') and args.database_provider:
             self.database.provider = args.database_provider
+        if hasattr(args, 'falkordb_group_routing') and args.falkordb_group_routing:
+            if self.database.providers.falkordb is None:
+                self.database.providers.falkordb = FalkorDBProviderConfig()
+            self.database.providers.falkordb.group_routing = args.falkordb_group_routing
 
         # Override Graphiti settings
         if hasattr(args, 'group_id') and args.group_id:

--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -235,6 +235,7 @@ class GraphitiService:
                         username=db_config.get('username'),
                         password=db_config['password'],
                         database=db_config['database'],
+                        group_routing=db_config['group_routing'],
                     )
 
                     self.client = Graphiti(
@@ -1132,6 +1133,14 @@ async def initialize_server() -> ServerConfig:
         '--database-provider',
         choices=['neo4j', 'falkordb'],
         help='Database provider to use',
+    )
+    parser.add_argument(
+        '--falkordb-group-routing',
+        choices=['database', 'record'],
+        help=(
+            'FalkorDB group routing mode. database maps each group_id to its own graph; '
+            'record keeps the configured Falkor graph fixed and filters by group_id.'
+        ),
     )
 
     # LLM configuration arguments

--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -479,6 +479,7 @@ class DatabaseDriverFactory:
                     'username': username,
                     'password': password,
                     'database': falkor_config.database,
+                    'group_routing': falkor_config.group_routing,
                 }
 
             case _:

--- a/mcp_server/tests/test_configuration.py
+++ b/mcp_server/tests/test_configuration.py
@@ -161,6 +161,7 @@ def test_cli_override():
         embedder_provider = 'voyage'
         embedder_model = 'voyage-3'
         database_provider = 'falkordb'
+        falkordb_group_routing = 'record'
         group_id = 'test-group'
         user_id = 'test-user'
 
@@ -169,6 +170,10 @@ def test_cli_override():
 
     assert config.server.host == '127.0.0.1', f'Expected host 127.0.0.1, got {config.server.host}'
     assert config.server.port == 9999, f'Expected port 9999, got {config.server.port}'
+    assert config.database.providers.falkordb is not None, (
+        'Expected FalkorDB provider config to exist'
+    )
+    assert config.database.providers.falkordb.group_routing == 'record'
 
     print('✓ CLI overrides applied successfully')
     print(f'  - Transport: {config.server.transport}')
@@ -194,6 +199,7 @@ def test_cli_override():
         embedder_provider = None
         embedder_model = None
         database_provider = None
+        falkordb_group_routing = None
         group_id = None
         user_id = None
 

--- a/mcp_server/tests/test_falkordb_config.py
+++ b/mcp_server/tests/test_falkordb_config.py
@@ -24,6 +24,7 @@ def test_falkordb_config_preserves_uri_username(monkeypatch):
     assert db_config['username'] == 'falkordb'
     assert db_config['password'] is None
     assert db_config['database'] == 'cloud-db'
+    assert db_config['group_routing'] == 'database'
 
 
 def test_falkordb_username_env_overrides_uri(monkeypatch):
@@ -42,3 +43,24 @@ def test_falkordb_username_env_overrides_uri(monkeypatch):
     assert db_config['port'] == 6380
     assert db_config['username'] == 'env-user'
     assert db_config['password'] == 'env-secret'
+
+
+def test_falkordb_config_supports_record_group_routing(monkeypatch):
+    monkeypatch.delenv('FALKORDB_URI', raising=False)
+    monkeypatch.delenv('FALKORDB_USERNAME', raising=False)
+    monkeypatch.delenv('FALKORDB_PASSWORD', raising=False)
+
+    config = DatabaseConfig(
+        provider='falkordb',
+        providers=DatabaseProvidersConfig(
+            falkordb=FalkorDBProviderConfig(
+                database='graphiti_personal',
+                group_routing='record',
+            )
+        ),
+    )
+
+    db_config = DatabaseDriverFactory.create_config(config)
+
+    assert db_config['database'] == 'graphiti_personal'
+    assert db_config['group_routing'] == 'record'

--- a/tests/test_fixed_falkor_tenant_scope.py
+++ b/tests/test_fixed_falkor_tenant_scope.py
@@ -1,0 +1,100 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.falkordb.operations.graph_ops import FalkorGraphMaintenanceOperations
+from graphiti_core.graphiti import Graphiti
+from graphiti_core.utils.maintenance.graph_data_operations import clear_data
+
+
+class _FakeFalkorDriver:
+    provider = GraphProvider.FALKORDB
+    graph_operations_interface = FalkorGraphMaintenanceOperations()
+
+    def __init__(self, database: str, group_routing: str = 'database'):
+        self._database = database
+        self.group_routing = group_routing
+        self.clone_calls: list[str] = []
+        self.queries: list[tuple[str, dict]] = []
+
+    def clone(self, database: str) -> '_FakeFalkorDriver':
+        self.clone_calls.append(database)
+        return _FakeFalkorDriver(database, self.group_routing)
+
+    def should_route_group_id_to_database(self, group_id: str) -> bool:
+        return self.group_routing == 'database' and group_id != self._database
+
+    async def execute_query(self, query: str, **kwargs):
+        self.queries.append((query, kwargs))
+        return [], [], None
+
+
+def _graphiti_with_driver(driver: _FakeFalkorDriver) -> Graphiti:
+    graphiti = Graphiti.__new__(Graphiti)
+    graphiti.driver = driver
+    graphiti.clients = SimpleNamespace(driver=driver)
+    return graphiti
+
+
+def test_record_group_routing_keeps_episode_write_on_fixed_falkor_graph():
+    driver = _FakeFalkorDriver(
+        'graphiti_personal',
+        group_routing='record',
+    )
+    graphiti = _graphiti_with_driver(driver)
+
+    group_id = graphiti._resolve_group_id_for_write('harmony-cloud-shared-brain')
+
+    assert group_id == 'harmony-cloud-shared-brain'
+    assert graphiti.driver is driver
+    assert graphiti.clients.driver is driver
+    assert driver.clone_calls == []
+
+
+def test_default_group_routing_preserves_episode_write_graph_per_group():
+    driver = _FakeFalkorDriver(
+        'graphiti_personal',
+        group_routing='database',
+    )
+    graphiti = _graphiti_with_driver(driver)
+
+    group_id = graphiti._resolve_group_id_for_write('harmony-cloud-shared-brain')
+
+    assert group_id == 'harmony-cloud-shared-brain'
+    assert driver.clone_calls == ['harmony-cloud-shared-brain']
+    assert graphiti.driver._database == 'harmony-cloud-shared-brain'
+    assert graphiti.clients.driver is graphiti.driver
+
+
+@pytest.mark.asyncio
+async def test_record_group_routing_clears_only_scoped_records_without_cloning():
+    driver = _FakeFalkorDriver(
+        'graphiti_personal',
+        group_routing='record',
+    )
+
+    await clear_data(driver, group_ids=['harmony-cloud-shared-brain'])
+
+    assert driver.clone_calls == []
+    assert len(driver.queries) == 3
+    assert all(
+        params == {'group_ids': ['harmony-cloud-shared-brain']} for _, params in driver.queries
+    )
+    assert all('WHERE n.group_id IN $group_ids' in query for query, _ in driver.queries)

--- a/tests/test_handle_multiple_group_ids.py
+++ b/tests/test_handle_multiple_group_ids.py
@@ -23,14 +23,23 @@ from graphiti_core.driver.driver import GraphProvider
 
 
 class _FakeDriver:
-    def __init__(self, database: str, provider: GraphProvider = GraphProvider.FALKORDB):
+    def __init__(
+        self,
+        database: str,
+        provider: GraphProvider = GraphProvider.FALKORDB,
+        group_routing: str = 'database',
+    ):
         self._database = database
         self.provider = provider
+        self.group_routing = group_routing
         self.clone_calls: list[str] = []
 
     def clone(self, database: str) -> '_FakeDriver':
         self.clone_calls.append(database)
-        return _FakeDriver(database, self.provider)
+        return _FakeDriver(database, self.provider, self.group_routing)
+
+    def should_route_group_id_to_database(self, group_id: str) -> bool:
+        return self.group_routing == 'database' and group_id != self._database
 
 
 class _Host:
@@ -90,6 +99,32 @@ async def test_falkor_multi_group_ids_still_clones_each():
     assert host.clients.driver is driver
     assert set(host.seen_drivers) == {'a', 'b'}
     assert sorted(result) == ["q:a:['a']", "q:b:['b']"]
+
+
+@pytest.mark.asyncio
+async def test_falkor_record_group_routing_keeps_single_group_on_current_database():
+    driver = _FakeDriver('graphiti_personal', group_routing='record')
+    host = _Host(driver)
+
+    result = await host.search('q', group_ids=['harmony-cloud-shared-brain'])
+
+    assert driver.clone_calls == []
+    assert host.clients.driver is driver
+    assert host.seen_drivers == [None]
+    assert result == ["q:None:['harmony-cloud-shared-brain']"]
+
+
+@pytest.mark.asyncio
+async def test_falkor_record_group_routing_keeps_multi_group_search_in_one_database():
+    driver = _FakeDriver('graphiti_personal', group_routing='record')
+    host = _Host(driver)
+
+    result = await host.search('q', group_ids=['harmony-cloud-shared-brain', 'codex'])
+
+    assert driver.clone_calls == []
+    assert host.clients.driver is driver
+    assert host.seen_drivers == [None]
+    assert result == ["q:None:['harmony-cloud-shared-brain', 'codex']"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add an explicit FalkorDB `group_routing` mode
- preserve `database` as the default graph-per-group behavior
- add opt-in `record` routing that keeps the configured Falkor graph fixed while applying `group_id` as a record-level scope
- thread the option through Graphiti core and MCP configuration
- cover episode ingestion, single- and multi-group retrieval, and group-scoped cleanup with hermetic regression tests

RFC: #1684

## Compatibility

Default behavior is unchanged. The new mode is FalkorDB-specific and must be explicitly configured. Other database providers are unaffected.

## Verification

- focused core routing tests: 9 passed
- focused MCP configuration tests: 8 passed
- authoritative no-database core gate: 353 passed, 11 skipped
- MCP parity/configuration gate: 35 passed
- `make lint`: passed

No live database, provider, credential, container, or shared graph data is required by the added tests.