### PR TITLE
docs(mcp): fix Ollama config example to use nested provider schema

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -181,13 +181,20 @@ To use Ollama with the MCP server, configure it as an OpenAI-compatible endpoint
 llm:
   provider: "openai"
   model: "gpt-oss:120b"  # or your preferred Ollama model
-  api_base: "http://localhost:11434/v1"
-  api_key: "ollama"  # dummy key required
   structured_output_mode: "json_object"  # use when json_schema is accepted but not enforced
+  providers:
+    openai:
+      api_key: "ollama"  # dummy key required
+      api_url: "http://localhost:11434/v1"
 
 embedder:
-  provider: "sentence_transformers"  # recommended for local setup
-  model: "all-MiniLM-L6-v2"
+  provider: "openai"  # Ollama serves embeddings on the same OpenAI-compatible API
+  model: "nomic-embed-text"  # or another Ollama embedding model
+  dimensions: 768  # must match your embedding model
+  providers:
+    openai:
+      api_key: "ollama"
+      api_url: "http://localhost:11434/v1"
 ```
 
 Make sure Ollama is running locally with: `ollama serve`

--- a/mcp_server/tests/test_readme_config_examples.py
+++ b/mcp_server/tests/test_readme_config_examples.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Regression fence: the config examples in mcp_server/README.md must match the real schema.
+
+The YAML is extracted from README.md at runtime (never hand-copied) so the documented
+examples cannot silently drift away from `config.schema` / `services.factories` again.
+See getzep/graphiti#1556.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Add the src directory to the path (mirrors the other factory tests)
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+from graphiti_core.embedder.openai import OpenAIEmbedder
+from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
+
+from config.schema import EmbedderConfig, EmbedderProvidersConfig, LLMConfig
+from services.factories import EmbedderFactory, LLMClientFactory
+
+README_PATH = Path(__file__).parent.parent / 'README.md'
+
+OLLAMA_SECTION_RE = re.compile(
+    r'^###\s+Using Ollama for Local LLM\s*$.*?^```yaml\s*$(?P<yaml>.*?)^```\s*$',
+    re.MULTILINE | re.DOTALL,
+)
+
+YAML_FENCE_RE = re.compile(r'^```yaml\s*$(?P<yaml>.*?)^```\s*$', re.MULTILINE | re.DOTALL)
+
+OLLAMA_API_URL = 'http://localhost:11434/v1'
+
+
+def _readme_text() -> str:
+    """Read README.md relative to this test file, not the current working directory."""
+    assert README_PATH.is_file(), f'README not found at {README_PATH}'
+    return README_PATH.read_text(encoding='utf-8')
+
+
+def _ollama_example() -> dict:
+    """Extract and parse the YAML block from the 'Using Ollama for Local LLM' section."""
+    match = OLLAMA_SECTION_RE.search(_readme_text())
+    assert match is not None, 'no yaml fence found under "### Using Ollama for Local LLM"'
+    data = yaml.safe_load(match.group('yaml'))
+    assert isinstance(data, dict), 'Ollama example did not parse into a mapping'
+    return data
+
+
+@pytest.fixture
+def ollama_example() -> dict:
+    """Provide the parsed README Ollama config example."""
+    return _ollama_example()
+
+
+class TestReadmeOllamaExample:
+    """The documented Ollama example must build working clients through the real factories."""
+
+    def test_example_declares_llm_and_embedder_sections(self, ollama_example):
+        """The extractor found a block that actually configures both an LLM and an embedder."""
+        assert 'llm' in ollama_example, f'no llm section in {sorted(ollama_example)}'
+        assert 'embedder' in ollama_example, f'no embedder section in {sorted(ollama_example)}'
+
+    def test_llm_example_nests_ollama_endpoint_under_openai_provider(self, ollama_example):
+        """The Ollama endpoint must land on `llm.providers.openai.api_url`, not a dropped key."""
+        llm = LLMConfig(**ollama_example['llm'])
+        assert llm.providers.openai is not None, (
+            'llm.providers.openai is None - the documented endpoint keys are silently '
+            'ignored by LLMConfig (extra="ignore")'
+        )
+        assert llm.providers.openai.api_url == OLLAMA_API_URL
+
+    def test_llm_example_builds_chat_completions_client(self, ollama_example):
+        """A localhost endpoint must route through `is_non_openai_provider` to the generic client."""
+        llm = LLMConfig(**ollama_example['llm'])
+        client = LLMClientFactory.create(llm)
+        assert isinstance(client, OpenAIGenericClient), (
+            f'expected OpenAIGenericClient (Chat Completions) for {OLLAMA_API_URL}, '
+            f'got {type(client).__name__}'
+        )
+
+    def test_embedder_example_builds_openai_compatible_embedder(self, ollama_example):
+        """The documented embedder section must construct without network or a real API key."""
+        embedder = EmbedderFactory.create(EmbedderConfig(**ollama_example['embedder']))
+        assert isinstance(embedder, OpenAIEmbedder), (
+            f'expected an OpenAI-compatible embedder, got {type(embedder).__name__}'
+        )
+
+
+class TestReadmeEmbedderProviders:
+    """Every embedder provider named anywhere in the README must exist in the schema."""
+
+    def test_all_documented_embedder_providers_are_supported(self):
+        """`provider:` values under any README `embedder:` block must be schema fields."""
+        supported = set(EmbedderProvidersConfig.model_fields)
+        documented = set()
+        for match in YAML_FENCE_RE.finditer(_readme_text()):
+            data = yaml.safe_load(match.group('yaml'))
+            if not isinstance(data, dict):
+                continue
+            embedder = data.get('embedder')
+            if isinstance(embedder, dict) and 'provider' in embedder:
+                documented.add(str(embedder['provider']))
+
+        assert documented, 'no embedder provider found in any README yaml block'
+        unsupported = sorted(documented - supported)
+        assert not unsupported, (
+            f'README documents unsupported embedder provider(s) {unsupported}; '
+            f'supported: {sorted(supported)}'
+        )


### PR DESCRIPTION
Fixes #1556.

## Problem

The "Using Ollama for Local LLM" example in `mcp_server/README.md` documents a **flat** provider schema that the current config models no longer accept. Copying it verbatim fails to construct either client:

```
LLM create FAILED: ValueError: OpenAI provider configuration not found      (factories.py:140)
EMB create FAILED: ValueError: Unsupported Embedder provider: sentence_transformers  (factories.py:410)
```

Two independent defects in the same block:

1. **`llm.api_base` / `llm.api_key` are not fields on `LLMConfig`.** `mcp_server/src/config/schema.py` requires the endpoint under `providers.openai.api_url`. With the documented shape, `config.providers.openai` stays `None`, so `LLMClientFactory.create` raises — and `is_non_openai_provider()` never sees the Ollama URL, so even if construction succeeded the routing would be wrong.
2. **`embedder.provider: sentence_transformers` is not a supported provider.** `EmbedderProvidersConfig` supports `openai | azure_openai | gemini | voyage`; `sentence_transformers` falls to `case _` and raises. Ollama serves embeddings on the same OpenAI-compatible endpoint, so `openai` is the correct provider here.

## Change

Docs-only rewrite of the Ollama YAML block to the nested `providers:` schema already used elsewhere in this README and in `mcp_server/config/config.yaml`, plus a regression test.

The test (`mcp_server/tests/test_readme_config_examples.py`) **extracts the YAML from `README.md` at runtime** rather than copying it — so it is a real drift fence: if the section reverts to the flat shape, the test goes RED again. It asserts the documented endpoint lands on `providers.openai.api_url`, that `LLMClientFactory.create` actually returns an `OpenAIGenericClient` (Chat Completions path), that `EmbedderFactory.create` constructs, and that every embedder `provider:` appearing in the README is in the factory's supported set.

No `schema.py` / `factories.py` changes. No new provider added. No other README section touched.

## Test plan

Base: `71a719be482294dd4bbfc5cef557a3a6a500c134`. No network, no API key, no database required.

```bash
cd mcp_server
GRAPHITI_TELEMETRY_ENABLED=false uv run pytest tests/test_readme_config_examples.py -v
# RED on base: 4 of 5 fail with exactly the two ValueErrors above
# GREEN with this change: 5 passed

