### PR TITLE
fix: scope make test to core test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ lint:
 
 # Run tests
 test:
-	DISABLE_FALKORDB=1 DISABLE_KUZU=1 DISABLE_NEPTUNE=1 $(PYTEST) -m "not integration"
+	DISABLE_FALKORDB=1 DISABLE_KUZU=1 DISABLE_NEPTUNE=1 $(PYTEST) tests/ -m "not integration"
 
 # Run format, lint, and test
 check: format lint test


### PR DESCRIPTION
## Summary
- restrict `make test` to the repository's core `tests/` suite
- avoid collecting the separately packaged MCP server tests from the root target
- fixes #1180

## Test plan
- [x] `make -n test`
- [x] `DISABLE_FALKORDB=1 DISABLE_KUZU=1 DISABLE_NEPTUNE=1 uv run pytest tests/helpers_test.py -m \"not integration\"`
- [ ] full `make test` suite, which began `tests/cross_encoder/test_bge_reranker_client_int.py` and did not complete in the local environment
