### PR TITLE
feat(falkordb): add opt-in record-level group routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,32 @@ driver = FalkorDriver(
 graphiti = Graphiti(graph_driver=driver)
 ```
 
+#### FalkorDB with a Single Shared Graph (`group_routing`)
+
+By default FalkorDB maps every `group_id` to its own graph, so a new `group_id`
+selects (and creates) a separate physical graph. Set `group_routing="record"` to
+keep the configured graph fixed and use `group_id` purely as a record-level
+tenant scope — writes, search, retrieval, and group-scoped cleanup all stay
+inside that one graph.
+
+```python
+driver = FalkorDriver(
+    host="localhost",
+    port=6379,
+    database="graphiti_personal",  # every group lives in this graph
+    group_routing="record",  # default is "database" (graph per group_id)
+)
+
+graphiti = Graphiti(graph_driver=driver)
+
+# Both projects share `graphiti_personal`, isolated by group_id
+await graphiti.add_episode(..., group_id="project_a")
+await graphiti.search("...", group_ids=["project_a"])
+```
+
+The option is FalkorDB-specific and defaults to the existing graph-per-group
+behavior; other providers already treat `group_id` as a record-level scope.
+
 #### Kuzu
 
 > [!WARNING]

--- a/graphiti_core/decorators.py
+++ b/graphiti_core/decorators.py
@@ -35,6 +35,11 @@ def handle_multiple_group_ids(func: F) -> F:
     call-scoped driver clone. Without this, add_episode re-binds the shared
     driver for writes while search/retrieve with one group_id query the
     driver's default database and silently return empty results (#1659).
+
+    Both behaviors only apply when the driver maps group_ids to databases. Under
+    record-level routing (``FalkorDriver(group_routing='record')``) the graph is
+    fixed and the query's own group_id filter scopes the results, so the call
+    runs unchanged — including multiple group_ids in a single query.
     """
 
     @functools.wraps(func)
@@ -49,15 +54,16 @@ def handle_multiple_group_ids(func: F) -> F:
         if group_ids is None and group_ids_pos is not None and len(args) > group_ids_pos:
             group_ids = args[group_ids_pos]
 
-        is_falkor = (
+        routes_group_to_graph = (
             hasattr(self, 'clients')
             and hasattr(self.clients, 'driver')
             and self.clients.driver.provider == GraphProvider.FALKORDB
+            and self.clients.driver.routes_group_ids_to_databases
         )
 
         # FalkorDB: one group_id still needs the graph named after that id.
         # Clone is call-scoped so we never reassign self.driver / self.clients.driver.
-        if is_falkor and group_ids and len(group_ids) == 1:
+        if routes_group_to_graph and group_ids and len(group_ids) == 1:
             gid = group_ids[0]
             driver = self.clients.driver
             if gid != getattr(driver, '_database', None):
@@ -69,7 +75,7 @@ def handle_multiple_group_ids(func: F) -> F:
             return await func(self, *args, **kwargs)
 
         # FalkorDB with multiple group_ids: run per graph and merge
-        if is_falkor and group_ids and len(group_ids) > 1:
+        if routes_group_to_graph and group_ids and len(group_ids) > 1:
             # Execute for each group_id concurrently
             driver = self.clients.driver
 

--- a/graphiti_core/driver/driver.py
+++ b/graphiti_core/driver/driver.py
@@ -63,6 +63,20 @@ class GraphProvider(Enum):
     NEPTUNE = 'neptune'
 
 
+class GroupRouting(Enum):
+    """How a driver maps ``group_id`` onto physical storage.
+
+    ``DATABASE``: every ``group_id`` selects (and creates) its own database/graph.
+        This is FalkorDB's historical behavior.
+    ``RECORD``: the configured database/graph stays fixed and ``group_id`` is only
+        a record-level property used for filtering. Every provider other than
+        FalkorDB works this way.
+    """
+
+    DATABASE = 'database'
+    RECORD = 'record'
+
+
 class GraphDriverSession(ABC):
     provider: GraphProvider
 
@@ -94,9 +108,19 @@ class GraphDriver(QueryExecutor, ABC):
     )
     _database: str
     default_group_id: str = ''
+    group_routing: GroupRouting = GroupRouting.RECORD
     # Legacy interfaces (kept for backwards compatibility during Phase 1)
     search_interface: SearchInterface | None = None
     graph_operations_interface: GraphOperationsInterface | None = None
+
+    @property
+    def routes_group_ids_to_databases(self) -> bool:
+        """Whether a ``group_id`` selects a separate physical database/graph.
+
+        When ``False``, ``group_id`` is a record-level scope and group-filtered
+        queries run against the driver's configured database.
+        """
+        return self.group_routing is GroupRouting.DATABASE
 
     @abstractmethod
     def execute_query(self, cypher_query_: str, **kwargs: Any) -> Coroutine:

--- a/graphiti_core/driver/falkordb/operations/community_edge_ops.py
+++ b/graphiti_core/driver/falkordb/operations/community_edge_ops.py
@@ -137,13 +137,15 @@ class FalkorCommunityEdgeOperations(CommunityEdgeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[CommunityEdge]:
-        # For FalkorDB, route each group_id to its own graph database. The
-        # namespace/ops path receives the base driver (default_db), so a
-        # single-group read must be cloned to the group's graph or it queries
-        # an empty default database and returns nothing.
+        # With graph-per-group routing (the FalkorDB default), each group_id
+        # lives in its own graph database. The namespace/ops path receives the
+        # base driver (default_db), so a single-group read must be cloned to the
+        # group's graph or it queries an empty default database and returns
+        # nothing. Under record-level routing the graph is fixed and the
+        # group_id filter in the query below is the only scoping needed.
         if (
             isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
+            and executor.routes_group_ids_to_databases
             and group_ids
         ):
             if len(group_ids) == 1:

--- a/graphiti_core/driver/falkordb/operations/community_node_ops.py
+++ b/graphiti_core/driver/falkordb/operations/community_node_ops.py
@@ -159,13 +159,15 @@ class FalkorCommunityNodeOperations(CommunityNodeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[CommunityNode]:
-        # For FalkorDB, route each group_id to its own graph database. The
-        # namespace/ops path receives the base driver (default_db), so a
-        # single-group read must be cloned to the group's graph or it queries
-        # an empty default database and returns nothing.
+        # With graph-per-group routing (the FalkorDB default), each group_id
+        # lives in its own graph database. The namespace/ops path receives the
+        # base driver (default_db), so a single-group read must be cloned to the
+        # group's graph or it queries an empty default database and returns
+        # nothing. Under record-level routing the graph is fixed and the
+        # group_id filter in the query below is the only scoping needed.
         if (
             isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
+            and executor.routes_group_ids_to_databases
             and group_ids
         ):
             if len(group_ids) == 1:

--- a/graphiti_core/driver/falkordb/operations/entity_edge_ops.py
+++ b/graphiti_core/driver/falkordb/operations/entity_edge_ops.py
@@ -165,13 +165,15 @@ class FalkorEntityEdgeOperations(EntityEdgeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[EntityEdge]:
-        # For FalkorDB, route each group_id to its own graph database. The
-        # namespace/ops path receives the base driver (default_db), so a
-        # single-group read must be cloned to the group's graph or it queries
-        # an empty default database and returns nothing.
+        # With graph-per-group routing (the FalkorDB default), each group_id
+        # lives in its own graph database. The namespace/ops path receives the
+        # base driver (default_db), so a single-group read must be cloned to the
+        # group's graph or it queries an empty default database and returns
+        # nothing. Under record-level routing the graph is fixed and the
+        # group_id filter in the query below is the only scoping needed.
         if (
             isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
+            and executor.routes_group_ids_to_databases
             and group_ids
         ):
             if len(group_ids) == 1:

--- a/graphiti_core/driver/falkordb/operations/entity_node_ops.py
+++ b/graphiti_core/driver/falkordb/operations/entity_node_ops.py
@@ -180,13 +180,15 @@ class FalkorEntityNodeOperations(EntityNodeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[EntityNode]:
-        # For FalkorDB, route each group_id to its own graph database. The
-        # namespace/ops path receives the base driver (default_db), so a
-        # single-group read must be cloned to the group's graph or it queries
-        # an empty default database and returns nothing.
+        # With graph-per-group routing (the FalkorDB default), each group_id
+        # lives in its own graph database. The namespace/ops path receives the
+        # base driver (default_db), so a single-group read must be cloned to the
+        # group's graph or it queries an empty default database and returns
+        # nothing. Under record-level routing the graph is fixed and the
+        # group_id filter in the query below is the only scoping needed.
         if (
             isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
+            and executor.routes_group_ids_to_databases
             and group_ids
         ):
             if len(group_ids) == 1:

--- a/graphiti_core/driver/falkordb/operations/episode_node_ops.py
+++ b/graphiti_core/driver/falkordb/operations/episode_node_ops.py
@@ -174,13 +174,15 @@ class FalkorEpisodeNodeOperations(EpisodeNodeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[EpisodicNode]:
-        # For FalkorDB, route each group_id to its own graph database. The
-        # namespace/ops path receives the base driver (default_db), so a
-        # single-group read must be cloned to the group's graph or it queries
-        # an empty default database and returns nothing.
+        # With graph-per-group routing (the FalkorDB default), each group_id
+        # lives in its own graph database. The namespace/ops path receives the
+        # base driver (default_db), so a single-group read must be cloned to the
+        # group's graph or it queries an empty default database and returns
+        # nothing. Under record-level routing the graph is fixed and the
+        # group_id filter in the query below is the only scoping needed.
         if (
             isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
+            and executor.routes_group_ids_to_databases
             and group_ids
         ):
             if len(group_ids) == 1:

--- a/graphiti_core/driver/falkordb/operations/episodic_edge_ops.py
+++ b/graphiti_core/driver/falkordb/operations/episodic_edge_ops.py
@@ -151,13 +151,15 @@ class FalkorEpisodicEdgeOperations(EpisodicEdgeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[EpisodicEdge]:
-        # For FalkorDB, route each group_id to its own graph database. The
-        # namespace/ops path receives the base driver (default_db), so a
-        # single-group read must be cloned to the group's graph or it queries
-        # an empty default database and returns nothing.
+        # With graph-per-group routing (the FalkorDB default), each group_id
+        # lives in its own graph database. The namespace/ops path receives the
+        # base driver (default_db), so a single-group read must be cloned to the
+        # group's graph or it queries an empty default database and returns
+        # nothing. Under record-level routing the graph is fixed and the
+        # group_id filter in the query below is the only scoping needed.
         if (
             isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
+            and executor.routes_group_ids_to_databases
             and group_ids
         ):
             if len(group_ids) == 1:

--- a/graphiti_core/driver/falkordb/operations/has_episode_edge_ops.py
+++ b/graphiti_core/driver/falkordb/operations/has_episode_edge_ops.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.driver.driver import GraphDriver
 from graphiti_core.driver.operations.has_episode_edge_ops import HasEpisodeEdgeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.edges import HasEpisodeEdge
@@ -146,13 +146,15 @@ class FalkorHasEpisodeEdgeOperations(HasEpisodeEdgeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[HasEpisodeEdge]:
-        # For FalkorDB, route each group_id to its own graph database. The
-        # namespace/ops path receives the base driver (default_db), so a
-        # single-group read must be cloned to the group's graph or it queries
-        # an empty default database and returns nothing.
+        # With graph-per-group routing (the FalkorDB default), each group_id
+        # lives in its own graph database. The namespace/ops path receives the
+        # base driver (default_db), so a single-group read must be cloned to the
+        # group's graph or it queries an empty default database and returns
+        # nothing. Under record-level routing the graph is fixed and the
+        # group_id filter in the query below is the only scoping needed.
         if (
             isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
+            and executor.routes_group_ids_to_databases
             and group_ids
         ):
             if len(group_ids) == 1:

--- a/graphiti_core/driver/falkordb/operations/next_episode_edge_ops.py
+++ b/graphiti_core/driver/falkordb/operations/next_episode_edge_ops.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.driver.driver import GraphDriver
 from graphiti_core.driver.operations.next_episode_edge_ops import NextEpisodeEdgeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.edges import NextEpisodeEdge
@@ -146,13 +146,15 @@ class FalkorNextEpisodeEdgeOperations(NextEpisodeEdgeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[NextEpisodeEdge]:
-        # For FalkorDB, route each group_id to its own graph database. The
-        # namespace/ops path receives the base driver (default_db), so a
-        # single-group read must be cloned to the group's graph or it queries
-        # an empty default database and returns nothing.
+        # With graph-per-group routing (the FalkorDB default), each group_id
+        # lives in its own graph database. The namespace/ops path receives the
+        # base driver (default_db), so a single-group read must be cloned to the
+        # group's graph or it queries an empty default database and returns
+        # nothing. Under record-level routing the graph is fixed and the
+        # group_id filter in the query below is the only scoping needed.
         if (
             isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
+            and executor.routes_group_ids_to_databases
             and group_ids
         ):
             if len(group_ids) == 1:

--- a/graphiti_core/driver/falkordb/operations/saga_node_ops.py
+++ b/graphiti_core/driver/falkordb/operations/saga_node_ops.py
@@ -159,13 +159,15 @@ class FalkorSagaNodeOperations(SagaNodeOperations):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[SagaNode]:
-        # For FalkorDB, route each group_id to its own graph database. The
-        # namespace/ops path receives the base driver (default_db), so a
-        # single-group read must be cloned to the group's graph or it queries
-        # an empty default database and returns nothing.
+        # With graph-per-group routing (the FalkorDB default), each group_id
+        # lives in its own graph database. The namespace/ops path receives the
+        # base driver (default_db), so a single-group read must be cloned to the
+        # group's graph or it queries an empty default database and returns
+        # nothing. Under record-level routing the graph is fixed and the
+        # group_id filter in the query below is the only scoping needed.
         if (
             isinstance(executor, GraphDriver)
-            and executor.provider == GraphProvider.FALKORDB
+            and executor.routes_group_ids_to_databases
             and group_ids
         ):
             if len(group_ids) == 1:

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -34,7 +34,12 @@ else:
             'Install it with: pip install graphiti-core[falkordb]'
         ) from None
 
-from graphiti_core.driver.driver import GraphDriver, GraphDriverSession, GraphProvider
+from graphiti_core.driver.driver import (
+    GraphDriver,
+    GraphDriverSession,
+    GraphProvider,
+    GroupRouting,
+)
 from graphiti_core.driver.falkordb import STOPWORDS as STOPWORDS
 from graphiti_core.driver.falkordb.operations.community_edge_ops import (
     FalkorCommunityEdgeOperations,
@@ -127,6 +132,7 @@ class FalkorDriver(GraphDriver):
     default_group_id: str = '_'
     fulltext_syntax: str = '@'  # FalkorDB uses a redisearch-like syntax for fulltext queries
     aoss_client: None = None
+    group_routing: GroupRouting = GroupRouting.DATABASE
 
     def __init__(
         self,
@@ -136,6 +142,7 @@ class FalkorDriver(GraphDriver):
         password: str | None = None,
         falkor_db: FalkorDB | None = None,
         database: str = 'default_db',
+        group_routing: GroupRouting | str = GroupRouting.DATABASE,
     ):
         """
         Initialize the FalkorDB driver.
@@ -151,9 +158,21 @@ class FalkorDriver(GraphDriver):
         password (str | None): The password for authentication (if required).
         falkor_db (FalkorDB | None): An existing FalkorDB instance to use instead of creating a new one.
         database (str): The name of the database to connect to. Defaults to 'default_db'.
+        group_routing (GroupRouting | str): How ``group_id`` maps to storage.
+            ``'database'`` (default) keeps the historical behavior where each
+            ``group_id`` selects its own FalkorDB graph. ``'record'`` pins every
+            operation to ``database`` and treats ``group_id`` as a record-level
+            tenant scope, so a single shared graph holds all groups.
         """
         super().__init__()
         self._database = database
+        try:
+            self.group_routing = GroupRouting(group_routing)
+        except ValueError as e:
+            raise ValueError(
+                f'Invalid group_routing {group_routing!r}. '
+                f'Expected one of: {", ".join(m.value for m in GroupRouting)}.'
+            ) from e
         if falkor_db is not None:
             # If a FalkorDB instance is provided, use it directly
             self.client = falkor_db
@@ -325,13 +344,21 @@ class FalkorDriver(GraphDriver):
         Returns a shallow copy of this driver with a different default database.
         Reuses the same connection (e.g. FalkorDB, Neo4j).
         """
+        if self.group_routing is GroupRouting.RECORD:
+            # Record-level routing pins every operation to the configured graph;
+            # group_id is applied as a filter on records instead of selecting a
+            # graph, so a group_id must never re-point the driver.
+            return self
+
         if database == self._database:
             cloned = self
         elif database == self.default_group_id:
-            cloned = FalkorDriver(falkor_db=self.client)
+            cloned = FalkorDriver(falkor_db=self.client, group_routing=self.group_routing)
         else:
             # Create a new instance of FalkorDriver with the same connection but a different database
-            cloned = FalkorDriver(falkor_db=self.client, database=database)
+            cloned = FalkorDriver(
+                falkor_db=self.client, database=database, group_routing=self.group_routing
+            )
 
         return cloned
 

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -153,7 +153,19 @@ database:
       uri: "redis://localhost:6379"
       password: ""  # Optional
       database: "default_db"  # Optional
+      group_routing: "database"  # Optional: "database" (default) or "record"
 ```
+
+`group_routing` controls how `group_id` maps to storage:
+
+- `database` (default): each `group_id` selects — and creates — its own FalkorDB
+  graph.
+- `record`: the graph named above stays fixed and `group_id` is applied as a
+  record-level tenant filter, so several projects share one physical graph while
+  their episodes, search results, and group-scoped cleanup stay isolated.
+
+Set it with the `FALKORDB_GROUP_ROUTING` environment variable when using the
+shipped `config.yaml`.
 
 ### Configuration File (config.yaml)
 

--- a/mcp_server/config/config.yaml
+++ b/mcp_server/config/config.yaml
@@ -78,6 +78,9 @@ database:
       uri: ${FALKORDB_URI:redis://localhost:6379}
       password: ${FALKORDB_PASSWORD:}
       database: ${FALKORDB_DATABASE:default_db}
+      # database (default): each group_id gets its own FalkorDB graph
+      # record: keep the graph above fixed and scope group_id per record
+      group_routing: ${FALKORDB_GROUP_ROUTING:database}
 
     neo4j:
       uri: ${NEO4J_URI:bolt://localhost:7687}

--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, Field
@@ -190,6 +190,14 @@ class FalkorDBProviderConfig(BaseModel):
     username: str | None = None
     password: str | None = None
     database: str = 'default_db'
+    group_routing: Literal['database', 'record'] = Field(
+        default='database',
+        description=(
+            "How group_id maps to storage. 'database' (default) gives each group_id "
+            "its own FalkorDB graph. 'record' keeps the configured graph fixed and "
+            'applies group_id as a record-level tenant filter.'
+        ),
+    )
 
 
 class DatabaseProvidersConfig(BaseModel):

--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -235,6 +235,7 @@ class GraphitiService:
                         username=db_config.get('username'),
                         password=db_config['password'],
                         database=db_config['database'],
+                        group_routing=db_config.get('group_routing', 'database'),
                     )
 
                     self.client = Graphiti(

--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -479,6 +479,7 @@ class DatabaseDriverFactory:
                     'username': username,
                     'password': password,
                     'database': falkor_config.database,
+                    'group_routing': falkor_config.group_routing,
                 }
 
             case _:

--- a/mcp_server/tests/test_falkordb_config.py
+++ b/mcp_server/tests/test_falkordb_config.py
@@ -26,6 +26,40 @@ def test_falkordb_config_preserves_uri_username(monkeypatch):
     assert db_config['database'] == 'cloud-db'
 
 
+def test_falkordb_group_routing_defaults_to_database(monkeypatch):
+    """Default config keeps graph-per-group routing (#1684)."""
+    monkeypatch.delenv('FALKORDB_URI', raising=False)
+
+    config = DatabaseConfig(
+        provider='falkordb',
+        providers=DatabaseProvidersConfig(falkordb=FalkorDBProviderConfig()),
+    )
+
+    db_config = DatabaseDriverFactory.create_config(config)
+
+    assert db_config['group_routing'] == 'database'
+
+
+def test_falkordb_record_group_routing_is_passed_through(monkeypatch):
+    """Opting into record routing reaches the driver config unchanged."""
+    monkeypatch.delenv('FALKORDB_URI', raising=False)
+
+    config = DatabaseConfig(
+        provider='falkordb',
+        providers=DatabaseProvidersConfig(
+            falkordb=FalkorDBProviderConfig(
+                database='graphiti_personal',
+                group_routing='record',
+            )
+        ),
+    )
+
+    db_config = DatabaseDriverFactory.create_config(config)
+
+    assert db_config['database'] == 'graphiti_personal'
+    assert db_config['group_routing'] == 'record'
+
+
 def test_falkordb_username_env_overrides_uri(monkeypatch):
     monkeypatch.setenv('FALKORDB_URI', 'redis://uri-user:secret@example.cloud:6380')
     monkeypatch.setenv('FALKORDB_USERNAME', 'env-user')

--- a/tests/driver/test_falkordb_group_routing.py
+++ b/tests/driver/test_falkordb_group_routing.py
@@ -1,0 +1,171 @@
+"""Unit tests for the FalkorDB ``group_routing`` mode (#1684).
+
+``group_routing='database'`` (the default) keeps the historical behavior where a
+``group_id`` selects its own FalkorDB graph. ``group_routing='record'`` pins the
+driver to the configured graph and treats ``group_id`` as a record-level tenant
+scope, so a single shared graph can hold several groups.
+
+The tests are hermetic: the driver is built with a mocked FalkorDB client and the
+operations layer runs against ``spec=GraphDriver`` mocks, so no live database,
+LLM, embedder, or credentials are required.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from graphiti_core.driver.driver import GraphDriver, GraphProvider, GroupRouting
+from graphiti_core.driver.falkordb.operations.entity_node_ops import (
+    FalkorEntityNodeOperations,
+)
+from graphiti_core.driver.falkordb.operations.episode_node_ops import (
+    FalkorEpisodeNodeOperations,
+)
+from graphiti_core.utils.maintenance.graph_data_operations import clear_data
+
+try:
+    from graphiti_core.driver.falkordb_driver import FalkorDriver
+
+    HAS_FALKORDB = True
+except ImportError:
+    FalkorDriver = None
+    HAS_FALKORDB = False
+
+requires_falkordb = pytest.mark.skipif(not HAS_FALKORDB, reason='FalkorDB is not installed')
+
+
+def _make_driver(**kwargs):
+    """Build a FalkorDriver against a mocked client (no connection, no index build)."""
+    with patch('graphiti_core.driver.falkordb_driver.FalkorDB'):
+        return FalkorDriver(**kwargs)
+
+
+# --- driver-level routing -------------------------------------------------
+
+
+@requires_falkordb
+def test_default_routing_is_database():
+    """Default behavior is unchanged: group_id selects its own graph."""
+    driver = _make_driver(database='default_db')
+
+    assert driver.group_routing is GroupRouting.DATABASE
+    assert driver.routes_group_ids_to_databases is True
+
+
+@requires_falkordb
+def test_default_routing_clone_selects_group_graph():
+    driver = _make_driver(database='default_db')
+
+    cloned = driver.clone(database='projecta')
+
+    assert cloned is not driver
+    assert cloned._database == 'projecta'
+    assert cloned.client is driver.client
+
+
+@requires_falkordb
+def test_record_routing_pins_driver_to_configured_graph():
+    """Record routing never re-points the driver, whatever group_id asks for."""
+    driver = _make_driver(database='graphiti_personal', group_routing='record')
+
+    assert driver.group_routing is GroupRouting.RECORD
+    assert driver.routes_group_ids_to_databases is False
+    assert driver.clone(database='projecta') is driver
+    assert driver.clone(database=driver.default_group_id) is driver
+    assert driver._database == 'graphiti_personal'
+
+
+@requires_falkordb
+def test_record_routing_accepts_enum_member():
+    driver = _make_driver(database='shared', group_routing=GroupRouting.RECORD)
+
+    assert driver.group_routing is GroupRouting.RECORD
+
+
+@requires_falkordb
+def test_database_routing_propagates_to_clones():
+    driver = _make_driver(database='default_db', group_routing='database')
+
+    cloned = driver.clone(database='projecta')
+
+    assert cloned.group_routing is GroupRouting.DATABASE
+
+
+@requires_falkordb
+def test_invalid_group_routing_is_rejected():
+    with pytest.raises(ValueError, match='group_routing'):
+        _make_driver(group_routing='per-tenant')
+
+
+@requires_falkordb
+def test_record_routing_session_uses_configured_graph():
+    """Sessions (used by group-scoped cleanup) stay on the configured graph."""
+    driver = _make_driver(database='graphiti_personal', group_routing='record')
+    driver.client = MagicMock()
+
+    driver.session()
+
+    driver.client.select_graph.assert_called_once_with('graphiti_personal')
+
+
+@requires_falkordb
+@pytest.mark.asyncio
+async def test_record_routing_group_cleanup_stays_in_fixed_graph():
+    """Group-scoped cleanup deletes by group_id inside the one configured graph."""
+    graph = MagicMock()
+    graph.query = AsyncMock(return_value=MagicMock(header=[], result_set=[]))
+
+    with patch.object(FalkorDriver, 'build_indices_and_constraints', new=AsyncMock()):
+        driver = _make_driver(database='graphiti_personal', group_routing='record')
+    driver.client = MagicMock()
+    driver.client.select_graph = MagicMock(return_value=graph)
+
+    await clear_data(driver, group_ids=['projecta'])
+
+    assert driver.client.select_graph.call_args_list == [call('graphiti_personal')]
+    # One delete per label, each scoped by group_id rather than by graph.
+    assert graph.query.await_count == 3
+    for query_call in graph.query.await_args_list:
+        cypher, params = query_call.args
+        assert 'n.group_id IN $group_ids' in cypher
+        assert params == {'group_ids': ['projecta']}
+
+
+# --- operations-layer routing ---------------------------------------------
+
+
+def _record_mode_driver(execute_return=None):
+    """A GraphDriver-shaped mock configured for record-level routing."""
+    driver = MagicMock(spec=GraphDriver)
+    driver.provider = GraphProvider.FALKORDB
+    driver.group_routing = GroupRouting.RECORD
+    driver.routes_group_ids_to_databases = False
+    driver.execute_query = AsyncMock(return_value=execute_return or ([], None, None))
+    driver.clone = MagicMock(return_value=driver)
+    return driver
+
+
+@pytest.mark.asyncio
+async def test_episode_get_by_group_ids_record_mode_does_not_clone():
+    ops = FalkorEpisodeNodeOperations()
+    driver = _record_mode_driver()
+
+    result = await ops.get_by_group_ids(driver, ['projecta'])
+
+    driver.clone.assert_not_called()
+    driver.execute_query.assert_awaited_once()
+    assert driver.execute_query.await_args.kwargs['group_ids'] == ['projecta']
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_entity_node_get_by_group_ids_record_mode_queries_all_groups_at_once():
+    """Multiple group_ids resolve in a single filtered query, not one graph per group."""
+    ops = FalkorEntityNodeOperations()
+    driver = _record_mode_driver()
+
+    await ops.get_by_group_ids(driver, ['projecta', 'projectb'])
+
+    driver.clone.assert_not_called()
+    driver.execute_query.assert_awaited_once()
+    assert driver.execute_query.await_args.kwargs['group_ids'] == ['projecta', 'projectb']

--- a/tests/test_handle_multiple_group_ids.py
+++ b/tests/test_handle_multiple_group_ids.py
@@ -19,18 +19,31 @@ from types import SimpleNamespace
 import pytest
 
 from graphiti_core.decorators import handle_multiple_group_ids
-from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.driver import GraphProvider, GroupRouting
 
 
 class _FakeDriver:
-    def __init__(self, database: str, provider: GraphProvider = GraphProvider.FALKORDB):
+    def __init__(
+        self,
+        database: str,
+        provider: GraphProvider = GraphProvider.FALKORDB,
+        group_routing: GroupRouting = GroupRouting.DATABASE,
+    ):
         self._database = database
         self.provider = provider
+        self.group_routing = group_routing
         self.clone_calls: list[str] = []
+
+    @property
+    def routes_group_ids_to_databases(self) -> bool:
+        return self.group_routing is GroupRouting.DATABASE
 
     def clone(self, database: str) -> '_FakeDriver':
         self.clone_calls.append(database)
-        return _FakeDriver(database, self.provider)
+        if self.group_routing is GroupRouting.RECORD:
+            # Mirrors FalkorDriver.clone: record routing never re-points the driver.
+            return self
+        return _FakeDriver(database, self.provider, self.group_routing)
 
 
 class _Host:
@@ -90,6 +103,34 @@ async def test_falkor_multi_group_ids_still_clones_each():
     assert host.clients.driver is driver
     assert set(host.seen_drivers) == {'a', 'b'}
     assert sorted(result) == ["q:a:['a']", "q:b:['b']"]
+
+
+@pytest.mark.asyncio
+async def test_falkor_record_routing_single_group_id_stays_on_fixed_graph():
+    """Record routing keeps the configured graph; group_id only filters records (#1684)."""
+    driver = _FakeDriver('graphiti_personal', group_routing=GroupRouting.RECORD)
+    host = _Host(driver)
+
+    result = await host.search('q', group_ids=['projecta'])
+
+    assert driver.clone_calls == []
+    assert host.clients.driver is driver
+    assert host.clients.driver._database == 'graphiti_personal'
+    assert host.seen_drivers == [None]
+    assert result == ["q:None:['projecta']"]
+
+
+@pytest.mark.asyncio
+async def test_falkor_record_routing_multi_group_ids_run_as_one_query():
+    """Record routing needs no per-group fan-out: one query filters all group_ids."""
+    driver = _FakeDriver('graphiti_personal', group_routing=GroupRouting.RECORD)
+    host = _Host(driver)
+
+    result = await host.search('q', group_ids=['a', 'b'])
+
+    assert driver.clone_calls == []
+    assert host.seen_drivers == [None]
+    assert result == ["q:None:['a', 'b']"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds an opt-in FalkorDB `group_routing` mode so a deployment can keep one shared graph and use `group_id` purely as a record-level tenant scope, as proposed in #1684.

- `database` (default): unchanged graph-per-group behavior.
- `record` (opt-in): the configured graph stays fixed and `group_id` is applied as a record filter for episode ingestion, search/retrieval, and group-scoped cleanup.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective

FalkorDB currently treats `group_id` as a graph name in several write and retrieval paths, so a new `group_id` selects — and creates — a separate physical graph. Deployments that intentionally share one graph (e.g. a local `graphiti_personal` graph used by several projects) need `group_id` to stay a logical tenant scope inside that graph.

Implementation: `GraphDriver` gains a `group_routing` attribute and a `routes_group_ids_to_databases` predicate. That predicate replaces the provider check at the three places that routed `group_id` to a graph:

- `handle_multiple_group_ids` — no per-group clone or fan-out under record routing, so several `group_id`s resolve in one filtered query instead of one query per graph.
- the Falkor `*Operations.get_by_group_ids` read path.
- `FalkorDriver.clone()` — returns `self` under record routing, so `add_episode` / `add_episode_bulk` never re-point the shared driver.

The option is exposed through the core driver (`FalkorDriver(group_routing='record')`) and MCP configuration (`group_routing:` / `FALKORDB_GROUP_ROUTING`), defaults to the existing behavior, and leaves other providers untouched.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

New hermetic tests (mocked driver/client only — no live database, LLM, embedder, or credentials):

- `tests/driver/test_falkordb_group_routing.py` — default compatibility, record-mode graph pinning, `clone()` no-op, invalid value rejection, session graph selection, group-scoped cleanup emitting `n.group_id IN $group_ids` against the fixed graph, and single-/multi-group retrieval.
- `tests/test_handle_multiple_group_ids.py` — record-mode single and multiple `group_id` cases.
- `mcp_server/tests/test_falkordb_config.py` — config default and pass-through.

`make lint` passes (ruff + pyright, 0 errors). `make test` reports 393 passed / 2 skipped locally; the remaining errors are fixture setup failures from no local Neo4j (:7687) / FalkorDB (:6379) in this environment and are unrelated to this change.

## Breaking Changes
- [ ] This PR contains breaking changes

The change is additive and opt-in; the default `group_routing='database'` preserves current behavior.

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary (root `README.md` and `mcp_server/README.md`)
- [x] No secrets or sensitive information committed

Closes #1684

🤖 Generated with [Claude Code](https://claude.com/claude-code)