GRAPHITI_TELEMETRY_ENABLED=false uv run pytest \
  tests/test_readme_config_examples.py tests/test_configuration.py tests/test_factories.py -q
# 36 passed
```

Related regressions are clean, so no baseline attribution was needed. `ruff check` and `ruff format --check` on the new test file are clean.

Independent adversarial probes were run on throwaway copies of the tree: reverting the README block, renaming the section heading, and swapping `api_url` to the official OpenAI endpoint each make the test fail as intended — confirming the fence bites rather than passing vacuously.

## Refresh onto current main

Branch refreshed via merge of `upstream/main` (`2645dee`, the only upstream delta being a CLA record in `signatures/version1/cla.json`) at head `864d41ee8a677f42f2d0958c3170c28882420fa3`. The two-file candidate patch is byte-identical before/after the refresh (patch SHA-256 `b4c26640b75a7a72b21be8570b7a7280114a28ccc9366806ad7b367d8b1186d5`). Post-refresh re-verification: 36 focused tests pass, `ruff check` / `ruff format --check` clean, and an independent read-only review of the exact tree found zero unresolved findings.

## CI note

The `triage` check failure on this PR is a known infrastructure problem in the `anthropics/claude-code-action` runner when triaging fork PRs, not a defect in this change — the job log shows `Internal error: directory mismatch for directory ".../claude-code-action/.../tsconfig.json", fd 4. You don't need to do anything, but this indicates a bug.` (https://github.com/getzep/graphiti/actions/runs/30499248316/job/90735021052). All candidate-owned checks (`ruff`, CLA, Socket, `check-fork`) are green.

## Notes

Docs + test only; no runtime behavior change.
