### PR TITLE
Let .env reach the containers in docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# The root Dockerfile builds only server/, so exclude the whole repo and add that one
+# subtree back. An allow-list keeps the context minimal without needing an update every
+# time the repo grows a new top-level directory.
+*
+!server/
+
+# Re-exclude what lives under server/ but never belongs in an image layer: a local
+# virtualenv (larger than the image itself), local secrets, and build droppings.
+server/.venv
+server/.env
+server/.env.*
+server/tests
+server/**/__pycache__
+server/**/*.pyc

--- a/.env.example
+++ b/.env.example
@@ -38,8 +38,3 @@ SEMAPHORE_LIMIT=10
 # EMBEDDING_MODEL_NAME=
 # Point at an OpenAI-compatible gateway instead of api.openai.com.
 # OPENAI_BASE_URL=
-
-# --- Pinning ----------------------------------------------------------------------
-# The graphiti-core release docker-compose builds against, matching render.yaml. This
-# is a PyPI release number, not this repo's own version in pyproject.toml.
-GRAPHITI_VERSION=0.29.3

--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,45 @@
+# Copy to .env for local development. On Render these are set by render.yaml, except
+# OPENAI_API_KEY, which Render prompts for at deploy time.
+#
+# Optional settings are left commented out rather than assigned an empty value. An
+# empty assignment is not the same as unset: it reaches the app as '' and is taken as
+# a real setting. Uncomment a line to use it.
+
+# --- Required ---------------------------------------------------------------------
+# Graphiti calls an LLM to extract entities and facts. https://platform.openai.com/api-keys
 OPENAI_API_KEY=
 
-# Neo4j database connection
-NEO4J_URI=
-NEO4J_PORT=
-NEO4J_USER=
-NEO4J_PASSWORD=
+# --- Graph backend ----------------------------------------------------------------
+# 'falkordb' (what this template deploys) or 'neo4j'.
+DB_BACKEND=falkordb
 
-# FalkorDB database connection 
-FALKORDB_URI=
-FALKORDB_PORT=
-FALKORDB_USER=
-FALKORDB_PASSWORD=
+# FalkorDB. On Render, FALKORDB_HOST is wired to the private graphiti-falkordb service.
+FALKORDB_HOST=localhost
+FALKORDB_PORT=6379
+FALKORDB_DATABASE=default_db
+# Only if you put FalkorDB behind a password (see the README).
+# FALKORDB_USERNAME=
+# FALKORDB_PASSWORD=
 
-USE_PARALLEL_RUNTIME=
-SEMAPHORE_LIMIT=
-GITHUB_SHA=
-MAX_REFLEXION_ITERATIONS=
-ANTHROPIC_API_KEY=
+# Neo4j, used instead of the FalkorDB block when DB_BACKEND=neo4j.
+# NEO4J_URI=
+# NEO4J_USER=
+# NEO4J_PASSWORD=
+# Bolt port; read by docker-compose.yml, which defaults it to 7687.
+# NEO4J_PORT=
+
+# --- Model ------------------------------------------------------------------------
+# Any OpenAI model id; leave unset to use graphiti-core's default.
+MODEL_NAME=gpt-5.5
+# Concurrent LLM calls during ingestion. graphiti-core defaults to 20; this is lower to
+# stay under the rate limits on a fresh OpenAI account.
+SEMAPHORE_LIMIT=10
+# Embedding model; leave unset for graphiti-core's default (text-embedding-3-small).
+# EMBEDDING_MODEL_NAME=
+# Point at an OpenAI-compatible gateway instead of api.openai.com.
+# OPENAI_BASE_URL=
+
+# --- Pinning ----------------------------------------------------------------------
+# The graphiti-core release docker-compose builds against, matching render.yaml. This
+# is a PyPI release number, not this repo's own version in pyproject.toml.
+GRAPHITI_VERSION=0.29.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
 # syntax=docker/dockerfile:1.9
 FROM python:3.12-slim
 
+# The graphiti-core release installed from PyPI below, and the value of the version
+# labels. This default is the single source of truth for the pin: render.yaml,
+# docker-compose.yml, and local builds all inherit it, so a bump happens here and
+# nowhere else. It is a PyPI release number, not this repo's own version.
+#
+# 0.29.2 in particular does not work on FalkorDB: it writes episodes fine but reads them
+# back empty, so /search and /episodes return nothing. Verify a write-then-search round
+# trip before bumping. Release CI overrides this with the version it is publishing.
+ARG GRAPHITI_VERSION=0.29.3
+
 # Inherit build arguments for labels
-ARG GRAPHITI_VERSION
 ARG BUILD_DATE
 ARG VCS_REF
 
@@ -45,19 +54,12 @@ COPY ./server/graph_service ./graph_service
 # This prevents the stale lockfile from pinning an old graphiti-core version
 ARG INSTALL_FALKORDB=false
 RUN --mount=type=cache,target=/root/.cache/uv \
+    : "${GRAPHITI_VERSION:?must be a graphiti-core release from PyPI}" && \
     uv sync --frozen --no-dev && \
-    if [ -n "$GRAPHITI_VERSION" ]; then \
-        if [ "$INSTALL_FALKORDB" = "true" ]; then \
-            uv pip install --upgrade "graphiti-core[falkordb]==$GRAPHITI_VERSION"; \
-        else \
-            uv pip install --upgrade "graphiti-core==$GRAPHITI_VERSION"; \
-        fi; \
+    if [ "$INSTALL_FALKORDB" = "true" ]; then \
+        uv pip install --upgrade "graphiti-core[falkordb]==$GRAPHITI_VERSION"; \
     else \
-        if [ "$INSTALL_FALKORDB" = "true" ]; then \
-            uv pip install --upgrade "graphiti-core[falkordb]"; \
-        else \
-            uv pip install --upgrade graphiti-core; \
-        fi; \
+        uv pip install --upgrade "graphiti-core==$GRAPHITI_VERSION"; \
     fi
 
 # Change ownership to app user

--- a/README.md
+++ b/README.md
@@ -60,8 +60,15 @@ from `graphiti-api` over Render's private network.
    | Variable          | Default   | Notes                                                                             |
    | ----------------- | --------- | --------------------------------------------------------------------------------- |
    | `MODEL_NAME`      | `gpt-5.5` | Any OpenAI model id.                                                              |
-   | `GRAPHITI_VERSION` | `0.29.3` | The `graphiti-core` release from PyPI the image is built against — not this repo's own version number. Pinned so every fork deploys the same library. Test a write-then-search round trip before bumping it. |
    | `SEMAPHORE_LIMIT` | `10`      | Concurrent LLM calls during ingestion. Deliberately below graphiti-core's default of 20, so a burst of episodes doesn't trip the rate limits on a fresh OpenAI key. Raise it once you know your account's limits. |
+
+   The `graphiti-core` version is pinned in one place: the `GRAPHITI_VERSION` build arg
+   default in [`Dockerfile`](Dockerfile). Every fork therefore deploys the same library,
+   and local `docker compose` builds match Render without a second pin to keep in step.
+   Bump it there, and verify a write-then-search round trip before you do — `0.29.2`, for
+   one, writes episodes on FalkorDB but reads them back empty. To override it for a single
+   Render service without editing the Dockerfile, add `GRAPHITI_VERSION` as an env var on
+   that service; Render passes env vars to the Docker build as build args.
 
 3. Wait for both services to go live. `graphiti-api` passes its health check at `/healthcheck`.
 

--- a/README.md
+++ b/README.md
@@ -1,722 +1,184 @@
-<p align="center">
-  <a href="https://www.getzep.com/">
-    <img src="https://github.com/user-attachments/assets/119c5682-9654-4257-8922-56b7cb8ffd73" width="150" alt="Zep Logo">
-  </a>
-</p>
+# Graphiti on Render
 
-<h1 align="center">
-Graphiti
-</h1>
-<h2 align="center">Build Temporal Context Graphs for AI Agents</h2>
+Deploy [Graphiti](https://github.com/getzep/graphiti) on Render in one click. Get a hosted
+temporal knowledge-graph API your agents can write memories to and search over time.
 
-<div align="center">
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Ho1yShif/graphiti)
 
