### PR TITLE
Consolidate overlapping backend fixes

### DIFF
--- a/graphiti_core/driver/falkordb/fulltext.py
+++ b/graphiti_core/driver/falkordb/fulltext.py
@@ -1,0 +1,83 @@
+"""Shared FalkorDB fulltext-query construction."""
+
+import re
+
+from graphiti_core.driver.falkordb import STOPWORDS
+from graphiti_core.helpers import validate_group_ids
+
+MAX_QUERY_LENGTH = 128
+
+# FalkorDB separator characters that break text into tokens.
+_SEPARATOR_MAP = str.maketrans(
+    {
+        ',': ' ',
+        '.': ' ',
+        '<': ' ',
+        '>': ' ',
+        '{': ' ',
+        '}': ' ',
+        '[': ' ',
+        ']': ' ',
+        '"': ' ',
+        "'": ' ',
+        ':': ' ',
+        ';': ' ',
+        '!': ' ',
+        '@': ' ',
+        '#': ' ',
+        '$': ' ',
+        '%': ' ',
+        '^': ' ',
+        '&': ' ',
+        '*': ' ',
+        '(': ' ',
+        ')': ' ',
+        '-': ' ',
+        '+': ' ',
+        '=': ' ',
+        '~': ' ',
+        '?': ' ',
+        '|': ' ',
+        '/': ' ',
+        '\\': ' ',
+        '`': ' ',
+    }
+)
+
+
+def sanitize_falkor_fulltext_query(query: str) -> str:
+    """Replace FalkorDB special characters with whitespace."""
+    return ' '.join(query.translate(_SEPARATOR_MAP).split())
+
+
+def _escape_fulltext_group_id(group_id: str) -> str:
+    """Escape a validated group ID for RediSearch fulltext syntax."""
+    return re.sub(r'([^a-zA-Z0-9])', r'\\\1', group_id)
+
+
+def build_falkor_fulltext_query(
+    query: str,
+    group_ids: list[str] | None = None,
+    max_query_length: int = MAX_QUERY_LENGTH,
+) -> str:
+    """Build a FalkorDB RedisSearch fulltext query."""
+    validate_group_ids(group_ids)
+
+    group_filter = ''
+    if group_ids:
+        escaped_group_ids = [f'"{_escape_fulltext_group_id(group_id)}"' for group_id in group_ids]
+        group_filter = f'(@group_id:{"|".join(escaped_group_ids)})'
+
+    filtered_words = [
+        word
+        for word in sanitize_falkor_fulltext_query(query).split()
+        if word.lower() not in STOPWORDS
+    ]
+    if not filtered_words:
+        return ''
+
+    sanitized_query = ' | '.join(filtered_words)
+    if len(sanitized_query.split(' ')) + len(group_ids or []) >= max_query_length:
+        return ''
+
+    return f'{group_filter} ({sanitized_query})'

--- a/graphiti_core/driver/falkordb/operations/graph_ops.py
+++ b/graphiti_core/driver/falkordb/operations/graph_ops.py
@@ -175,28 +175,6 @@ class FalkorGraphMaintenanceOperations(GraphMaintenanceOperations):
 
         return community_clusters
 
