### PR TITLE
fix(azure): use max_completion_tokens and return token usage tuple

### DIFF
--- a/graphiti_core/llm_client/azure_openai_client.py
+++ b/graphiti_core/llm_client/azure_openai_client.py
@@ -95,7 +95,7 @@ class AzureOpenAILLMClient(BaseOpenAIClient):
             request_kwargs = {
                 'model': model,
                 'messages': messages,
-                'max_tokens': max_tokens,
+                'max_completion_tokens': max_tokens,
                 'response_format': response_model,  # Structured output
             }
 
@@ -118,7 +118,7 @@ class AzureOpenAILLMClient(BaseOpenAIClient):
         request_kwargs = {
             'model': model,
             'messages': messages,
-            'max_tokens': max_tokens,
+            'max_completion_tokens': max_tokens,
             'response_format': {'type': 'json_object'},
         }
 
@@ -128,19 +128,25 @@ class AzureOpenAILLMClient(BaseOpenAIClient):
 
         return await self.client.chat.completions.create(**request_kwargs)
 
-    def _handle_structured_response(self, response: Any) -> dict[str, Any]:
+    def _handle_structured_response(self, response: Any) -> tuple[dict[str, Any], int, int]:
         """Handle structured response parsing for both reasoning and non-reasoning models.
 
         For reasoning models (responses.parse): uses response.output_text
         For regular models (beta.chat.completions.parse): uses response.choices[0].message.parsed
+
+        Returns:
+            tuple: (parsed_response, input_tokens, output_tokens)
         """
         # Check if this is a ParsedChatCompletion (from beta.chat.completions.parse)
         if hasattr(response, 'choices') and response.choices:
+            input_tokens, output_tokens = self._extract_token_usage(
+                response, 'prompt_tokens', 'completion_tokens'
+            )
             # Standard ParsedChatCompletion format
             message = response.choices[0].message
             if hasattr(message, 'parsed') and message.parsed:
                 # The parsed object is already a Pydantic model, convert to dict
-                return message.parsed.model_dump()
+                return message.parsed.model_dump(), input_tokens, output_tokens
             elif hasattr(message, 'refusal') and message.refusal:
                 from graphiti_core.llm_client.errors import RefusalError
 
@@ -148,10 +154,13 @@ class AzureOpenAILLMClient(BaseOpenAIClient):
             else:
                 raise Exception(f'Invalid response from LLM: {response.model_dump()}')
         elif hasattr(response, 'output_text'):
+            input_tokens, output_tokens = self._extract_token_usage(
+                response, 'input_tokens', 'output_tokens'
+            )
             # Reasoning model response format (responses.parse)
             response_object = response.output_text
             if response_object:
-                return json.loads(response_object)
+                return json.loads(response_object), input_tokens, output_tokens
             elif hasattr(response, 'refusal') and response.refusal:
                 from graphiti_core.llm_client.errors import RefusalError
 
@@ -160,6 +169,17 @@ class AzureOpenAILLMClient(BaseOpenAIClient):
                 raise Exception(f'Invalid response from LLM: {response.model_dump()}')
         else:
             raise Exception(f'Unknown response format: {type(response)}')
+
+    @staticmethod
+    def _extract_token_usage(response: Any, input_field: str, output_field: str) -> tuple[int, int]:
+        """Best-effort token usage extraction; missing usage reports zero."""
+        usage = getattr(response, 'usage', None)
+        if not usage:
+            return 0, 0
+        return (
+            getattr(usage, input_field, 0) or 0,
+            getattr(usage, output_field, 0) or 0,
+        )
 
     @staticmethod
     def _supports_reasoning_features(model: str) -> bool:

--- a/tests/llm_client/test_azure_openai_client.py
+++ b/tests/llm_client/test_azure_openai_client.py
@@ -81,7 +81,9 @@ async def test_structured_completion_strips_reasoning_for_unsupported_models():
     call_args = dummy_client.beta.chat.completions.parse_calls[0]
     assert call_args['model'] == 'gpt-4.1'
     assert call_args['messages'] == []