-[![Lint](https://github.com/getzep/Graphiti/actions/workflows/lint.yml/badge.svg?style=flat)](https://github.com/getzep/Graphiti/actions/workflows/lint.yml)
-[![Unit Tests](https://github.com/getzep/Graphiti/actions/workflows/unit_tests.yml/badge.svg)](https://github.com/getzep/Graphiti/actions/workflows/unit_tests.yml)
-[![MyPy Check](https://github.com/getzep/Graphiti/actions/workflows/typecheck.yml/badge.svg)](https://github.com/getzep/Graphiti/actions/workflows/typecheck.yml)
+## What you get
 
-[![GitHub Repo stars](https://img.shields.io/github/stars/getzep/graphiti)](https://github.com/getzep/graphiti/stargazers)
-[![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?&logo=discord&logoColor=white)](https://discord.com/invite/W8Kw6bsgXQ)
-[![arXiv](https://img.shields.io/badge/arXiv-2501.13956-b31b1b.svg?style=flat)](https://arxiv.org/abs/2501.13956)
-[![Release](https://img.shields.io/github/v/release/getzep/graphiti?style=flat&label=Release&color=limegreen)](https://github.com/getzep/graphiti/releases)
+Graphiti turns a stream of conversations or events into a knowledge graph, and keeps track of
+_when_ each fact was true. When something changes — someone switches teams, a deadline moves —
+it doesn't overwrite the old fact, it invalidates it and records the new one. So an agent can
+ask what's true now, and also what was true last quarter.
 
-</div>
-<div align="center">
+This template deploys the backend for that: a REST API and the graph store behind it. **There
+is no web UI.** The deliverable is a live URL like `https://graphiti-api.onrender.com` that you
+call from your own agent code, a script, or a framework like LangGraph.
 
-<a href="https://trendshift.io/repositories/12986" target="_blank"><img src="https://trendshift.io/api/badge/repositories/12986" alt="getzep%2Fgraphiti | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+### Architecture
 
-</div>
+```
+                       ┌───────────────────────────┐
+   your agent /        │   graphiti-api (docker)   │        ┌──────────────┐
+   script / app  ─────▶│   FastAPI · public HTTPS  │───────▶│  OpenAI API  │
+      HTTPS            │   /messages  /search      │  facts └──────────────┘
+                       └─────────────┬─────────────┘  entities
+                                     │
+                         Redis proto │ private network only
+                                     ▼
+                       ┌───────────────────────────┐
+                       │ graphiti-falkordb (image) │
+                       │ private service · :6379   │
+                       │ 10 GB disk, append-only   │
+                       └───────────────────────────┘
+```
 
-> [!NOTE]
-> **We're Hiring!** Build context graphs that power reliable, personalized, fast production AI agents.
-> Come build with us — we're hiring Engineers and Developer Relations folks. [View open roles](https://www.getzep.com/careers/).
+`graphiti-falkordb` is a **private service**: it has no public address and accepts traffic only
+from `graphiti-api` over Render's private network.
 
-⭐ *Help us reach more developers and grow the Graphiti community. Star this repo!*
+## Deploy
 
-&nbsp;
+1. Click **Deploy to Render** above. Render reads [`render.yaml`](render.yaml) and creates a
+   `graphiti` project containing both services.
+2. Render prompts for one secret on `graphiti-api`:
 
-> [!TIP]
-> Check out the new [MCP server for Graphiti](mcp_server/README.md)! Give Claude, Cursor, and other MCP clients powerful
-> context graph-based memory with temporal awareness.
+   | Variable         | What it's for                                                                                       | Where to get it                                                      |
+   | ---------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+   | `OPENAI_API_KEY` | Graphiti calls an LLM to pull entities and facts out of each episode, and to embed them for search. | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
 
-Graphiti is a framework for building and querying temporal context graphs for AI agents. Unlike static knowledge graphs,
-Graphiti's context graphs track how facts change over time, maintain provenance to source data, and support both
-prescribed and learned ontology — making them purpose-built for agents operating on evolving, real-world data.
+   If you use a **restricted** OpenAI key, this deployment needs exactly two of the
+   permissions under **Model capabilities**, both write:
 
-Unlike traditional retrieval-augmented generation (RAG) methods, Graphiti continuously integrates user interactions,
-structured and unstructured enterprise data, and external information into a coherent, queryable graph. The framework
-supports incremental data updates, efficient retrieval, and precise historical queries without requiring complete graph
-recomputation, making it suitable for developing interactive, context-aware AI applications.
+   | Permission     | Used for                                                                           |
+   | -------------- | ---------------------------------------------------------------------------------- |
+   | **Responses**  | Write access on `/v1/responses` — extracting entities and facts from each episode. |
+   | **Embeddings** | Write access on `/v1/embeddings` — embedding nodes, edges, and search queries.     |
 
-Use Graphiti to:
+   Everything else is set for you in `render.yaml`. The ones worth knowing about:
 
-- Build context graphs that evolve with every interaction — tracking what's true now and what was true before.
-- Give agents rich, structured context instead of flat document chunks or raw chat history.
-- Query across time, meaning, and relationships with hybrid retrieval (semantic + keyword + graph traversal).
+   | Variable          | Default   | Notes                                                                             |
+   | ----------------- | --------- | --------------------------------------------------------------------------------- |
+   | `MODEL_NAME`      | `gpt-5.5` | Any OpenAI model id.                                                              |
+   | `GRAPHITI_VERSION` | `0.29.3` | The `graphiti-core` release from PyPI the image is built against — not this repo's own version number. Pinned so every fork deploys the same library. Test a write-then-search round trip before bumping it. |
+   | `SEMAPHORE_LIMIT` | `10`      | Concurrent LLM calls during ingestion. Deliberately below graphiti-core's default of 20, so a burst of episodes doesn't trip the rate limits on a fresh OpenAI key. Raise it once you know your account's limits. |
 
-&nbsp;
+3. Wait for both services to go live. `graphiti-api` passes its health check at `/healthcheck`.
 
-<p align="center">
-    <img src="images/graphiti-graph-intro.gif" alt="Graphiti temporal walkthrough" width="700px">
-</p>
+> **This API has no authentication.** Anyone who knows your URL can write to your graph and
+> spend your OpenAI key. Before you point real traffic at it, put it behind your own auth,
+> an API gateway, or a private network. In the meantime, use a dedicated OpenAI key you can
+> revoke and set a monthly spend cap in the OpenAI console — that cap is your backstop.
 
-&nbsp;
+### Using the app
 
-## What is a Context Graph?
+Ingestion is asynchronous — `/messages` queues the episode and returns immediately, then
+Graphiti extracts entities and facts in the background. Give it 10–30 seconds before searching.
 
-A **context graph** is a temporal graph of entities, relationships, and facts — like *"Kendra loves Adidas shoes (as of
-March 2026)."* Unlike traditional knowledge graphs, each fact in a context graph has a validity window: when it became
-true, and when (if ever) it was superseded. Entities evolve over time with updated summaries. Everything traces back to
-**episodes** — the raw data that produced it.
-
-What makes Graphiti unique is its ability to autonomously build context graphs from unstructured and structured data,
-handling changing relationships while preserving full temporal history.
-
-A context graph contains:
-
-| Component | What it stores |
-|-----------|---------------|
-| **Entities** (nodes) | People, products, policies, concepts — with summaries that evolve over time |
-| **Facts / Relationships** (edges) | Triplets (Entity → Relationship → Entity) with temporal validity windows |
-| **Episodes** (provenance) | Raw data as ingested — the ground truth stream. Every derived fact traces back here |
-| **Custom Types** (ontology) | Developer-defined entity and edge types via Pydantic models |
-
-## Graphiti and Zep
-
-Graphiti is the open-source temporal context graph engine at the core of
-[Zep's](https://www.getzep.com) context infrastructure for AI agents. Zep manages context graphs at scale, providing
-governed, low-latency context retrieval and assembly for production agent deployments.
-
-Under the hood, Zep is powered by a proprietary graph database — the
-[Context Graph Engine](https://www.getzep.com/platform/context-graph-engine/) — built for millions of context graphs
-with low-latency retrieval, so production deployments don't require a separate third-party graph database.
-
-Using Graphiti, we've demonstrated Zep is
-the [State of the Art in Agent Memory](https://blog.getzep.com/state-of-the-art-agent-memory/).
-
-Read our paper: [Zep: A Temporal Knowledge Graph Architecture for Agent Memory](https://arxiv.org/abs/2501.13956).
-
-We're excited to open-source Graphiti, believing its potential as a context graph engine reaches far beyond memory
-applications.
-
-<p align="center">
-    <a href="https://arxiv.org/abs/2501.13956"><img src="images/arxiv-screenshot.png" alt="Zep: A Temporal Knowledge Graph Architecture for Agent Memory" width="700px"></a>
-</p>
-
-## Zep vs Graphiti
-
-| Aspect | Zep | Graphiti |
-|--------|-----|---------|
-| **What they are** | Managed context graph infrastructure for AI agents | Open-source temporal context graph engine |
-| **Context graphs** | Manages vast numbers of per-user/entity context graphs with governance | Build and query individual context graphs |
-| **Graph database** | Proprietary [Context Graph Engine](https://www.getzep.com/platform/context-graph-engine/) — built for millions of context graphs with low-latency retrieval; no third-party graph database vendor required | Bring your own third-party graph database |
-| **User & conversation management** | Built-in users, threads, and message storage | Build your own |
-| **Retrieval & performance** | Pre-configured, production-ready retrieval with sub-200ms performance at scale | Custom implementation required; performance depends on your setup |
-| **Developer tools** | Dashboard with graph visualization, debug logs, API logs; SDKs for Python, TypeScript, and Go | Build your own tools |
-| **Enterprise features** | SLAs, support, security guarantees | Self-managed |
-| **Deployment** | Fully managed or in your cloud | Self-hosted only |
-
-### When to choose which
-
-**Choose Zep** if you want a turnkey, enterprise-grade platform with security, performance, and support baked in.
-
-**Choose Graphiti** if you want a flexible OSS core and you're comfortable building/operating the surrounding system.
-
-## Why Graphiti?
-
-Traditional RAG approaches often rely on batch processing and static data summarization, making them inefficient for
-frequently changing data. Graphiti addresses these challenges by providing:
-
-- **Temporal Fact Management:** Facts have validity windows. When information changes, old facts are
-  invalidated — not deleted. Query what's true now, or what was true at any point in time.
-- **Episodes & Provenance:** Every entity and relationship traces back to the episodes (raw data) that produced it.
-  Full lineage from derived fact to source.
-- **Prescribed & Learned Ontology:** Define entity and edge types upfront via Pydantic models (prescribed), or let
-  structure emerge from your data (learned). Start simple, evolve as patterns appear.
-- **Incremental Graph Construction:** New data integrates immediately without batch recomputation. The graph evolves
-  in real-time as episodes are ingested.
-- **Hybrid Retrieval:** Combines semantic embeddings, keyword (BM25), and graph traversal for low-latency,
-  high-precision queries without reliance on LLM summarization.
-- **Scalability:** Efficiently manages large datasets with parallel processing, pluggable graph backends, suitable
-  for enterprise workloads.
-
-<p align="center">
-    <img src="/images/graphiti-intro-slides-stock-2.gif" alt="Graphiti structured + unstructured demo" width="700px">
-</p>
-
-## Graphiti vs. GraphRAG
-
-| Aspect | GraphRAG | Graphiti |
-|--------|----------|---------|
-| **Primary Use** | Static document summarization | Dynamic, evolving context for agents |
-| **Data Handling** | Batch-oriented processing | Continuous, incremental updates |
-| **Knowledge Structure** | Entity clusters & community summaries | Temporal context graph — entities, facts with validity windows, episodes, communities |
-| **Retrieval Method** | Sequential LLM summarization | Hybrid semantic, keyword, and graph-based search |
-| **Adaptability** | Low | High |
-| **Temporal Handling** | Basic timestamp tracking | Explicit bi-temporal tracking with automatic fact invalidation |
-| **Contradiction Handling** | LLM-driven summarization judgments | Automatic fact invalidation with temporal history preserved |
-| **Query Latency** | Seconds to tens of seconds | Typically sub-second latency |
-| **Custom Entity Types** | No | Yes, customizable via Pydantic models |
-| **Scalability** | Moderate | High, optimized for large datasets |
-
-Graphiti is specifically designed to address the challenges of dynamic and frequently updated datasets, making it
-particularly suitable for applications requiring real-time interaction and precise historical queries.
-
-## Installation
-
-Requirements:
-
-- Python 3.10 or higher
-- Neo4j 5.26 / FalkorDB 1.1.2 / Amazon Neptune Database Cluster or Neptune Analytics Graph + Amazon OpenSearch
-  Serverless collection (serves as the full text search backend) / Kuzu 0.11.2 (**deprecated**, see below)
-- OpenAI API key (Graphiti defaults to OpenAI for LLM inference and embedding)
-
-> [!IMPORTANT]
-> Graphiti works best with LLM services that support Structured Output (such as OpenAI, Anthropic, and Gemini).
-> Using other services may result in incorrect output schemas and ingestion failures. This is particularly
-> problematic when using smaller models.
-
-Optional:
-
-- Google Gemini, Anthropic, or Groq API key (for alternative LLM providers)
-
-> [!TIP]
-> The simplest way to install Neo4j is via [Neo4j Desktop](https://neo4j.com/download/). It provides a user-friendly
-> interface to manage Neo4j instances and databases.
-> Alternatively, you can use FalkorDB on-premises via Docker and instantly start with the quickstart example:
-> ```
-> docker run -p 6379:6379 -p 3000:3000 -it --rm falkordb/falkordb:latest
-> ```
+Set your URL once:
 
 ```bash
-pip install graphiti-core
+export GRAPHITI_URL=https://graphiti-api.onrender.com
 ```
 
-or
-
-```bash
-uv add graphiti-core
-```
-
-### Installing with FalkorDB Support
-
-If you plan to use FalkorDB as your graph database backend, install with the FalkorDB extra:
-
-```bash
-pip install graphiti-core[falkordb]
-
-# or with uv
-uv add graphiti-core[falkordb]
-
-# or embedded version (requires Python 3.12+)
-pip install graphiti-core[falkordblite]
-# or with uv
-uv add graphiti-core[falkordblite]
-```
-
-### Installing with Kuzu Support
-
-> [!WARNING]
-> **Kuzu is deprecated** and will be removed in a future release — the upstream Kuzu project is no longer
-> maintained. New projects should use Neo4j or FalkorDB. The driver still ships for now but emits a
-> `DeprecationWarning`.
-
-If you plan to use Kuzu as your graph database backend, install with the Kuzu extra:
-
-```bash
-pip install graphiti-core[kuzu]
-
-# or with uv
-uv add graphiti-core[kuzu]
-```
-
-### Installing with Amazon Neptune Support
-
-If you plan to use Amazon Neptune as your graph database backend, install with the Amazon Neptune extra:
-
-```bash
-pip install graphiti-core[neptune]
-
-# or with uv
-uv add graphiti-core[neptune]
-```
-
-### You can also install optional LLM providers as extras:
-
-```bash
-# Install with Anthropic support
-pip install graphiti-core[anthropic]
-
-# Install with Groq support
-pip install graphiti-core[groq]
-
-# Install with Google Gemini support
-pip install graphiti-core[google-genai]
-
-# Install with multiple providers
-pip install graphiti-core[anthropic,groq,google-genai]
-
-# Install with FalkorDB and LLM providers
-pip install graphiti-core[falkordb,anthropic,google-genai]
-
-# Install with Amazon Neptune
-pip install graphiti-core[neptune]
-```
-
-## Default to Low Concurrency; LLM Provider 429 Rate Limit Errors
-
-Graphiti's ingestion pipelines are designed for high concurrency. By default, concurrency is set low to avoid LLM
-Provider 429 Rate Limit Errors. If you find Graphiti slow, please increase concurrency as described below.
-
-Concurrency controlled by the `SEMAPHORE_LIMIT` environment variable. By default, `SEMAPHORE_LIMIT` is set to `10`
-concurrent operations to help prevent `429` rate limit errors from your LLM provider. If you encounter such errors, try
-lowering this value.
-
-If your LLM provider allows higher throughput, you can increase `SEMAPHORE_LIMIT` to boost episode ingestion
-performance.
-
-## Quick Start
-
-> [!IMPORTANT]
-> Graphiti defaults to using OpenAI for LLM inference and embedding. Ensure that an `OPENAI_API_KEY` is set in your
-> environment.
-> Support for Anthropic, Gemini, and Groq is available, too. Other LLM providers — both hosted OpenAI-compatible APIs
-> (DeepSeek, Together, OpenRouter, …) and local servers (Ollama, vLLM, llama.cpp, LM Studio) — may be used via their
-> OpenAI-compatible endpoints; see
-> [Using Graphiti with OpenAI-compatible providers and local LLMs](#using-graphiti-with-openai-compatible-providers-and-local-llms).
-
-For a complete working example, see the [Quickstart Example](examples/quickstart/README.md) in the examples directory.
-The quickstart demonstrates:
-
-1. Connecting to a Neo4j, Amazon Neptune, FalkorDB, or Kuzu database
-2. Initializing Graphiti indices and constraints
-3. Adding episodes to the graph (both text and structured JSON)
-4. Searching for relationships (edges) using hybrid search
-5. Reranking search results using graph distance
-6. Searching for nodes using predefined search recipes
-
-The example is fully documented with clear explanations of each functionality and includes a comprehensive README with
-setup instructions and next steps.
-
-### Running with Docker Compose
-
-You can use Docker Compose to quickly start the required services:
-
-- **Neo4j Docker:**
-
-  ```bash
-  docker compose up
-  ```
-
-  This will start the Neo4j Docker service and related components.
-
-- **FalkorDB Docker:**
-
-  ```bash
-  docker compose --profile falkordb up
-  ```
-
-  This will start the FalkorDB Docker service and related components.
-
-## MCP Server
-
-The `mcp_server` directory contains a Model Context Protocol (MCP) server implementation for Graphiti. This server
-allows AI assistants to interact with Graphiti's context graph capabilities through the MCP protocol.
-
-Key features of the MCP server include:
-
-- Episode management (add, retrieve, delete)
-- Entity management and relationship handling
-- Semantic and hybrid search capabilities
-- Group management for organizing related data
-- Graph maintenance operations
-
-The MCP server can be deployed using Docker with Neo4j, making it easy to integrate Graphiti into your AI assistant
-workflows.
-
-For detailed setup instructions and usage examples, see the [MCP server README](mcp_server/README.md).
-
-## REST Service
-
-The `server` directory contains an API service for interacting with the Graphiti API. It is built using FastAPI.
-
-Please see the [server README](server/README.md) for more information.
-
-## Optional Environment Variables
-
-In addition to the Neo4j and OpenAi-compatible credentials, Graphiti also has a few optional environment variables.
-If you are using one of our supported models, such as Anthropic or Voyage models, the necessary environment variables
-must be set.
-
-### Database Configuration
-
-Database names are configured directly in the driver constructors:
-
-- **Neo4j**: Database name defaults to `neo4j` (hardcoded in Neo4jDriver)
-- **FalkorDB**: Database name defaults to `default_db` (hardcoded in FalkorDriver)
-
-As of v0.17.0, if you need to customize your database configuration, you can instantiate a database driver and pass it
-to the Graphiti constructor using the `graph_driver` parameter.
-
-#### Neo4j with Custom Database Name
-
-```python
-from graphiti_core import Graphiti
-from graphiti_core.driver.neo4j_driver import Neo4jDriver
-
-# Create a Neo4j driver with custom database name
-driver = Neo4jDriver(
-    uri="bolt://localhost:7687",
-    user="neo4j",
-    password="password",
-    database="my_custom_database"  # Custom database name
-)
-
-# Pass the driver to Graphiti
-graphiti = Graphiti(graph_driver=driver)
-```
-
-#### FalkorDB with Custom Database Name
-
-```python
-from graphiti_core import Graphiti
-from graphiti_core.driver.falkordb_driver import FalkorDriver
-
-# Create a FalkorDB driver with custom database name
-driver = FalkorDriver(
-    host="localhost",
-    port=6379,
-    username="falkor_user",  # Optional
-    password="falkor_password",  # Optional
-    database="my_custom_graph"  # Custom database name
-)
-
-# Or use embedded FalkorDB Lite (requires Python 3.12+)
-# from redislite.async_falkordb_client import AsyncFalkorDB
-# falkordb_client = AsyncFalkorDB(dbfilename='/path/to/database.db')
-# driver = FalkorDriver(falkor_db=falkordb_client)
-
-# Pass the driver to Graphiti
-graphiti = Graphiti(graph_driver=driver)
-```
-
-#### Kuzu
-
-> [!WARNING]
-> Kuzu is **deprecated** (upstream project unmaintained) and will be removed in a future release. Prefer Neo4j or
-> FalkorDB.
-
-```python
-from graphiti_core import Graphiti
-from graphiti_core.driver.kuzu_driver import KuzuDriver
-
-# Create a Kuzu driver
-driver = KuzuDriver(db="/tmp/graphiti.kuzu")
-
-# Pass the driver to Graphiti
-graphiti = Graphiti(graph_driver=driver)
-```
-
-#### Amazon Neptune
-
-```python
-from graphiti_core import Graphiti
-from graphiti_core.driver.neptune_driver import NeptuneDriver
-
-# Create a Neptune driver
-driver = NeptuneDriver(
-    host='<NEPTUNE_ENDPOINT>',
-    aoss_host='<AMAZON_OPENSEARCH_SERVERLESS_HOST>',
-    port=8182,      # Optional, defaults to 8182
-    aoss_port=443,  # Optional, defaults to 443
-)
-
-# Pass the driver to Graphiti
-graphiti = Graphiti(graph_driver=driver)
-```
-
-Contributing a new graph backend? See [Adding a graph driver](CONTRIBUTING.md#adding-a-graph-driver).
-
-## Using Graphiti with Azure OpenAI
-
-Graphiti supports Azure OpenAI for both LLM inference and embeddings using Azure's OpenAI v1 API compatibility layer.
-
-### Quick Start
-
-```python
-from openai import AsyncOpenAI
-from graphiti_core import Graphiti
-from graphiti_core.llm_client.azure_openai_client import AzureOpenAILLMClient
-from graphiti_core.llm_client.config import LLMConfig
-from graphiti_core.embedder.azure_openai import AzureOpenAIEmbedderClient
-
-# Initialize Azure OpenAI client using the standard OpenAI client
-# with Azure's v1 API endpoint
-azure_client = AsyncOpenAI(
-    base_url="https://your-resource-name.openai.azure.com/openai/v1/",
-    api_key="your-api-key",
-)
-
-# Create LLM and Embedder clients
-llm_client = AzureOpenAILLMClient(
-    azure_client=azure_client,
-    config=LLMConfig(model="gpt-5-mini", small_model="gpt-5-mini")  # Your Azure deployment name
-)
-embedder_client = AzureOpenAIEmbedderClient(
-    azure_client=azure_client,
-    model="text-embedding-3-small"  # Your Azure embedding deployment name
-)
-
-# Initialize Graphiti with Azure OpenAI clients
-graphiti = Graphiti(
-    "bolt://localhost:7687",
-    "neo4j",
-    "password",
-    llm_client=llm_client,
-    embedder=embedder_client,
-)
-
-# Now you can use Graphiti with Azure OpenAI
-```
-
-**Key Points:**
-
-- Use the standard `AsyncOpenAI` client with Azure's v1 API endpoint format:
-  `https://your-resource-name.openai.azure.com/openai/v1/`
-- The deployment names (e.g., `gpt-5-mini`, `text-embedding-3-small`) should match your Azure OpenAI deployment names
-- See `examples/azure-openai/` for a complete working example
-
-Make sure to replace the placeholder values with your actual Azure OpenAI credentials and deployment names.
-
-## Using Graphiti with Google Gemini
-
-Graphiti supports Google's Gemini models for LLM inference, embeddings, and cross-encoding/reranking. To use Gemini,
-you'll need to configure the LLM client, embedder, and the cross-encoder with your Google API key.
-
-Install Graphiti:
-
-```bash
-uv add "graphiti-core[google-genai]"
-
-# or
-
-pip install "graphiti-core[google-genai]"
-```
-
-```python
-from graphiti_core import Graphiti
-from graphiti_core.llm_client.gemini_client import GeminiClient, LLMConfig
-from graphiti_core.embedder.gemini import GeminiEmbedder, GeminiEmbedderConfig
-from graphiti_core.cross_encoder.gemini_reranker_client import GeminiRerankerClient
-
-# Google API key configuration
-api_key = "<your-google-api-key>"
-
-# Initialize Graphiti with Gemini clients
-graphiti = Graphiti(
-    "bolt://localhost:7687",
-    "neo4j",
-    "password",
-    llm_client=GeminiClient(
-        config=LLMConfig(
-            api_key=api_key,
-            model="gemini-2.0-flash"
-        )
-    ),
-    embedder=GeminiEmbedder(
-        config=GeminiEmbedderConfig(
-            api_key=api_key,
-            embedding_model="embedding-001"
-        )
-    ),
-    cross_encoder=GeminiRerankerClient(
-        config=LLMConfig(
-            api_key=api_key,
-            model="gemini-2.5-flash-lite"
-        )
-    )
-)
-
-# Now you can use Graphiti with Google Gemini for all components
-```
-
-The Gemini reranker uses the `gemini-2.5-flash-lite` model by default, which is optimized for
-cost-effective and low-latency classification tasks. It uses the same boolean classification approach as the OpenAI
-reranker, leveraging Gemini's log probabilities feature to rank passage relevance.
-
-## Using Graphiti with OpenAI-compatible providers and local LLMs
-
-Graphiti can use any OpenAI-compatible `/v1` endpoint for LLM inference via `OpenAIGenericClient` — both **hosted
-providers** (DeepSeek, Together, OpenRouter, Fireworks, etc.) and **local servers** (Ollama, vLLM, llama.cpp, LM
-Studio). Local servers are ideal for privacy-focused applications or avoiding API costs. The example below uses Ollama;
-for any other provider, point `base_url` at its endpoint and set the appropriate `api_key` and `model`.
-
-**Note:** Use `OpenAIGenericClient` (not `OpenAIClient`) for these endpoints. It is optimized for local models with a
-higher default max token limit (16K vs 8K) and handles structured outputs across compatible providers.
-
-Install the models:
-
-```bash
-ollama pull deepseek-r1:7b # LLM
-ollama pull nomic-embed-text # embeddings
-```
-
-```python
-from graphiti_core import Graphiti
-from graphiti_core.llm_client.config import LLMConfig
-from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
-from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig
-from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient
-
-# Configure Ollama LLM client
-llm_config = LLMConfig(
-    api_key="ollama",  # Ollama doesn't require a real API key, but some placeholder is needed
-    model="deepseek-r1:7b",
-    small_model="deepseek-r1:7b",
-    base_url="http://localhost:11434/v1",  # Ollama's OpenAI-compatible endpoint
-)
-
-llm_client = OpenAIGenericClient(config=llm_config)
-
-# Initialize Graphiti with Ollama clients
-graphiti = Graphiti(
-    "bolt://localhost:7687",
-    "neo4j",
-    "password",
-    llm_client=llm_client,
-    embedder=OpenAIEmbedder(
-        config=OpenAIEmbedderConfig(
-            api_key="ollama",  # Placeholder API key
-            embedding_model="nomic-embed-text",
-            embedding_dim=768,
-            base_url="http://localhost:11434/v1",
-        )
-    ),
-    cross_encoder=OpenAIRerankerClient(client=llm_client, config=llm_config),
-)
-
-# Now you can use Graphiti with local Ollama models
-```
-
-Ensure Ollama is running (`ollama serve`) and that you have pulled the models you want to use.
-
-### Structured output and small models
-
-Graphiti depends on structured (JSON) output for entity/edge extraction and deduplication, and works best with models
-and providers that reliably honor it (OpenAI, Anthropic, Gemini). Reliability varies across OpenAI-compatible providers and
-especially on smaller or local models, so `OpenAIGenericClient` exposes a `structured_output_mode`:
-
-- `"json_schema"` (default): requests native structured output via `response_format`. Best on capable models and
-  providers that enforce the schema via constrained decoding.
-- `"json_object"`: requests plain-JSON mode and injects the schema into the prompt instead. Use this for
-  providers/models that don't reliably honor `json_schema` — including some local servers that accept the `json_schema`
-  request but don't actually constrain output to it, where `json_object` can be *more* reliable.
-
-When using smaller or local models:
-
-- Prefer the most capable model you can run. Very small models frequently emit JSON that doesn't match the requested
-  schema, which surfaces as extraction failures.
-- Responses wrapped in Markdown ` ```json ` code fences are stripped automatically.
-- Keep `SEMAPHORE_LIMIT` low (see [above](#default-to-low-concurrency-llm-provider-429-rate-limit-errors)) — local
-  servers and some providers have limited concurrency.
-
-## Documentation
-
-- [Guides and API documentation](https://help.getzep.com/graphiti).
-- [Quick Start](https://help.getzep.com/graphiti/graphiti/quick-start)
-- [Building an agent with LangChain's LangGraph and Graphiti](https://help.getzep.com/graphiti/integrations/lang-graph-agent)
-
-## Telemetry
-
-Graphiti collects anonymous usage statistics to help us understand how the framework is being used and improve it for
-everyone. We believe transparency is important, so here's exactly what we collect and why.
-
-### What We Collect
-
-When you initialize a Graphiti instance, we collect:
-
-- **Anonymous identifier**: A randomly generated UUID stored locally in `~/.cache/graphiti/telemetry_anon_id`
-- **System information**: Operating system, Python version, and system architecture
-- **Graphiti version**: The version you're using
-- **Configuration choices**:
-  - LLM provider type (OpenAI, Azure, Anthropic, etc.)
-  - Database backend (Neo4j, FalkorDB, Kuzu, Amazon Neptune Database or Neptune Analytics)
-  - Embedder provider (OpenAI, Azure, Voyage, etc.)
-
-### What We Don't Collect
-
-We are committed to protecting your privacy. We **never** collect:
-
-- Personal information or identifiers
-- API keys or credentials
-- Your actual data, queries, or graph content
-- IP addresses or hostnames
-- File paths or system-specific information
-- Any content from your episodes, nodes, or edges
-
-### Why We Collect This Data
-
-This information helps us:
-
-- Understand which configurations are most popular to prioritize support and testing
-- Identify which LLM and database providers to focus development efforts on
-- Track adoption patterns to guide our roadmap
-- Ensure compatibility across different Python versions and operating systems
-
-By sharing this anonymous information, you help us make Graphiti better for everyone in the community.
-
-### View the Telemetry Code
-
-The Telemetry code [may be found here](graphiti_core/telemetry/telemetry.py).
-
-### How to Disable Telemetry
-
-Telemetry is **opt-out** and can be disabled at any time. To disable telemetry collection:
-
-**Option 1: Environment Variable**
-
-```bash
-export GRAPHITI_TELEMETRY_ENABLED=false
-```
-
-**Option 2: Set in your shell profile**
-
-```bash
-# For bash users (~/.bashrc or ~/.bash_profile)
-echo 'export GRAPHITI_TELEMETRY_ENABLED=false' >> ~/.bashrc
-
-# For zsh users (~/.zshrc)
-echo 'export GRAPHITI_TELEMETRY_ENABLED=false' >> ~/.zshrc
-```
-
-**Option 3: Set for a specific Python session**
-
-```python
-import os
-
-os.environ['GRAPHITI_TELEMETRY_ENABLED'] = 'false'
-
-# Then initialize Graphiti as usual
-from graphiti_core import Graphiti
-
-graphiti = Graphiti(...)
-```
-
-Telemetry is automatically disabled during test runs (when `pytest` is detected).
-
-### Technical Details
-
-- Telemetry uses PostHog for anonymous analytics collection
-- All telemetry operations are designed to fail silently - they will never interrupt your application or affect Graphiti
-  functionality
-- The anonymous ID is stored locally and is not tied to any personal information
-
-## Contributing
-
-We encourage and appreciate all forms of contributions, whether it's code, documentation, addressing GitHub Issues, or
-answering questions in the Graphiti Discord channel. For detailed guidelines on code contributions, please refer
-to [CONTRIBUTING](CONTRIBUTING.md).
-
-## Support
-
-Join the [Zep Discord server](https://discord.com/invite/W8Kw6bsgXQ) and make your way to the **#Graphiti** channel!
+1. **Check it's up.**
+
+   ```bash
+   curl $GRAPHITI_URL/healthcheck
+   # {"status":"healthy"}
+   ```
+
+2. **Ingest the sample episode** that ships in this repo
+   ([`examples/render/sample-episode.json`](examples/render/sample-episode.json)). It's a short
+   conversation where Alex leads the payments team in May and hands it to Priya in July. The
+   messages carry explicit `timestamp` fields — that spread is what gives Graphiti something to
+   be temporal about. Omit them and every message is stamped with the time it arrived, so the
+   facts all land at once and nothing supersedes anything:
+
+   ```bash
+   curl -X POST $GRAPHITI_URL/messages \
+     -H 'Content-Type: application/json' \
+     -d @examples/render/sample-episode.json
+   # {"message":"Messages added to processing queue","success":true}
+   ```
+
+3. **Watch the episodes land.**
+
+   ```bash
+   curl "$GRAPHITI_URL/episodes/demo?last_n=5"
+   ```
+
+4. **Search the facts Graphiti extracted.**
+
+   ```bash
+   curl -X POST $GRAPHITI_URL/search \
+     -H 'Content-Type: application/json' \
+     -d '{"group_ids": ["demo"], "query": "who leads the payments team?", "max_facts": 10}'
+   ```
+
+   Among the results you'll find both sides of the handover, each stamped with when it
+   became true:
+
+   ```
+   Alex leads the payments team at Acme.
+       valid_at: 2026-05-04T14:00:00+00:00   invalid_at: None
+   Priya now leads the payments team at Acme.
+       valid_at: 2026-07-13T10:15:00+00:00   invalid_at: None
+   ```
+
+   That's the point of the graph. Alex's fact wasn't overwritten when Priya took over — both
+   are stored, each anchored to the message that asserted it, so you can ask who led the team
+   in June and get an answer. The `valid_at` values come straight from the message timestamps
+   and are reliable.
+
+   `invalid_at` is the other half: when Graphiti recognizes that a new fact contradicts an
+   older one, it closes the old one off at that moment, and you'd see
+   `invalid_at: 2026-07-13T10:15:00+00:00` on Alex's fact. Whether that fires is an LLM
+   judgment call made during ingestion, and on this three-message sample it happens on some
+   runs and not others. Treat it as opportunistic: real workloads give the model far more
+   signal than three messages do. The extracted wording, the capitalization, and the result
+   ordering vary between runs too.
+
+5. **Clean up** when you're done experimenting. On FalkorDB each `group_id` is a separate
+   graph, so deleting the group means deleting that graph. Open a shell on
+   `graphiti-falkordb` from the Render Dashboard and run:
+
+   ```bash
+   redis-cli GRAPH.DELETE demo
+   ```
+
+   > The HTTP endpoints `DELETE /group/{group_id}` and `POST /clear` do **not** work on this
+   > deployment. Both return `{"success": true}` and delete nothing: they query the default
+   > graph, while the data lives in a graph named after the `group_id`. This is a
+   > [graphiti-core](https://github.com/getzep/graphiti) driver issue, not a misconfiguration
+   > here. Don't rely on them to erase a tenant's data.
+
+Full endpoint list at `$GRAPHITI_URL/docs` (FastAPI's generated OpenAPI docs).
+
+`group_id` partitions the graph. Use one per user, per tenant, or per agent, and search stays
+scoped to it. On FalkorDB each one is a distinct graph held in memory, so the instance plan —
+not the disk — is what bounds how many you can keep.
+
+## Configuration notes
+
+**FalkorDB has no password.** It's a private service with no public address, so isolation comes
+from the network. To add one anyway, set `REDIS_ARGS` to `--appendonly yes --requirepass <your
+password>` on `graphiti-falkordb`, and set `FALKORDB_PASSWORD` to the same value on
+`graphiti-api`. Render can't interpolate one env var into another, so this is a manual step.
+
+**Using Neo4j instead.** Set `DB_BACKEND=neo4j` and supply `NEO4J_URI`, `NEO4J_USER`, and
+`NEO4J_PASSWORD` (e.g. from Neo4j Aura), then drop the `graphiti-falkordb` service from
+`render.yaml`.
+
+**Local development.** Copy [`.env.example`](.env.example) to `.env`, fill in `OPENAI_API_KEY`,
+and run `docker compose --profile falkordb up`. That mirrors this Blueprint — the API on
+`http://localhost:8001`, FalkorDB beside it. A plain `docker compose up` runs the repo's other
+pairing, API plus Neo4j, on port 8000.
+
+## Learn more
+
+This repo is a fork of [getzep/graphiti](https://github.com/getzep/graphiti) with a Render
+Blueprint added. For how Graphiti works — custom entity types, search strategies, the MCP
+server, the Python library — see the
+[upstream README](https://github.com/getzep/graphiti#readme) and
+[the paper](https://arxiv.org/abs/2501.13956).

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ from `graphiti-api` over Render's private network.
    | `MODEL_NAME`      | `gpt-5.5` | Any OpenAI model id.                                                              |
    | `SEMAPHORE_LIMIT` | `10`      | Concurrent LLM calls during ingestion. Deliberately below graphiti-core's default of 20, so a burst of episodes doesn't trip the rate limits on a fresh OpenAI key. Raise it once you know your account's limits. |
 
+   The rest is wiring you shouldn't need to touch. `DB_BACKEND` selects the FalkorDB code
+   path; `FALKORDB_HOST` is filled in from the private service's hostname, with
+   `FALKORDB_PORT` and `FALKORDB_DATABASE` fixed to match it. `INSTALL_FALKORDB` is a build
+   arg that pulls in the `graphiti-core[falkordb]` extra, and `BROWSER=0` turns off the
+   FalkorDB Browser UI so `6379` is the only port the graph store listens on.
+
    The `graphiti-core` version is pinned in one place: the `GRAPHITI_VERSION` build arg
    default in [`Dockerfile`](Dockerfile). Every fork therefore deploys the same library,
    and local `docker compose` builds match Render without a second pin to keep in step.
@@ -172,6 +178,14 @@ not the disk — is what bounds how many you can keep.
 from the network. To add one anyway, set `REDIS_ARGS` to `--appendonly yes --requirepass <your
 password>` on `graphiti-falkordb`, and set `FALKORDB_PASSWORD` to the same value on
 `graphiti-api`. Render can't interpolate one env var into another, so this is a manual step.
+
+**`graphiti-falkordb` logs a security warning while it starts.** For the first few minutes
+you'll see `Possible SECURITY ATTACK detected ... Connection from 127.0.0.1 aborted` about
+once a minute. That's Render's port scanner sending an HTTP probe to `6379` to work out which
+port the service listens on; FalkorDB speaks the Redis protocol, so it reports the HTTP
+request as a cross-protocol attempt and drops it. It stops once the port is detected, and
+nothing reaches the graph. The startup line about Redis having no authentication is expected
+too — see the note above on why the private network is what isolates it.
 
 **Using Neo4j instead.** Set `DB_BACKEND=neo4j` and supply `NEO4J_URI`, `NEO4J_USER`, and
 `NEO4J_PASSWORD` (e.g. from Neo4j Aura), then drop the `graphiti-falkordb` service from

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,16 @@ services:
     depends_on:
       neo4j:
         condition: service_healthy
+    # Everything else the app reads comes straight from .env, so the settings documented
+    # in .env.example reach the container instead of being silently dropped. Listing them
+    # here one by one would mean a blank value for each one the user left out, and a blank
+    # is not the same as unset: SEMAPHORE_LIMIT is read as int(os.getenv(...)), so '' is a
+    # crash on import. Absent from .env means absent from the environment.
+    env_file:
+      - path: .env
+        required: false
+    # Compose-specific wiring, which has to win over whatever .env says: these hostnames
+    # only make sense on the compose network. environment takes precedence over env_file.
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - NEO4J_URI=bolt://neo4j:${NEO4J_PORT:-7687}
@@ -81,6 +91,10 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    # See the note on the graph service above.
+    env_file:
+      - path: .env
+        required: false
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - FALKORDB_HOST=falkordb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,7 @@ services:
       - NEO4J_URI=bolt://neo4j:${NEO4J_PORT:-7687}
       - NEO4J_USER=${NEO4J_USER:-neo4j}
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:-password}
-      - PORT=8000
-      - db_backend=neo4j
+      - DB_BACKEND=neo4j
   neo4j:
     image: neo4j:5.26.2
     profiles: [""]
@@ -70,10 +69,6 @@ services:
     build:
       args:
         INSTALL_FALKORDB: "true"
-        # Same pin as render.yaml. Left unset, the Dockerfile installs whatever
-        # graphiti-core is newest at build time, so local dev would drift off the
-        # version Render runs — the thing pinning was meant to prevent.
-        GRAPHITI_VERSION: ${GRAPHITI_VERSION:-0.29.3}
       context: .
     profiles: ["falkordb"]
     ports:
@@ -91,8 +86,7 @@ services:
       - FALKORDB_HOST=falkordb
       - FALKORDB_PORT=6379
       - FALKORDB_DATABASE=default_db
-      - PORT=8000
-      - db_backend=falkordb
+      - DB_BACKEND=falkordb
 
 volumes:
   neo4j_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,14 +48,18 @@ services:
       - NEO4J_AUTH=${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD:-password}
 
   falkordb:
-    image: falkordb/falkordb:latest
+    # Kept in step with render.yaml so local dev matches what Render runs.
+    image: falkordb/falkordb:v4.20.1
     profiles: ["falkordb"]
     ports:
       - "6379:6379"
     volumes:
-      - falkordb_data:/data
+      - falkordb_data:/var/lib/falkordb/data
     environment:
-      - FALKORDB_ARGS=--port 6379 --cluster-enabled no
+      # REDIS_ARGS goes to redis-server; FALKORDB_ARGS goes to the module. The flags that
+      # used to sit in FALKORDB_ARGS were redis-server flags in the module's slot, and
+      # both were already the defaults. Append-only matches what render.yaml runs.
+      - REDIS_ARGS=--appendonly yes
     healthcheck:
       test: ["CMD", "redis-cli", "-p", "6379", "ping"]
       interval: 1s
@@ -66,6 +70,10 @@ services:
     build:
       args:
         INSTALL_FALKORDB: "true"
+        # Same pin as render.yaml. Left unset, the Dockerfile installs whatever
+        # graphiti-core is newest at build time, so local dev would drift off the
+        # version Render runs — the thing pinning was meant to prevent.
+        GRAPHITI_VERSION: ${GRAPHITI_VERSION:-0.29.3}
       context: .
     profiles: ["falkordb"]
     ports:
@@ -83,7 +91,6 @@ services:
       - FALKORDB_HOST=falkordb
       - FALKORDB_PORT=6379
       - FALKORDB_DATABASE=default_db
-      - GRAPHITI_BACKEND=falkordb
       - PORT=8000
       - db_backend=falkordb
 

--- a/examples/render/sample-episode.json
+++ b/examples/render/sample-episode.json
@@ -1,0 +1,29 @@
+{
+  "group_id": "demo",
+  "messages": [
+    {
+      "name": "kickoff",
+      "role_type": "user",
+      "role": "alex",
+      "timestamp": "2026-05-04T14:00:00Z",
+      "content": "I'm Alex, I lead the payments team at Acme. We're migrating our billing service off Stripe Billing and onto our own ledger by the end of Q3.",
+      "source_description": "Render template sample episode"
+    },
+    {
+      "name": "kickoff-reply",
+      "role_type": "assistant",
+      "role": "assistant",
+      "timestamp": "2026-05-04T14:01:00Z",
+      "content": "Got it. So Alex leads the payments team at Acme, and the ledger migration is due end of Q3.",
+      "source_description": "Render template sample episode"
+    },
+    {
+      "name": "handover",
+      "role_type": "user",
+      "role": "alex",
+      "timestamp": "2026-07-13T10:15:00Z",
+      "content": "Update: I've moved to the infrastructure team. Priya now leads the payments team at Acme, and she owns the ledger migration.",
+      "source_description": "Render template sample episode"
+    }
+  ]
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,94 @@
+# Graphiti on Render — a temporal knowledge graph API backed by FalkorDB.
+#
+# graphiti-api      public REST service, built from the repo's root Dockerfile
+# graphiti-falkordb the graph store, private: reachable only from graphiti-api
+#
+# Secrets are never written here. OPENAI_API_KEY is declared sync: false, so Render
+# prompts for it at deploy time and stores it outside the repo.
+
+previews:
+  generation: off
+
+projects:
+  - name: graphiti
+    environments:
+      - name: production
+        services:
+          - type: pserv
+            name: graphiti-falkordb
+            runtime: image
+            region: oregon
+            # FalkorDB keeps the whole graph in RAM and only writes the append-only file
+            # to disk, so this plan is the real ceiling on graph size. Standard (2 GB) is
+            # the smallest that leaves room to grow; the disk below just has to outlast it.
+            plan: standard
+            # Pinned, not :latest — every fork deploys this exact version, so an upstream
+            # bump can't break new deploys out from under you. Bump it deliberately.
+            image:
+              url: docker.io/falkordb/falkordb:v4.20.1
+            disk:
+              name: falkordb-data
+              mountPath: /var/lib/falkordb/data
+              sizeGB: 10
+            envVars:
+              # Append-only file, so the graph survives a restart or redeploy.
+              - key: REDIS_ARGS
+                value: --appendonly yes
+              # The image otherwise also serves the FalkorDB Browser UI on :3000. Nothing
+              # uses it here, and leaving it on gives Render's port scanner a second port
+              # to choose from. Off, so 6379 is the only thing listening.
+              - key: BROWSER
+                value: '0'
+
+          - type: web
+            name: graphiti-api
+            runtime: docker
+            region: oregon
+            # The API idles near 100 MB and spends most of each request waiting on OpenAI,
+            # so it needs far less than the graph store does.
+            plan: starter
+            dockerfilePath: ./Dockerfile
+            dockerContext: .
+            healthCheckPath: /healthcheck
+            envVars:
+              # Declared on the service, not in an env var group: sync: false is silently
+              # ignored inside a group, so Render would never prompt for the value.
+              - key: OPENAI_API_KEY
+                sync: false
+
+              # Render exposes env vars to the Docker build as build args, which is how
+              # the root Dockerfile picks up the graphiti-core FalkorDB extra.
+              - key: INSTALL_FALKORDB
+                value: 'true'
+              # Pinned for the same reason the FalkorDB image is: left unset, the
+              # Dockerfile installs whatever graphiti-core is newest at build time, so two
+              # forks deployed a month apart run different libraries.
+              #
+              # This is the graphiti-core release to install from PyPI. It is not the same
+              # number as this repo's own version in pyproject.toml, and 0.29.2 in
+              # particular does not work here: on FalkorDB it writes episodes fine but
+              # reads them back empty, so /search and /episodes return nothing. Verify a
+              # round trip before bumping this.
+              - key: GRAPHITI_VERSION
+                value: 0.29.3
+
+              - key: DB_BACKEND
+                value: falkordb
+              - key: FALKORDB_HOST
+                fromService:
+                  name: graphiti-falkordb
+                  type: pserv
+                  property: host
+              - key: FALKORDB_PORT
+                value: '6379'
+              - key: FALKORDB_DATABASE
+                value: default_db
+
+              # The model Graphiti uses to extract entities and facts. Any OpenAI model id.
+              - key: MODEL_NAME
+                value: gpt-5.5
+              # Concurrent LLM calls during ingestion. Held below graphiti-core's default
+              # of 20 so a burst of episodes doesn't trip OpenAI rate limits on a new key.
+              # Raise it once you know your account's limits.
+              - key: SEMAPHORE_LIMIT
+                value: '10'

--- a/render.yaml
+++ b/render.yaml
@@ -60,17 +60,10 @@ projects:
               # the root Dockerfile picks up the graphiti-core FalkorDB extra.
               - key: INSTALL_FALKORDB
                 value: 'true'
-              # Pinned for the same reason the FalkorDB image is: left unset, the
-              # Dockerfile installs whatever graphiti-core is newest at build time, so two
-              # forks deployed a month apart run different libraries.
-              #
-              # This is the graphiti-core release to install from PyPI. It is not the same
-              # number as this repo's own version in pyproject.toml, and 0.29.2 in
-              # particular does not work here: on FalkorDB it writes episodes fine but
-              # reads them back empty, so /search and /episodes return nothing. Verify a
-              # round trip before bumping this.
-              - key: GRAPHITI_VERSION
-                value: 0.29.3
+              # The graphiti-core version is deliberately not set here. It is pinned once,
+              # as the GRAPHITI_VERSION build arg default in the Dockerfile, so a bump is
+              # a one-line change rather than three configs to keep in step. Setting it
+              # here would override that pin for this service only.
 
               - key: DB_BACKEND
                 value: falkordb

--- a/server/graph_service/config.py
+++ b/server/graph_service/config.py
@@ -1,23 +1,48 @@
 from functools import lru_cache
-from typing import Annotated
+from typing import Annotated, Any, Literal
 
 from fastapi import Depends
-from pydantic import Field
+from pydantic import BeforeValidator, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict  # type: ignore
 
 
+def _blank_to_none(value: Any) -> Any:
+    """Treat an env var that is set but empty as unset."""
+    if isinstance(value, str) and not value.strip():
+        return None
+    return value
+
+
+# A .env file and a dashboard UI both make it easy to define a variable with an empty
+# value, which is not the same thing as leaving it out: '' arrives here as a real setting
+# and gets passed on to the clients. A blank model_name would be sent to OpenAI as the
+# model to use, and a blank falkordb_port would fail validation before the app can boot.
+#
+# One case this cannot reach: the OpenAI SDK falls back to reading OPENAI_BASE_URL from
+# the environment when it is handed base_url=None, so a blank OPENAI_BASE_URL still ends
+# up as '' inside the client, and requests go out with no host. Leave it unset, not empty.
+OptionalStr = Annotated[str | None, BeforeValidator(_blank_to_none)]
+OptionalInt = Annotated[int | None, BeforeValidator(_blank_to_none)]
+
+
 class Settings(BaseSettings):
-    openai_api_key: str
-    openai_base_url: str | None = Field(None)
-    model_name: str | None = Field(None)
-    embedding_model_name: str | None = Field(None)
-    neo4j_uri: str | None = Field(None)
-    neo4j_user: str | None = Field(None)
-    neo4j_password: str | None = Field(None)
-    falkordb_host: str | None = Field(None)
-    falkordb_port: int | None = Field(None)
-    falkordb_database: str | None = Field(None)
-    db_backend: str = Field('neo4j')
+    # Rejected when blank rather than defaulted, so a missing key fails the deploy at
+    # startup instead of turning every background ingestion into a 401 nobody is watching.
+    openai_api_key: str = Field(min_length=1)
+    openai_base_url: OptionalStr = None
+    model_name: OptionalStr = None
+    embedding_model_name: OptionalStr = None
+    neo4j_uri: OptionalStr = None
+    neo4j_user: OptionalStr = None
+    neo4j_password: OptionalStr = None
+    falkordb_host: OptionalStr = None
+    falkordb_port: OptionalInt = None
+    falkordb_username: OptionalStr = None
+    falkordb_password: OptionalStr = None
+    falkordb_database: OptionalStr = None
+    # Only these two backends are wired up in zep_graphiti, so a typo should be a startup
+    # error naming the valid values, not a silent fall-through to the Neo4j branch.
+    db_backend: Literal['neo4j', 'falkordb'] = 'neo4j'
 
     model_config = SettingsConfigDict(env_file='.env', extra='ignore')
 

--- a/server/graph_service/main.py
+++ b/server/graph_service/main.py
@@ -5,7 +5,7 @@ from fastapi.responses import JSONResponse
 
 from graph_service.config import get_settings
 from graph_service.routers import ingest, retrieve
-from graph_service.zep_graphiti import initialize_graphiti
+from graph_service.zep_graphiti import initialize_graphiti, shutdown_graphiti
 
 
 @asynccontextmanager
@@ -13,8 +13,7 @@ async def lifespan(_: FastAPI):
     settings = get_settings()
     await initialize_graphiti(settings)
     yield
-    # Shutdown
-    # No need to close Graphiti here, as it's handled per-request
+    await shutdown_graphiti()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -93,9 +93,9 @@ def _create_openai_clients(
     base_url = settings.openai_base_url
 
     embedder_config = OpenAIEmbedderConfig(api_key=api_key, base_url=base_url)
-    # Assigned only when set, rather than passed to the constructor: embedding_model
-    # defaults to a real model name, so handing it None would overwrite that default.
-    # LLMConfig.model below defaults to None, which is why it can be passed straight in.
+    # Assigned only when set, rather than passed to the constructor: embedding_model is
+    # typed str (defaulting to a real model name), so passing None would fail validation.
+    # LLMConfig.model below is str | None, which is why it can be passed straight in.
     if settings.embedding_model_name is not None:
         embedder_config.embedding_model = settings.embedding_model_name
 
@@ -155,7 +155,7 @@ async def get_graphiti(settings: ZepEnvDep):
         await client.close()
 
 
-async def initialize_graphiti(settings: ZepEnvDep):
+async def initialize_graphiti(settings: Settings):
     client = _create_graphiti_client(settings)
     try:
         await client.build_indices_and_constraints()

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -10,7 +10,7 @@ from graphiti_core.errors import EdgeNotFoundError, GroupsEdgesNotFoundError, No
 from graphiti_core.llm_client import LLMClient, LLMConfig, OpenAIClient  # type: ignore
 from graphiti_core.nodes import EntityNode, EpisodicNode  # type: ignore
 
-from graph_service.config import Settings, ZepEnvDep
+from graph_service.config import Settings
 from graph_service.dto import FactResult
 
 logger = logging.getLogger(__name__)
@@ -147,20 +147,39 @@ def _create_graphiti_client(settings: Settings) -> ZepGraphiti:
         )
 
 
-async def get_graphiti(settings: ZepEnvDep):
-    client = _create_graphiti_client(settings)
-    try:
-        yield client
-    finally:
-        await client.close()
+# One client for the life of the process, rather than one per request.
+#
+# Both graph drivers fire off build_indices_and_constraints() as an unawaited background task
+# from their constructor. Building a client per request therefore started an index build per
+# request, and closing that client when the request ended cut the task's connection mid-query
+# — which is where the 'Connection closed by server' tracebacks came from. The same close also
+# broke /messages, which hands its ingestion work to the async worker: those jobs outlive the
+# request, so they ran against a client that had already been closed and only survived on the
+# redis client's transparent reconnect.
+#
+# Sharing one client fixes both: the index build happens once, awaited, at startup, and queued
+# jobs keep a client that stays open. It also stops rebuilding the OpenAI clients and the
+# connection pool on every request.
+_graphiti_client: ZepGraphiti | None = None
+
+
+async def get_graphiti() -> ZepGraphiti:
+    if _graphiti_client is None:
+        raise RuntimeError('Graphiti client requested before startup completed')
+    return _graphiti_client
 
 
 async def initialize_graphiti(settings: Settings):
-    client = _create_graphiti_client(settings)
-    try:
-        await client.build_indices_and_constraints()
-    finally:
-        await client.close()
+    global _graphiti_client
+    _graphiti_client = _create_graphiti_client(settings)
+    await _graphiti_client.build_indices_and_constraints()
+
+
+async def shutdown_graphiti():
+    global _graphiti_client
+    if _graphiti_client is not None:
+        await _graphiti_client.close()
+        _graphiti_client = None
 
 
 def get_fact_result_from_edge(edge: EntityEdge):

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -3,12 +3,14 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException
 from graphiti_core import Graphiti  # type: ignore
+from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient  # type: ignore
 from graphiti_core.edges import EntityEdge  # type: ignore
+from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig  # type: ignore
 from graphiti_core.errors import EdgeNotFoundError, GroupsEdgesNotFoundError, NodeNotFoundError
-from graphiti_core.llm_client import LLMClient  # type: ignore
+from graphiti_core.llm_client import LLMClient, LLMConfig, OpenAIClient  # type: ignore
 from graphiti_core.nodes import EntityNode, EpisodicNode  # type: ignore
 
-from graph_service.config import ZepEnvDep
+from graph_service.config import Settings, ZepEnvDep
 from graph_service.dto import FactResult
 
 logger = logging.getLogger(__name__)
@@ -78,17 +80,56 @@ class ZepGraphiti(Graphiti):
             raise HTTPException(status_code=404, detail=e.message) from e
 
 
-def _create_graphiti_client(settings: ZepEnvDep) -> ZepGraphiti:
+def _create_openai_clients(
+    settings: Settings,
+) -> tuple[OpenAIClient, OpenAIEmbedder, OpenAIRerankerClient]:
+    """Build the OpenAI-backed clients Graphiti needs, configured from settings.
+
+    These have to be constructed with the settings rather than patched afterwards: each
+    client builds its AsyncOpenAI in __init__ out of config.api_key and config.base_url,
+    so assigning to the config later leaves the already-built client pointing elsewhere.
+    """
+    api_key = settings.openai_api_key
+    base_url = settings.openai_base_url
+
+    embedder_config = OpenAIEmbedderConfig(api_key=api_key, base_url=base_url)
+    # Assigned only when set, rather than passed to the constructor: embedding_model
+    # defaults to a real model name, so handing it None would overwrite that default.
+    # LLMConfig.model below defaults to None, which is why it can be passed straight in.
+    if settings.embedding_model_name is not None:
+        embedder_config.embedding_model = settings.embedding_model_name
+
+    return (
+        OpenAIClient(
+            config=LLMConfig(api_key=api_key, base_url=base_url, model=settings.model_name)
+        ),
+        OpenAIEmbedder(config=embedder_config),
+        # No model override here. The reranker scores passages off logprobs on a one-token
+        # completion, which is a different job from extraction — leave it on its default.
+        OpenAIRerankerClient(config=LLMConfig(api_key=api_key, base_url=base_url)),
+    )
+
+
+def _create_graphiti_client(settings: Settings) -> ZepGraphiti:
     """Create a ZepGraphiti client based on the configured database backend."""
+    llm_client, embedder, cross_encoder = _create_openai_clients(settings)
+
     if settings.db_backend == 'falkordb':
         from graphiti_core.driver.falkordb_driver import FalkorDriver
 
-        driver = FalkorDriver(  # type: ignore
-            host=settings.falkordb_host or 'localhost',  # type: ignore
-            port=settings.falkordb_port or 6379,  # type: ignore
-            database=settings.falkordb_database or 'default_db',  # type: ignore
+        driver = FalkorDriver(
+            host=settings.falkordb_host or 'localhost',
+            port=settings.falkordb_port or 6379,
+            username=settings.falkordb_username,
+            password=settings.falkordb_password,
+            database=settings.falkordb_database or 'default_db',
         )
-        return ZepGraphiti(graph_driver=driver)  # type: ignore
+        return ZepGraphiti(
+            graph_driver=driver,
+            llm_client=llm_client,
+            embedder=embedder,
+            cross_encoder=cross_encoder,
+        )
     else:
         # Validate Neo4j settings are present
         if not all([settings.neo4j_uri, settings.neo4j_user, settings.neo4j_password]):
@@ -100,18 +141,14 @@ def _create_graphiti_client(settings: ZepEnvDep) -> ZepGraphiti:
             uri=settings.neo4j_uri,
             user=settings.neo4j_user,
             password=settings.neo4j_password,
+            llm_client=llm_client,
+            embedder=embedder,
+            cross_encoder=cross_encoder,
         )
 
 
 async def get_graphiti(settings: ZepEnvDep):
     client = _create_graphiti_client(settings)
-    if settings.openai_base_url is not None:
-        client.llm_client.config.base_url = settings.openai_base_url
-    if settings.openai_api_key is not None:
-        client.llm_client.config.api_key = settings.openai_api_key
-    if settings.model_name is not None:
-        client.llm_client.model = settings.model_name
-
     try:
         yield client
     finally:

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -162,14 +162,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.2.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Found while running the template quality bar on this repo.

## The problem

Both app services in `docker-compose.yml` listed their `environment:` explicitly, so only the vars named there were passed into the container. Everything else a user put in `.env` was silently dropped:

- `MODEL_NAME`
- `SEMAPHORE_LIMIT`
- `EMBEDDING_MODEL_NAME`
- `OPENAI_BASE_URL`
- `FALKORDB_USERNAME` / `FALKORDB_PASSWORD`

That contradicts three things we already tell people: the README says to copy `.env.example` to `.env` and that the falkordb profile "mirrors this Blueprint", and `.env.example` documents every var the app reads. In practice a local run used graphiti-core's default model while Render used `gpt-5.5`.

Confirmed before the change, on a clean clone:

```
$ docker compose --profile falkordb exec -T graph-falkordb printenv MODEL_NAME SEMAPHORE_LIMIT
(nothing)
```

## The fix

`env_file:` with `required: false`, rather than naming each var in `environment:`.

Naming them would hand a blank value to every var the user left out, and blank is not the same as unset — graphiti-core reads `int(os.getenv('SEMAPHORE_LIMIT', 20))`, so `''` is a crash on import. With `env_file`, absent from `.env` means absent from the environment. `.env.example` already leaves optional settings commented out for exactly this reason.

The compose-only wiring stays in `environment:`, which takes precedence over `env_file`, so the compose network hostnames still win over whatever `.env` says.

## Verification

On a fresh clone of `main`, from-scratch build:

- `MODEL_NAME=gpt-5.5` and `SEMAPHORE_LIMIT=10` now reach the container.
- Precedence holds: `FALKORDB_HOST` stays `falkordb` (not `.env`'s `localhost`), and on the default profile `DB_BACKEND` stays `neo4j` with `NEO4J_URI=bolt://neo4j:7687` despite `.env` saying `falkordb`.
- falkordb profile boots healthy, `/healthcheck` 200, no error-level logs, and a write-then-search round trip returns the temporal facts.
- With `.env` deleted entirely, the API still fails fast: `ValidationError ... openai_api_key: String should have at least 1 character`, container exits 3. No silent misconfiguration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)