### PR TITLE
Bump graphiti-core to 0.29.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "graphiti-core"
 description = "A temporal graph building library"
-version = "0.29.2"
+version = "0.29.3"
 authors = [
     { name = "Paul Paliychuk", email = "paul@getzep.com" },
     { name = "Preston Rasmussen", email = "preston@getzep.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1097,7 +1097,7 @@ wheels = [
 
 [[package]]
 name = "graphiti-core"
-version = "0.29.2"
+version = "0.29.3"
 source = { editable = "." }
 dependencies = [
     { name = "neo4j" },


### PR DESCRIPTION
## Summary

Bumps the `graphiti-core` patch version from `0.29.2` to `0.29.3` after the recent bug-fix batch.

## Impact

This makes the fixes released on `main` available as a new patch version without changing the MCP server's independently versioned package.

## Validation

- `uv lock --locked`
- `uv build --wheel --out-dir /private/tmp/graphiti-core-0.29.3-wheel`

The build produced `graphiti_core-0.29.3-py3-none-any.whl`.
