### PR TITLE
fix(falkordb): isolate per-group drivers

### DIFF
--- a/graphiti_core/driver/driver.py
+++ b/graphiti_core/driver/driver.py
@@ -128,6 +128,14 @@ class GraphDriver(QueryExecutor, ABC):
     async def build_indices_and_constraints(self, delete_existing: bool = False):
         raise NotImplementedError()
 
+    async def wait_for_initialization(self) -> None:
+        """Wait for any index/constraint build scheduled when the driver was created.
+
+        Drivers that bootstrap themselves in the background override this so
+        callers can surface failures instead of losing them on an orphaned task.
+        """
+        return None
+
     def clone(self, database: str) -> GraphDriver:
         """Clone the driver with a different database or graph name."""
         return self

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -180,6 +180,7 @@ class FalkorDriver(GraphDriver):
         try:
             loop = asyncio.get_running_loop()
             self._init_task = loop.create_task(self.build_indices_and_constraints())
+            self._init_task.add_done_callback(self._log_init_task_result)
         except RuntimeError:
             pass
 
@@ -342,6 +343,34 @@ class FalkorDriver(GraphDriver):
             cloned = FalkorDriver(falkor_db=self.client, database=database)
 
         return cloned
+
+    def _log_init_task_result(self, task: asyncio.Task) -> None:
+        """Retrieve the background init task's outcome so failures are never silent."""
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None:
+            logger.warning(
+                'Failed to build indices and constraints for FalkorDB graph %s: %s',
+                self._database,
+                error,
+            )
+
+    async def wait_for_initialization(self) -> None:
+        """Await the index/constraint build scheduled when this driver was created.
+
+        ``clone`` builds a fresh driver per graph, and each one schedules its own
+        index build. Awaiting here keeps a group's first write from racing its
+        indices and turns a failed build into a logged warning instead of an
+        orphaned "Task exception was never retrieved".
+        """
+        task = self._init_task
+        if task is None:
+            return
+        self._init_task = None
+        # _log_init_task_result reports any failure; gathering here only ensures
+        # the build has finished before the caller issues its first query.
+        await asyncio.gather(task, return_exceptions=True)
 
     async def health_check(self) -> None:
         """Check FalkorDB connectivity by running a simple query."""

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import logging
+from copy import copy
 from datetime import datetime
 from time import time
 from uuid import uuid4
@@ -601,6 +602,18 @@ class Graphiti:
         """
         await self.driver.build_indices_and_constraints(delete_existing)
 
+    def _with_database(self, database: str) -> 'Graphiti':
+        """Return a shallow copy that uses a database-specific driver.
+
+        FalkorDB maps each group ID to a distinct graph. Keeping both the driver
+        and its clients container on the copy prevents concurrent requests from
+        rebinding state on the shared Graphiti instance.
+        """
+        graphiti = copy(self)
+        graphiti.driver = self.driver.clone(database=database)
+        graphiti.clients = self.clients.model_copy(update={'driver': graphiti.driver})
+        return graphiti
+
     async def _extract_and_resolve_nodes(
         self,
         episode: EpisodicNode | list[EpisodicNode],
@@ -1077,9 +1090,24 @@ class Graphiti:
         else:
             validate_group_id(group_id)
             if group_id != self.driver._database:
-                # if group_id is provided, use it as the database name
-                self.driver = self.driver.clone(database=group_id)
-                self.clients.driver = self.driver
+                return await self._with_database(group_id).add_episode(
+                    name=name,
+                    episode_body=episode_body,
+                    source_description=source_description,
+                    reference_time=reference_time,
+                    source=source,
+                    group_id=group_id,
+                    uuid=uuid,
+                    update_communities=update_communities,
+                    entity_types=entity_types,
+                    excluded_entity_types=excluded_entity_types,
+                    previous_episode_uuids=previous_episode_uuids,
+                    edge_types=edge_types,
+                    edge_type_map=edge_type_map,
+                    custom_extraction_instructions=custom_extraction_instructions,
+                    saga=saga,
+                    saga_previous_episode_uuid=saga_previous_episode_uuid,
+                )
 
         with self.tracer.start_span('add_episode') as span:
             try:
@@ -1305,9 +1333,16 @@ class Graphiti:
                 else:
                     validate_group_id(group_id)
                     if group_id != self.driver._database:
-                        # if group_id is provided, use it as the database name
-                        self.driver = self.driver.clone(database=group_id)
-                        self.clients.driver = self.driver
+                        return await self._with_database(group_id).add_episode_bulk(
+                            bulk_episodes=bulk_episodes,
+                            group_id=group_id,
+                            entity_types=entity_types,
+                            excluded_entity_types=excluded_entity_types,
+                            edge_types=edge_types,
+                            edge_type_map=edge_type_map,
+                            custom_extraction_instructions=custom_extraction_instructions,
+                            saga=saga,
+                        )
 
                 # Create default edge type map
                 edge_type_map_default = (

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -602,16 +602,21 @@ class Graphiti:
         """
         await self.driver.build_indices_and_constraints(delete_existing)
 
