### PR TITLE
feat(mcp): allow explicit reranker provider selection

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -169,9 +169,20 @@ llm:
   # Optional for OpenAI-compatible providers: "json_schema" (default) or "json_object"
   structured_output_mode: "json_schema"
 
+reranker:
+  # "auto" infers from the LLM, then embedder, then falls back to local BGE.
+  # Or select "openai", "azure_openai", "gemini", or "bge" explicitly.
+  provider: "auto"
+
 database:
   provider: "falkordb"  # Default. Options: "falkordb", "neo4j"
 ```
+
+An explicit API-backed reranker reuses credentials from the matching `llm.providers` or
+`embedder.providers` entry, even when that provider is not selected for the LLM or embedder. For
+example, `reranker.provider: "gemini"` uses the configured Gemini API key. Set
+`RERANKER_PROVIDER` when using the shipped `config.yaml`, or `RERANKER__PROVIDER` with direct
+environment-based configuration.
 
 ### Using Ollama for Local LLM
 

--- a/mcp_server/config/config.yaml
+++ b/mcp_server/config/config.yaml
@@ -73,6 +73,12 @@ embedder:
       api_url: ${VOYAGE_API_URL:https://api.voyageai.com/v1}
       model: "voyage-3"
 
+# By default, infer a reranker from the LLM and embedder providers, then fall back to local BGE.
+# Set this explicitly to openai, azure_openai, gemini, or bge to override that selection.
+# API-backed rerankers reuse credentials from the matching llm.providers or embedder.providers block.
+reranker:
+  provider: ${RERANKER_PROVIDER:auto}
+
 database:
   provider: "falkordb"  # Default: falkordb. Options: neo4j, falkordb
 

--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -181,6 +181,14 @@ class EmbedderConfig(BaseModel):
     providers: EmbedderProvidersConfig = Field(default_factory=EmbedderProvidersConfig)
 
 
+class RerankerConfig(BaseModel):
+    """Cross-encoder reranker configuration."""
+
+    provider: Literal['auto', 'openai', 'azure_openai', 'gemini', 'bge'] = Field(
+        default='auto', description='Reranker provider'
+    )
+
+
 class Neo4jProviderConfig(BaseModel):
     """Neo4j provider configuration."""
 
@@ -277,6 +285,7 @@ class GraphitiConfig(BaseSettings):
     server: ServerConfig = Field(default_factory=ServerConfig)
     llm: LLMConfig = Field(default_factory=LLMConfig)
     embedder: EmbedderConfig = Field(default_factory=EmbedderConfig)
+    reranker: RerankerConfig = Field(default_factory=RerankerConfig)
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)
     graphiti: GraphitiAppConfig = Field(default_factory=GraphitiAppConfig)
 

--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -221,7 +221,9 @@ class GraphitiService:
             # Create cross-encoder (reranker) client. Without this, Graphiti defaults to
             # OpenAIRerankerClient, which needs an OpenAI API key even on non-OpenAI setups.
             # Reranker setup errors must remain fatal rather than silently restoring that default.
-            cross_encoder_client = CrossEncoderFactory.create(self.config.llm, self.config.embedder)
+            cross_encoder_client = CrossEncoderFactory.create(
+                self.config.llm, self.config.embedder, self.config.reranker
+            )
 
             # Get database configuration
             db_config = DatabaseDriverFactory.create_config(self.config.database)

--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -6,7 +6,7 @@ from graphiti_core.llm_client import LLMClient, OpenAIClient
 from graphiti_core.llm_client.config import LLMConfig as GraphitiLLMConfig
 from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
 
-from config.schema import DatabaseConfig, EmbedderConfig, LLMConfig
+from config.schema import DatabaseConfig, EmbedderConfig, LLMConfig, RerankerConfig
 
 # Try to import FalkorDriver if available
 try:
@@ -414,16 +414,39 @@ class CrossEncoderFactory:
     """Factory for creating cross-encoder (reranker) clients based on configuration.
 
     Graphiti defaults the cross_encoder to OpenAIRerankerClient, which needs an OpenAI API key.
-    To keep the server usable on non-OpenAI setups, pick a reranker from the LLM provider, then
-    the embedder provider, and fall back to the local BGE reranker.
+    To keep the server usable on non-OpenAI setups, honor an explicit reranker provider when
+    configured. Otherwise, pick one from the LLM provider, then the embedder provider, and fall
+    back to the local BGE reranker.
     """
 
     @staticmethod
-    def create(llm_config: LLMConfig, embedder_config: EmbedderConfig) -> CrossEncoderClient:
+    def create(
+        llm_config: LLMConfig,
+        embedder_config: EmbedderConfig,
+        reranker_config: RerankerConfig | None = None,
+    ) -> CrossEncoderClient:
         """Create a cross-encoder client based on the configured providers."""
         import logging
 
         logger = logging.getLogger(__name__)
+
+        provider = reranker_config.provider if reranker_config is not None else 'auto'
+        if provider != 'auto':
+            if provider == 'bge':
+                return CrossEncoderFactory._local_reranker(logger)
+
+            for source, config in (('LLM', llm_config), ('embedder', embedder_config)):
+                explicit_config = config.model_copy(update={'provider': provider})
+                reranker = CrossEncoderFactory._reranker_for_provider(
+                    source, explicit_config, logger
+                )
+                if reranker is not None:
+                    return reranker
+
+            raise ValueError(
+                f"Reranker provider '{provider}' is not configured under "
+                'llm.providers or embedder.providers'
+            )
 
         # Try the LLM provider first, then the embedder, before falling back to a local model.
         for source, config in (('LLM', llm_config), ('embedder', embedder_config)):
@@ -431,8 +454,11 @@ class CrossEncoderFactory:
             if reranker is not None:
                 return reranker
 
-        # No provider reranker available (e.g. Anthropic LLM + Voyage embedder), so use the
-        # local BGE cross-encoder, which needs no API key.
+        return CrossEncoderFactory._local_reranker(logger)
+
+    @staticmethod
+    def _local_reranker(logger) -> CrossEncoderClient:
+        """Create the local BGE fallback reranker."""
         logger.warning(
             'No provider reranker available, using local BGERerankerClient '
             '(downloads BAAI/bge-reranker-v2-m3, ~2.3 GB, on first run)'

--- a/mcp_server/tests/test_cross_encoder_factory.py
+++ b/mcp_server/tests/test_cross_encoder_factory.py
@@ -26,6 +26,7 @@ from config.schema import (
     LLMConfig,
     LLMProvidersConfig,
     OpenAIProviderConfig,
+    RerankerConfig,
     VoyageProviderConfig,
 )
 from services.factories import CrossEncoderFactory
@@ -57,6 +58,28 @@ class TestCrossEncoderFactory:
             providers=EmbedderProvidersConfig(gemini=GeminiProviderConfig(api_key='test-key')),
         )
         assert isinstance(CrossEncoderFactory.create(llm, embedder), GeminiRerankerClient)
+
+    def test_graphiti_config_accepts_explicit_reranker_provider(self):
+        config = GraphitiConfig(reranker={'provider': 'gemini'})
+
+        assert config.model_dump().get('reranker') == {'provider': 'gemini'}
+
+    def test_explicit_gemini_reranker_overrides_provider_inference(self):
+        llm = LLMConfig(
+            provider='openai',
+            providers=LLMProvidersConfig(
+                openai=OpenAIProviderConfig(api_key='openai-key'),
+                gemini=GeminiProviderConfig(api_key='gemini-key'),
+            ),
+        )
+        embedder = EmbedderConfig(
+            provider='openai',
+            providers=EmbedderProvidersConfig(openai=OpenAIProviderConfig(api_key='openai-key')),
+        )
+
+        reranker = CrossEncoderFactory.create(llm, embedder, RerankerConfig(provider='gemini'))
+
+        assert isinstance(reranker, GeminiRerankerClient)
 
     def test_missing_local_reranker_dependency_is_actionable(self, monkeypatch, caplog):
         llm = LLMConfig(
@@ -100,3 +123,35 @@ async def test_graphiti_service_does_not_swallow_reranker_configuration_error(mo
 
     with pytest.raises(ValueError, match='reranker setup failed'):
         await service.initialize()
+
+
+@pytest.mark.asyncio
+async def test_graphiti_service_uses_explicit_reranker_config(monkeypatch):
+    constructed = {}
+    fake_client = Mock()
+    fake_client.build_indices_and_constraints = AsyncMock()
+
+    def capture_graphiti(**kwargs):
+        constructed.update(kwargs)
+        return fake_client
+
+    monkeypatch.setattr(graphiti_mcp_server, 'Graphiti', capture_graphiti)
+    config = GraphitiConfig(
+        llm=LLMConfig(
+            provider='openai',
+            providers=LLMProvidersConfig(
+                openai=OpenAIProviderConfig(api_key='openai-key'),
+                gemini=GeminiProviderConfig(api_key='gemini-key'),
+            ),
+        ),
+        embedder=EmbedderConfig(
+            provider='openai',
+            providers=EmbedderProvidersConfig(openai=OpenAIProviderConfig(api_key='openai-key')),
+        ),
+        reranker=RerankerConfig(provider='gemini'),
+        database=DatabaseConfig(provider='neo4j'),
+    )
+
+    await graphiti_mcp_server.GraphitiService(config).initialize()
+
+    assert isinstance(constructed['cross_encoder'], GeminiRerankerClient)


### PR DESCRIPTION
## Summary

Add an explicit MCP `reranker.provider` configuration while preserving the automatic selection behavior merged in #1637.

- `auto` keeps the current LLM → embedder → local BGE fallback chain.
- `openai`, `azure_openai`, and `gemini` reuse credentials already configured under the matching LLM/embedder provider entry.
- `bge` explicitly selects the existing local reranker.
- Document both YAML and direct environment overrides.

This is the explicit configuration follow-up discussed around #1637 and the earlier provider-matched proposal #1669.

Closes #1697.

## Testing

- Test-first coverage for configuration parsing, explicit Gemini override behavior, and Graphiti service wiring.
- `68 passed` across MCP factory, configuration, core-parity, transport, and stdio unit tests.
- `ruff check` and `ruff format --check` pass for all changed Python files.
- Focused Pyright passes with 0 errors, 0 warnings.