-    async def remove_communities(
-        self,
-        executor: QueryExecutor,
-        group_ids: list[str] | None = None,
-    ) -> None:
-        if group_ids:
-            await executor.execute_query(
-                """
-                MATCH (c:Community)
-                WHERE c.group_id IN $group_ids
-                DETACH DELETE c
-                """,
-                group_ids=group_ids,
-            )
-        else:
-            await executor.execute_query(
-                """
-                MATCH (c:Community)
-                DETACH DELETE c
-                """
-            )
-
     async def determine_entity_community(
         self,
         executor: QueryExecutor,

--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -15,11 +15,13 @@ limitations under the License.
 """
 
 import logging
-import re
 from typing import Any
 
 from graphiti_core.driver.driver import GraphProvider
-from graphiti_core.driver.falkordb import STOPWORDS
+from graphiti_core.driver.falkordb.fulltext import (
+    MAX_QUERY_LENGTH,
+    build_falkor_fulltext_query,
+)
 from graphiti_core.driver.operations.search_ops import SearchOperations
 from graphiti_core.driver.query_executor import QueryExecutor
 from graphiti_core.driver.record_parsers import (
@@ -49,99 +51,14 @@ from graphiti_core.search.search_filters import (
 
 logger = logging.getLogger(__name__)
 
-MAX_QUERY_LENGTH = 128
-
-# FalkorDB separator characters that break text into tokens
-_SEPARATOR_MAP = str.maketrans(
-    {
-        ',': ' ',
-        '.': ' ',
-        '<': ' ',
-        '>': ' ',
-        '{': ' ',
-        '}': ' ',
-        '[': ' ',
-        ']': ' ',
-        '"': ' ',
-        "'": ' ',
-        ':': ' ',
-        ';': ' ',
-        '!': ' ',
-        '@': ' ',
-        '#': ' ',
-        '$': ' ',
-        '%': ' ',
-        '^': ' ',
-        '&': ' ',
-        '*': ' ',
-        '(': ' ',
-        ')': ' ',
-        '-': ' ',
-        '+': ' ',
-        '=': ' ',
-        '~': ' ',
-        '?': ' ',
-        '|': ' ',
-        '/': ' ',
-        '\\': ' ',
-        '`': ' ',
-    }
-)
-
-
-def _sanitize(query: str) -> str:
-    """Replace FalkorDB special characters with whitespace."""
-    sanitized = query.translate(_SEPARATOR_MAP)
-    return ' '.join(sanitized.split())
-
-
-def _escape_fulltext_group_id(group_id: str) -> str:
-    """Escape non-alphanumeric characters in a group_id for RediSearch fulltext.
-
-    RediSearch treats characters like '_' and '-' as token separators/operators,
-    so an unescaped group_id (e.g. the default '_') causes a parse error or fails
-    to match. group_ids are restricted to ``[a-zA-Z0-9_-]`` by ``validate_group_id``,
-    so escaping every non-alphanumeric char makes them match as literals.
-    """
-    return re.sub(r'([^a-zA-Z0-9])', r'\\\1', group_id)
-
 
 def _build_falkor_fulltext_query(
     query: str,
     group_ids: list[str] | None = None,
     max_query_length: int = MAX_QUERY_LENGTH,
 ) -> str:
-    """Build a fulltext query string for FalkorDB using RedisSearch syntax."""
-    if group_ids is None or len(group_ids) == 0:
-        group_filter = ''
-    else:
-        escaped_group_ids = [f'"{_escape_fulltext_group_id(gid)}"' for gid in group_ids]
-        group_values = '|'.join(escaped_group_ids)
-        group_filter = f'(@group_id:{group_values})'
-
-    sanitized_query = _sanitize(query)
-
-    # Remove stopwords and empty tokens
-    query_words = sanitized_query.split()
-    filtered_words = [word for word in query_words if word and word.lower() not in STOPWORDS]
-
-    if not filtered_words:
-        return ''
-
-    sanitized_query = ' | '.join(filtered_words)
-
-    # Short-circuit when every input token was a stopword; otherwise we
-    # emit `(@group_id:"...") ()`, which FalkorDB/RediSearch rejects
-    # with `Syntax error at offset N near <group_id>`. Callers already
-    # special-case `''` as 'no candidates'.
-    if not filtered_words:
-        return ''
-
-    if len(sanitized_query.split(' ')) + len(group_ids or '') >= max_query_length:
-        return ''
-
-    full_query = group_filter + ' (' + sanitized_query + ')'
-    return full_query
+    """Backward-compatible wrapper for the shared FalkorDB query builder."""
+    return build_falkor_fulltext_query(query, group_ids, max_query_length)
 
 
 class FalkorSearchOperations(SearchOperations):

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -17,7 +17,6 @@ limitations under the License.
 import asyncio
 import datetime
 import logging
-import re
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
@@ -36,7 +35,10 @@ else:
         ) from None
 
 from graphiti_core.driver.driver import GraphDriver, GraphDriverSession, GraphProvider
-from graphiti_core.driver.falkordb import STOPWORDS as STOPWORDS
+from graphiti_core.driver.falkordb.fulltext import (
+    build_falkor_fulltext_query,
+    sanitize_falkor_fulltext_query,
+)
 from graphiti_core.driver.falkordb.operations.community_edge_ops import (
     FalkorCommunityEdgeOperations,
 )
@@ -68,7 +70,6 @@ from graphiti_core.driver.operations.next_episode_edge_ops import NextEpisodeEdg
 from graphiti_core.driver.operations.saga_node_ops import SagaNodeOperations
 from graphiti_core.driver.operations.search_ops import SearchOperations
 from graphiti_core.graph_queries import get_fulltext_indices, get_range_indices
-from graphiti_core.helpers import validate_group_ids
 from graphiti_core.utils.datetime_utils import convert_datetimes_to_strings
 
 logger = logging.getLogger(__name__)
@@ -365,101 +366,10 @@ class FalkorDriver(GraphDriver):
             return obj
 
     def sanitize(self, query: str) -> str:
-        """
-        Replace FalkorDB special characters with whitespace.
-        Based on FalkorDB tokenization rules: ,.<>{}[]"':;!@#$%^&*()-+=~
-        """
-        # FalkorDB separator characters that break text into tokens
-        separator_map = str.maketrans(
-            {
-                ',': ' ',
-                '.': ' ',
-                '<': ' ',
-                '>': ' ',
-                '{': ' ',
-                '}': ' ',
-                '[': ' ',
-                ']': ' ',
-                '"': ' ',
-                "'": ' ',
-                ':': ' ',
-                ';': ' ',
-                '!': ' ',
-                '@': ' ',
-                '#': ' ',
-                '$': ' ',
-                '%': ' ',
-                '^': ' ',
-                '&': ' ',
-                '*': ' ',
-                '(': ' ',
-                ')': ' ',
-                '-': ' ',
-                '+': ' ',
-                '=': ' ',
-                '~': ' ',
-                '?': ' ',
-                '|': ' ',
-                '/': ' ',
-                '\\': ' ',
-                '`': ' ',
-            }
-        )
-        sanitized = query.translate(separator_map)
-        # Clean up multiple spaces
-        sanitized = ' '.join(sanitized.split())
-        return sanitized
+        """Replace FalkorDB special characters with whitespace."""
+        return sanitize_falkor_fulltext_query(query)
 
     def build_fulltext_query(
         self, query: str, group_ids: list[str] | None = None, max_query_length: int = 128
     ) -> str:
-        """
-        Build a fulltext query string for FalkorDB using RedisSearch syntax.
-        FalkorDB uses RedisSearch-like syntax where:
-        - Field queries use @ prefix: @field:value
-        - Multiple values for same field: (@field:value1|value2)
-        - Text search doesn't need @ prefix for content fields
-        - AND is implicit with space: (@group_id:value) (text)
-        - OR uses pipe within parentheses: (@group_id:value1|value2)
-        """
-        validate_group_ids(group_ids)
-
-        if group_ids is None or len(group_ids) == 0:
-            group_filter = ''
-        else:
-            # Quote group_ids and escape non-alphanumeric chars (e.g. '_' in the
-            # default group_id, or hyphens). RediSearch treats these as token
-            # separators/operators, which otherwise causes a syntax error or a
-            # failure to match. group_ids are restricted to [a-zA-Z0-9_-] by
-            # validate_group_ids above.
-            escaped_group_ids = [
-                '"' + re.sub(r'([^a-zA-Z0-9])', r'\\\1', gid) + '"' for gid in group_ids
-            ]
-            group_values = '|'.join(escaped_group_ids)
-            group_filter = f'(@group_id:{group_values})'
-
-        sanitized_query = self.sanitize(query)
-
-        # Remove stopwords and empty tokens from the sanitized query
-        query_words = sanitized_query.split()
-        filtered_words = [word for word in query_words if word and word.lower() not in STOPWORDS]
-
-        if not filtered_words:
-            return ''
-
-        sanitized_query = ' | '.join(filtered_words)
-
-        # Short-circuit when every input token was a stopword; otherwise we
-        # emit `(@group_id:"...") ()`, which FalkorDB/RediSearch rejects
-        # with `Syntax error at offset N near <group_id>`. Callers already
-        # special-case `''` as 'no candidates'.
-        if not filtered_words:
-            return ''
-
-        # If the query is too long return no query
-        if len(sanitized_query.split(' ')) + len(group_ids or '') >= max_query_length:
-            return ''
-
-        full_query = group_filter + ' (' + sanitized_query + ')'
-
-        return full_query
+        return build_falkor_fulltext_query(query, group_ids, max_query_length)

--- a/graphiti_core/driver/kuzu/operations/graph_ops.py
+++ b/graphiti_core/driver/kuzu/operations/graph_ops.py
@@ -150,28 +150,6 @@ class KuzuGraphMaintenanceOperations(GraphMaintenanceOperations):
 
         return community_clusters
 
-    async def remove_communities(
-        self,
-        executor: QueryExecutor,
-        group_ids: list[str] | None = None,
-    ) -> None:
-        if group_ids:
-            await executor.execute_query(
-                """
-                MATCH (c:Community)
-                WHERE c.group_id IN $group_ids
-                DETACH DELETE c
-                """,
-                group_ids=group_ids,
-            )
-        else:
-            await executor.execute_query(
-                """
-                MATCH (c:Community)
-                DETACH DELETE c
-                """
-            )
-
     async def determine_entity_community(
         self,
         executor: QueryExecutor,

--- a/graphiti_core/driver/neo4j/operations/graph_ops.py
+++ b/graphiti_core/driver/neo4j/operations/graph_ops.py
@@ -145,28 +145,6 @@ class Neo4jGraphMaintenanceOperations(GraphMaintenanceOperations):
 
         return community_clusters
 
-    async def remove_communities(
-        self,
-        executor: QueryExecutor,
-        group_ids: list[str] | None = None,
-    ) -> None:
-        if group_ids:
-            await executor.execute_query(
-                """
-                MATCH (c:Community)
-                WHERE c.group_id IN $group_ids
-                DETACH DELETE c
-                """,
-                group_ids=group_ids,
-            )
-        else:
-            await executor.execute_query(
-                """
-                MATCH (c:Community)
-                DETACH DELETE c
-                """
-            )
-
     async def determine_entity_community(
         self,
         executor: QueryExecutor,

--- a/graphiti_core/driver/neptune/operations/graph_ops.py
+++ b/graphiti_core/driver/neptune/operations/graph_ops.py
@@ -150,28 +150,6 @@ class NeptuneGraphMaintenanceOperations(GraphMaintenanceOperations):
 
         return community_clusters
 
-    async def remove_communities(
-        self,
-        executor: QueryExecutor,
-        group_ids: list[str] | None = None,
-    ) -> None:
-        if group_ids:
-            await executor.execute_query(
-                """
-                MATCH (c:Community)
-                WHERE c.group_id IN $group_ids
-                DETACH DELETE c
-                """,
-                group_ids=group_ids,
-            )
-        else:
-            await executor.execute_query(
-                """
-                MATCH (c:Community)
-                DETACH DELETE c
-                """
-            )
-
     async def determine_entity_community(
         self,
         executor: QueryExecutor,

--- a/graphiti_core/driver/neptune/operations/search_ops.py
+++ b/graphiti_core/driver/neptune/operations/search_ops.py
@@ -398,18 +398,9 @@ class NeptuneSearchOperations(SearchOperations):
             + filter_query
             + """
             RETURN DISTINCT
-                e.uuid AS uuid,
-                e.group_id AS group_id,
-                startNode(e).uuid AS source_node_uuid,
-                endNode(e).uuid AS target_node_uuid,
-                e.created_at AS created_at,
-                e.name AS name,
-                e.fact AS fact,
-                split(e.episodes, ',') AS episodes,
-                e.expired_at AS expired_at,
-                e.valid_at AS valid_at,
-                e.invalid_at AS invalid_at,
-                properties(e) AS attributes
+            """
+            + get_entity_edge_return_query(GraphProvider.NEPTUNE)
+            + """
             LIMIT $limit
             """
         )

--- a/graphiti_core/driver/operations/graph_ops.py
+++ b/graphiti_core/driver/operations/graph_ops.py
@@ -49,12 +49,28 @@ class GraphMaintenanceOperations(ABC):
         group_ids: list[str] | None = None,
     ) -> list[Any]: ...
 
-    @abstractmethod
     async def remove_communities(
         self,
         executor: QueryExecutor,
         group_ids: list[str] | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Delete communities, optionally restricted to the provided groups."""
+        if group_ids:
+            await executor.execute_query(
+                """
+                MATCH (c:Community)
+                WHERE c.group_id IN $group_ids
+                DETACH DELETE c
+                """,
+                group_ids=group_ids,
+            )
+        else:
+            await executor.execute_query(
+                """
+                MATCH (c:Community)
+                DETACH DELETE c
+                """
+            )
 
     @abstractmethod
     async def determine_entity_community(

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -242,18 +242,9 @@ async def edge_fulltext_search(
                 AND id(e)=id
                 WITH e, id.score as score, startNode(e) AS n, endNode(e) AS m
                 RETURN
-                    e.uuid AS uuid,
-                    e.group_id AS group_id,
-                    n.uuid AS source_node_uuid,
-                    m.uuid AS target_node_uuid,
-                    e.created_at AS created_at,
-                    e.name AS name,
-                    e.fact AS fact,
-                    split(e.episodes, ",") AS episodes,
-                    e.expired_at AS expired_at,
-                    e.valid_at AS valid_at,
-                    e.invalid_at AS invalid_at,
-                    properties(e) AS attributes
+                """
+                + get_entity_edge_return_query(GraphProvider.NEPTUNE)
+                + """
                 ORDER BY score DESC LIMIT $limit
                             """
             )
@@ -529,18 +520,9 @@ async def edge_bfs_search(
                 + filter_query
                 + """
                 RETURN DISTINCT
-                    e.uuid AS uuid,
-                    e.group_id AS group_id,
-                    startNode(e).uuid AS source_node_uuid,
-                    endNode(e).uuid AS target_node_uuid,
-                    e.created_at AS created_at,
-                    e.name AS name,
-                    e.fact AS fact,
-                    split(e.episodes, ',') AS episodes,
-                    e.expired_at AS expired_at,
-                    e.valid_at AS valid_at,
-                    e.invalid_at AS invalid_at,
-                    properties(e) AS attributes
+                """
+                + get_entity_edge_return_query(GraphProvider.NEPTUNE)
+                + """
                 LIMIT $limit
                 """
             )

--- a/graphiti_core/utils/maintenance/community_operations.py
+++ b/graphiti_core/utils/maintenance/community_operations.py
@@ -250,6 +250,9 @@ async def remove_communities(driver: GraphDriver, group_ids: list[str] | None = 
         except NotImplementedError:
             pass
 
+    if driver.graph_ops:
+        return await driver.graph_ops.remove_communities(driver, group_ids=group_ids)
+
     if group_ids:
         await driver.execute_query(
             """

--- a/tests/utils/maintenance/test_remove_communities.py
+++ b/tests/utils/maintenance/test_remove_communities.py
@@ -24,6 +24,7 @@ from graphiti_core.utils.maintenance.community_operations import remove_communit
 def _mock_driver():
     driver = MagicMock()
     driver.graph_operations_interface = None
+    driver.graph_ops = None
     driver.execute_query = AsyncMock()
     return driver
 
@@ -80,4 +81,18 @@ async def test_remove_communities_scoped_via_graph_operations_interface():
     driver.graph_operations_interface.remove_communities.assert_awaited_once_with(
         driver, group_ids=['group_a']
     )
+    driver.execute_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_remove_communities_scoped_via_graph_ops():
+    driver = MagicMock()
+    driver.graph_operations_interface = None
+    driver.graph_ops = MagicMock()
+    driver.graph_ops.remove_communities = AsyncMock()
+    driver.execute_query = AsyncMock()
+
+    await remove_communities(driver, group_ids=['group_a'])
+
+    driver.graph_ops.remove_communities.assert_awaited_once_with(driver, group_ids=['group_a'])
     driver.execute_query.assert_not_awaited()

--- a/tests/utils/search/test_edge_bfs_query_shape.py
+++ b/tests/utils/search/test_edge_bfs_query_shape.py
@@ -23,6 +23,7 @@ from typing import Any
 import pytest
 
 from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.neptune.operations.search_ops import NeptuneSearchOperations
 from graphiti_core.search.search_filters import SearchFilters
 from graphiti_core.search.search_utils import edge_bfs_search, edge_fulltext_search
 
@@ -42,6 +43,18 @@ class RecordingDriver:
         self.cypher_query = cypher_query_
         self.params = kwargs
         return [], None, None
+
+
+class RecordingNeptuneDriver(RecordingDriver):
+    provider = GraphProvider.NEPTUNE
+
+    def run_aoss_query(self, index_name: str, query: str):
+        return {
+            'hits': {
+                'total': {'value': 1},
+                'hits': [{'_source': {'uuid': 'edge-uuid'}, '_score': 1}],
+            }
+        }
 
 
 @pytest.mark.asyncio
@@ -84,3 +97,40 @@ async def test_edge_fulltext_search_not_rewritten_by_bfs_fix():
 
     assert 'WITH rel AS e, startNode(rel) AS n, endNode(rel) AS m' not in driver.cypher_query
     assert "type(e) = 'RELATES_TO'" not in driver.cypher_query
+
+
+@pytest.mark.asyncio
+async def test_neptune_generic_edge_searches_return_reference_time():
+    driver = RecordingNeptuneDriver()
+
+    await edge_bfs_search(
+        driver,  # type: ignore[arg-type]
+        ['origin-uuid'],
+        2,
+        SearchFilters(),
+        group_ids=['group-a'],
+    )
+    assert 'e.reference_time AS reference_time' in driver.cypher_query
+
+    await edge_fulltext_search(
+        driver,  # type: ignore[arg-type]
+        'api test system',
+        SearchFilters(),
+        group_ids=['group-a'],
+    )
+    assert 'e.reference_time AS reference_time' in driver.cypher_query
+
+
+@pytest.mark.asyncio
+async def test_neptune_operations_bfs_search_returns_reference_time():
+    executor = RecordingNeptuneDriver()
+
+    await NeptuneSearchOperations().edge_bfs_search(
+        executor,  # type: ignore[arg-type]
+        ['origin-uuid'],
+        2,
+        SearchFilters(),
+        group_ids=['group-a'],
+    )
+
+    assert 'e.reference_time AS reference_time' in executor.cypher_query


### PR DESCRIPTION
## Summary

Consolidates the overlapping backend changes merged during the recent review:

- moves FalkorDB fulltext sanitizing, group-ID escaping, stopword handling, and query construction into one shared helper used by both the legacy driver and operations API;
- removes the duplicate stopword-only guard in those two implementations;
- reuses the canonical edge return projection in every remaining Neptune fulltext/BFS path, preserving `reference_time` consistently;
- routes community deletion through `graph_ops` and moves its identical provider implementations to the shared maintenance-operations base class.

## Why

The recent patches correctly fixed individual behavior, but several touched paths retained independent copies. Those copies had already drifted: Neptune's duplicated projections omitted `reference_time`, and the FalkorDB builders contained redundant guards.

## Validation

`uv run --extra dev ruff check` on all changed files

`uv run --extra dev pytest -q tests/test_edge_db_queries.py tests/utils/search/test_edge_bfs_query_shape.py tests/utils/search/test_search_security.py tests/test_handle_multiple_group_ids.py tests/driver/test_falkordb_ops_routing.py tests/utils/maintenance/test_remove_communities.py`

Result: 42 passed (one pre-existing Pydantic deprecation warning).
