### PR TITLE
fix(falkordb): episode_mentions_reranker inverted ordering and min_score bypass

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -674,7 +674,7 @@ class FalkorSearchOperations(SearchOperations):
 
         for uuid in node_uuids:
             if uuid not in scores:
-                scores[uuid] = float('inf')
+                scores[uuid] = 0
 
         sorted_uuids = list(node_uuids)
         sorted_uuids.sort(reverse=True, key=lambda cur_uuid: scores[cur_uuid])

--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -677,7 +677,7 @@ class FalkorSearchOperations(SearchOperations):
                 scores[uuid] = float('inf')
 
         sorted_uuids = list(node_uuids)
-        sorted_uuids.sort(key=lambda cur_uuid: scores[cur_uuid])
+        sorted_uuids.sort(reverse=True, key=lambda cur_uuid: scores[cur_uuid])
 
         reranked_uuids = [u for u in sorted_uuids if scores[u] >= min_score]
 

--- a/tests/driver/test_falkordb_driver.py
+++ b/tests/driver/test_falkordb_driver.py
@@ -429,3 +429,71 @@ class TestFalkorDriverIntegration:
 
         except Exception as e:
             pytest.skip(f'FalkorDB not available for integration test: {e}')
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_episode_mentions_reranker_ordering_and_min_score(self):
+        """Most-mentioned nodes must rank first and min_score must filter unmentioned nodes.
+
+        Regression test: scores were sorted ascending (least-mentioned first) and
+        unmentioned nodes were scored float('inf'), so they bypassed any min_score.
+        """
+        pytest.importorskip('falkordb')
+
+        from graphiti_core.nodes import EntityNode, EpisodeType, EpisodicNode
+        from graphiti_core.utils.datetime_utils import utc_now
+
+        falkor_host = os.getenv('FALKORDB_HOST', 'localhost')
+        falkor_port = os.getenv('FALKORDB_PORT', '6379')
+
+        try:
+            driver = FalkorDriver(host=falkor_host, port=falkor_port, database='test_reranker')
+            await driver.execute_query('MATCH (n) DETACH DELETE n')
+        except Exception as e:
+            pytest.skip(f'FalkorDB not available for integration test: {e}')
+
+        try:
+            embedding = [0.1] * 4
+            popular = EntityNode(
+                name='Popular', group_id='g1', labels=['Entity'], name_embedding=embedding
+            )
+            rare = EntityNode(
+                name='Rare', group_id='g1', labels=['Entity'], name_embedding=embedding
+            )
+            unmentioned = EntityNode(
+                name='Unmentioned', group_id='g1', labels=['Entity'], name_embedding=embedding
+            )
+            for node in (popular, rare, unmentioned):
+                await driver.entity_node_ops.save(driver, node)
+
+            # 3 episodes mention 'Popular', 1 mentions 'Rare'
+            for i in range(4):
+                episode = EpisodicNode(
+                    name=f'ep{i}',
+                    group_id='g1',
+                    source=EpisodeType.text,
+                    source_description='test',
+                    content=f'content {i}',
+                    valid_at=utc_now(),
+                    created_at=utc_now(),
+                )
+                await driver.episode_node_ops.save(driver, episode)
+                target = popular.uuid if i < 3 else rare.uuid
+                await driver.execute_query(
+                    'MATCH (e:Episodic {uuid: $e}), (n:Entity {uuid: $n}) '
+                    'CREATE (e)-[:MENTIONS {uuid: $u}]->(n)',
+                    e=episode.uuid,
+                    n=target,
+                    u=f'mention-{i}',
+                )
+
+            uuids = [popular.uuid, rare.uuid, unmentioned.uuid]
+
+            nodes = await driver.search_ops.episode_mentions_reranker(driver, uuids)
+            assert [n.name for n in nodes] == ['Popular', 'Rare', 'Unmentioned']
+
+            nodes = await driver.search_ops.episode_mentions_reranker(driver, uuids, min_score=2)
+            assert [n.name for n in nodes] == ['Popular']
+        finally:
+            await driver.execute_query('MATCH (n) DETACH DELETE n')
+            await driver.close()


### PR DESCRIPTION
## What it fixes

Two related bugs in `FalkorSearchOperations.episode_mentions_reranker` (`graphiti_core/driver/falkordb/operations/search_ops.py`):

**1. Ranking is inverted**

Scores are episode-mention counts (higher = more relevant), but the sort was ascending, so the *least*-mentioned nodes ranked first. A node mentioned by 3 episodes ranked below a node mentioned by 1.

**2. Unmentioned nodes bypass `min_score`**

Nodes with no `MENTIONS` edges were given `float('inf')` as a score, which passes any `min_score` threshold (and, combined with the ascending sort, also pushed them to the end rather than filtering them). They now score `0`, so any positive `min_score` filters them out.

Related: #1342 reported the inverted ordering for the legacy `search_utils.py` path (fix pending in #1640/#1512), but this ops-layer copy has the same bugs and is not covered by those PRs.

## Before / after

With `Popular` mentioned by 3 episodes, `Rare` by 1, `Unmentioned` by 0:

```python
await driver.search_ops.episode_mentions_reranker(driver, uuids)
# before: ['Rare', 'Popular', 'Unmentioned']
# after:  ['Popular', 'Rare', 'Unmentioned']

await driver.search_ops.episode_mentions_reranker(driver, uuids, min_score=2)
# before: ['Popular', 'Unmentioned']   (inf >= 2)
# after:  ['Popular']
```

## Validation

- New FalkorDB integration test covering both ordering and `min_score`; verified it fails on the unfixed code and passes with the fix
- Full `tests/driver` suite passes against a live FalkorDB