-    assert call_args['max_tokens'] == 64
+    # Azure OpenAI 2024-10-21+ rejects 'max_tokens' (see issue #1496)
+    assert 'max_tokens' not in call_args
+    assert call_args['max_completion_tokens'] == 64
     assert call_args['response_format'] is DummyResponseModel
     assert call_args['temperature'] == 0.4
     # Reasoning and verbosity parameters should not be passed for non-reasoning models

--- a/tests/llm_client/test_azure_openai_client_issue_1496.py
+++ b/tests/llm_client/test_azure_openai_client_issue_1496.py
@@ -1,0 +1,193 @@
+"""Regression tests for issue #1496.
+
+Two independent defects in ``AzureOpenAILLMClient``:
+
+1. ``_handle_structured_response`` returns a bare ``dict`` while the
+   ``BaseOpenAIClient`` contract (and ``_generate_response``'s own return
+   annotation) requires ``tuple[dict, int, int]``.  Every structured Azure
+   call therefore raises ``ValueError: not enough values to unpack``.
+2. The non-reasoning request paths send ``max_tokens``, which Azure OpenAI
+   rejects on API version 2024-10-21 and later in favour of
+   ``max_completion_tokens``.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+from graphiti_core.llm_client.azure_openai_client import AzureOpenAILLMClient
+from graphiti_core.llm_client.config import LLMConfig
+from graphiti_core.prompts.models import Message
+
+
+class DummyResponseModel(BaseModel):
+    foo: str
+
+
+class DummyResponses:
+    def __init__(self):
+        self.parse_calls: list[dict] = []
+
+    async def parse(self, **kwargs):
+        self.parse_calls.append(kwargs)
+        return SimpleNamespace(
+            output_text='{"foo": "bar"}',
+            usage=SimpleNamespace(input_tokens=11, output_tokens=7),
+        )
+
+
+class DummyChatCompletions:
+    def __init__(self):
+        self.create_calls: list[dict] = []
+        self.parse_calls: list[dict] = []
+
+    async def create(self, **kwargs):
+        self.create_calls.append(kwargs)
+        message = SimpleNamespace(content='{"foo": "bar"}')
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=message)],
+            usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3),
+        )
+
+    async def parse(self, **kwargs):
+        self.parse_calls.append(kwargs)
+        parsed_model = kwargs.get('response_format')
+        message = SimpleNamespace(parsed=parsed_model(foo='bar'))
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=message)],
+            usage=SimpleNamespace(prompt_tokens=13, completion_tokens=17),
+        )
+
+
+class DummyChat:
+    def __init__(self):
+        self.completions = DummyChatCompletions()
+
+
+class DummyBeta:
+    def __init__(self):
+        self.chat = DummyChat()
+
+
+class DummyAzureClient:
+    def __init__(self):
+        self.responses = DummyResponses()
+        self.chat = DummyChat()
+        self.beta = DummyBeta()
+
+
+def _client(dummy: DummyAzureClient) -> AzureOpenAILLMClient:
+    return AzureOpenAILLMClient(azure_client=dummy, config=LLMConfig(api_key='test'))
+
+
+# --- Defect 1: return-type contract violation -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_structured_response_returns_usage_tuple_for_parsed_completion():
+    dummy = DummyAzureClient()
+    client = _client(dummy)
+
+    response = await dummy.beta.chat.completions.parse(
+        model='gpt-4o', messages=[], response_format=DummyResponseModel
+    )
+    result = client._handle_structured_response(response)
+
+    assert isinstance(result, tuple), (
+        'Azure _handle_structured_response must honour the BaseOpenAIClient '
+        'tuple[dict, int, int] contract'
+    )
+    parsed, input_tokens, output_tokens = result
+    assert parsed == {'foo': 'bar'}
+    assert input_tokens == 13
+    assert output_tokens == 17
+
+
+@pytest.mark.asyncio
+async def test_handle_structured_response_returns_usage_tuple_for_responses_api():
+    dummy = DummyAzureClient()
+    client = _client(dummy)
+
+    response = await dummy.responses.parse(model='gpt-5', input=[])
+    result = client._handle_structured_response(response)
+
+    assert isinstance(result, tuple)
+    parsed, input_tokens, output_tokens = result
+    assert parsed == {'foo': 'bar'}
+    assert input_tokens == 11
+    assert output_tokens == 7
+
+
+@pytest.mark.asyncio
+async def test_generate_response_does_not_raise_unpack_error():
+    """End-to-end repro of the reported 'expected 3, got 1' crash."""
+    dummy = DummyAzureClient()
+    client = _client(dummy)
+    client.model = 'gpt-4o'
+
+    parsed = await client.generate_response(
+        messages=[Message(role='user', content='hello')],
+        response_model=DummyResponseModel,
+    )
+
+    assert parsed == {'foo': 'bar'}
+
+
+@pytest.mark.asyncio
+async def test_handle_structured_response_missing_usage_defaults_to_zero():
+    dummy = DummyAzureClient()
+    client = _client(dummy)
+
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                parsed=None, message=SimpleNamespace(parsed=DummyResponseModel(foo='bar'))
+            )
+        ]
+    )
+    parsed, input_tokens, output_tokens = client._handle_structured_response(response)
+    assert parsed == {'foo': 'bar'}
+    assert (input_tokens, output_tokens) == (0, 0)
+
+
+# --- Defect 2: max_tokens rejected by Azure 2024-10-21+ ---------------------
+
+
+@pytest.mark.asyncio
+async def test_structured_completion_uses_max_completion_tokens():
+    dummy = DummyAzureClient()
+    client = _client(dummy)
+
+    await client._create_structured_completion(
+        model='gpt-4o',
+        messages=[],
+        temperature=0.4,
+        max_tokens=64,
+        response_model=DummyResponseModel,
+        reasoning=None,
+        verbosity=None,
+    )
+
+    call_args = dummy.beta.chat.completions.parse_calls[0]
+    assert 'max_tokens' not in call_args, (
+        "Azure OpenAI 2024-10-21+ rejects 'max_tokens'; use 'max_completion_tokens'"
+    )
+    assert call_args['max_completion_tokens'] == 64
+
+
+@pytest.mark.asyncio
+async def test_json_completion_uses_max_completion_tokens():
+    dummy = DummyAzureClient()
+    client = _client(dummy)
+
+    await client._create_completion(
+        model='gpt-4o',
+        messages=[],
+        temperature=0.4,
+        max_tokens=128,
+    )
+
+    call_args = dummy.chat.completions.create_calls[0]
+    assert 'max_tokens' not in call_args
+    assert call_args['max_completion_tokens'] == 128


### PR DESCRIPTION
## Summary

Fixes two independent defects in `AzureOpenAILLMClient` reported in #1496. Both are still present on `main` (originally verified at `71a719be482294dd4bbfc5cef557a3a6a500c134`; re-verified after refreshing this branch onto `2645dee20fd71797a61e1c6177a93cccd5584574`); PR #1617 targeted the same issue but was closed unmerged by its own author on 2026-07-27.

**1. Return-type contract violation — every structured Azure call crashes.**
`BaseOpenAIClient._generate_response` is annotated `-> tuple[dict[str, Any], int, int]` and returns `self._handle_structured_response(response)` directly. The base implementation honours that 3-tuple, but the Azure override returned a bare `dict`, so callers hit `ValueError: not enough values to unpack (expected 3, got 1)`. As a side effect Azure users also got no token accounting through `token_tracker`.

The override now returns `(parsed, input_tokens, output_tokens)`, reading `prompt_tokens`/`completion_tokens` for the `choices` (chat completions) shape and `input_tokens`/`output_tokens` for the `responses.parse` shape, defaulting to `(0, 0)` when `usage` is absent.

**2. `max_tokens` rejected by Azure API version 2024-10-21+.**
The two non-reasoning request paths (`beta.chat.completions.parse` and `chat.completions.create`) sent `max_tokens`, which newer Azure models reject with *"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."* Both now send `max_completion_tokens`. The reasoning path already used `max_output_tokens` correctly and is untouched.

## Scope

Only `graphiti_core/llm_client/azure_openai_client.py` plus its tests. **Non-goals:** no changes to `openai_client.py`, `openai_generic_client.py`, or the shared base client; no reasoning-path or model-routing changes.

## Test plan

New `tests/llm_client/test_azure_openai_client_issue_1496.py` (6 tests), all verified RED on the base commit before the fix:

| Behaviour | Before | After |
|---|---|---|
| `_handle_structured_response` on parsed chat completion returns `(dict, 13, 17)` | fail (bare dict) | pass |
| same for `responses.parse` shape returns `(dict, 11, 7)` | fail | pass |
| `generate_response` end-to-end (the reported unpack crash) | fail | pass |
| missing `usage` defaults to `(0, 0)` | fail | pass |
| structured request sends `max_completion_tokens`, not `max_tokens` | fail | pass |
| JSON request sends `max_completion_tokens`, not `max_tokens` | fail | pass |

The pre-existing `test_structured_completion_strips_reasoning_for_unsupported_models` asserted `call_args['max_tokens'] == 64` — it encoded the buggy contract, so it is updated to assert the corrected parameter.

Reproduction is fully offline: a stub Azure client, no network and no API key, triggers both defects. No integration test is required.

Results on this branch:
- `uv run pytest tests/llm_client/` → **106 passed, 2 skipped**
- authoritative no-DB CI gate from `.github/workflows/unit_tests.yml` (`DISABLE_NEO4J=1 DISABLE_FALKORDB=1 DISABLE_KUZU=1 DISABLE_NEPTUNE=1` plus the `--ignore` list) → **372 passed, 11 skipped**
- `uv run ruff check graphiti_core tests/llm_client` → clean
- `uv run ruff format --check graphiti_core tests/llm_client` → clean
- `uv run pyright graphiti_core/llm_client/azure_openai_client.py` → 0 errors

## Refresh (2026-07-31)

The branch was refreshed by merging current `main` (`2645dee20fd71797a61e1c6177a93cccd5584574`, a CLA-signature-only commit) into the reviewed head — merge commit `e00f43eb42935f51dc375f1354369aa6a87c3577`, regular push, no history rewrite. The fix itself is byte-identical to the originally published patch (`git patch-id --stable` = `0da452cd4cbd9225d75028091c09c81cb99071ed` for both). All gates re-run green on the refreshed tree:
- focused Azure client tests → **8 passed**
- authoritative no-DB CI gate → **372 passed, 11 skipped**
- `ruff check` / `ruff format --check` on the 3 changed files → clean
- `pyright graphiti_core/llm_client/azure_openai_client.py` → 0 errors

Note on CI: the `triage` check failure on this PR is a known infrastructure issue in the triage action when run from fork PRs (`Internal error: directory mismatch … this indicates a bug` inside `anthropics/claude-code-action`), not a failure of the change — see the job log at https://github.com/getzep/graphiti/actions/runs/30485330362/job/90689477363. All code-facing checks (`ruff`, CLA, Socket Security, check-fork) pass.

## Risk / compatibility

`max_completion_tokens` is the parameter accepted by Azure OpenAI API version 2024-10-21 and later. Deployments pinned to an API version older than 2024-10-21 would need `max_tokens`; if you would prefer a version-conditional path instead of an unconditional switch, say so and I'll rework it.

The `_handle_structured_response` signature change aligns a subclass with the base-class contract it was already violating. Any third-party code calling that private method directly and expecting a bare dict would need to unpack — no public API changes.

Marked **ready for review**; the one open question for maintainers is the compatibility choice above (unconditional `max_completion_tokens` vs. a version-conditional path). Happy to re-scope or close.

Refs #1496