-    def _with_database(self, database: str) -> 'Graphiti':
+    async def _with_database(self, database: str) -> 'Graphiti':
         """Return a shallow copy that uses a database-specific driver.
 
         FalkorDB maps each group ID to a distinct graph. Keeping both the driver
         and its clients container on the copy prevents concurrent requests from
         rebinding state on the shared Graphiti instance.
+
+        Each cloned driver schedules its own index build, so wait for it here:
+        otherwise the group's first write races its indices and a failed build
+        is lost on an orphaned task.
         """
         graphiti = copy(self)
         graphiti.driver = self.driver.clone(database=database)
         graphiti.clients = self.clients.model_copy(update={'driver': graphiti.driver})
+        await graphiti.driver.wait_for_initialization()
         return graphiti
 
     async def _extract_and_resolve_nodes(
@@ -1090,7 +1095,8 @@ class Graphiti:
         else:
             validate_group_id(group_id)
             if group_id != self.driver._database:
-                return await self._with_database(group_id).add_episode(
+                scoped = await self._with_database(group_id)
+                return await scoped.add_episode(
                     name=name,
                     episode_body=episode_body,
                     source_description=source_description,
@@ -1333,7 +1339,8 @@ class Graphiti:
                 else:
                     validate_group_id(group_id)
                     if group_id != self.driver._database:
-                        return await self._with_database(group_id).add_episode_bulk(
+                        scoped = await self._with_database(group_id)
+                        return await scoped.add_episode_bulk(
                             bulk_episodes=bulk_episodes,
                             group_id=group_id,
                             entity_types=entity_types,

--- a/tests/test_handle_multiple_group_ids.py
+++ b/tests/test_handle_multiple_group_ids.py
@@ -20,6 +20,8 @@ import pytest
 
 from graphiti_core.decorators import handle_multiple_group_ids
 from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.graphiti import Graphiti
+from graphiti_core.graphiti_types import GraphitiClients
 
 
 class _FakeDriver:
@@ -102,3 +104,23 @@ async def test_non_falkor_single_group_id_is_passthrough():
     assert driver.clone_calls == []
     assert host.seen_drivers == [None]
     assert result == ["q:None:['tenant']"]
+
+
+def test_database_scoped_graphiti_copy_does_not_rebind_shared_driver():
+    """Concurrent FalkorDB requests must retain their own graph driver (#1676)."""
+    driver = _FakeDriver('default')
+    graphiti = Graphiti.__new__(Graphiti)
+    graphiti.driver = driver
+    graphiti.clients = GraphitiClients.model_construct(driver=driver)
+    graphiti.embedder = object()
+
+    group_a = graphiti._with_database('group-a')
+    group_b = graphiti._with_database('group-b')
+
+    assert driver.clone_calls == ['group-a', 'group-b']
+    assert graphiti.driver is driver
+    assert graphiti.clients.driver is driver
+    assert group_a.driver._database == 'group-a'
+    assert group_b.driver._database == 'group-b'
+    assert group_a.clients.driver is group_a.driver
+    assert group_b.clients.driver is group_b.driver

--- a/tests/test_handle_multiple_group_ids.py
+++ b/tests/test_handle_multiple_group_ids.py
@@ -29,10 +29,14 @@ class _FakeDriver:
         self._database = database
         self.provider = provider
         self.clone_calls: list[str] = []
+        self.init_waits = 0
 
     def clone(self, database: str) -> '_FakeDriver':
         self.clone_calls.append(database)
         return _FakeDriver(database, self.provider)
+
+    async def wait_for_initialization(self) -> None:
+        self.init_waits += 1
 
 
 class _Host:
@@ -106,7 +110,8 @@ async def test_non_falkor_single_group_id_is_passthrough():
     assert result == ["q:None:['tenant']"]
 
 
-def test_database_scoped_graphiti_copy_does_not_rebind_shared_driver():
+@pytest.mark.asyncio
+async def test_database_scoped_graphiti_copy_does_not_rebind_shared_driver():
     """Concurrent FalkorDB requests must retain their own graph driver (#1676)."""
     driver = _FakeDriver('default')
     graphiti = Graphiti.__new__(Graphiti)
@@ -114,8 +119,8 @@ def test_database_scoped_graphiti_copy_does_not_rebind_shared_driver():
     graphiti.clients = GraphitiClients.model_construct(driver=driver)
     graphiti.embedder = object()
 
-    group_a = graphiti._with_database('group-a')
-    group_b = graphiti._with_database('group-b')
+    group_a = await graphiti._with_database('group-a')
+    group_b = await graphiti._with_database('group-b')
 
     assert driver.clone_calls == ['group-a', 'group-b']
     assert graphiti.driver is driver
@@ -124,3 +129,7 @@ def test_database_scoped_graphiti_copy_does_not_rebind_shared_driver():
     assert group_b.driver._database == 'group-b'
     assert group_a.clients.driver is group_a.driver
     assert group_b.clients.driver is group_b.driver
+    # Each clone's own index build is awaited, not left on an orphaned task.
+    assert group_a.driver.init_waits == 1
+    assert group_b.driver.init_waits == 1
+    assert driver.init_waits == 0


### PR DESCRIPTION
## Summary
- keep FalkorDB database clones scoped to a copied `Graphiti` instance
- prevent concurrent `add_episode` and `add_episode_bulk` calls from rebinding shared driver state
- add a regression test proving each group retains its own driver while the shared client remains unchanged

Fixes #1676

## Test plan
- [x] `uv run pytest tests/test_handle_multiple_group_ids.py`
- [x] `uv run ruff check graphiti_core/graphiti.py tests/test_handle_multiple_group_ids.py`
