### PR TITLE
fix(falkordb): route grouped clears to tenant graphs

### DIFF
--- a/graphiti_core/driver/falkordb/operations/graph_ops.py
+++ b/graphiti_core/driver/falkordb/operations/graph_ops.py
@@ -18,7 +18,7 @@ import asyncio
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.driver import GraphDriver, GraphProvider
 from graphiti_core.driver.operations.graph_ops import GraphMaintenanceOperations
 from graphiti_core.driver.operations.graph_utils import Neighbor, label_propagation
 from graphiti_core.driver.query_executor import QueryExecutor
@@ -41,17 +41,27 @@ class FalkorGraphMaintenanceOperations(GraphMaintenanceOperations):
     ) -> None:
         if group_ids is None:
             await executor.execute_query('MATCH (n) DETACH DELETE n')
-        else:
-            # FalkorDB: iterate labels individually
-            for label in ['Entity', 'Episodic', 'Community']:
-                await executor.execute_query(
-                    f"""
-                    MATCH (n:{label})
-                    WHERE n.group_id IN $group_ids
-                    DETACH DELETE n
-                    """,
-                    group_ids=group_ids,
-                )
+            return
+
+        if isinstance(executor, GraphDriver):
+            # FalkorDB stores every group_id in its own physical graph. Route each
+            # clear to that graph instead of filtering the base/default graph.
+            for group_id in dict.fromkeys(group_ids):
+                group_driver = executor.clone(database=group_id)
+                await group_driver.execute_query('MATCH (n) DETACH DELETE n')
+            return
+
+        # Transaction-like executors cannot be cloned. Preserve the scoped
+        # fallback for callers that already opened a session on the target graph.
+        for label in ['Entity', 'Episodic', 'Community']:
+            await executor.execute_query(
+                f"""
+                MATCH (n:{label})
+                WHERE n.group_id IN $group_ids
+                DETACH DELETE n
+                """,
+                group_ids=group_ids,
+            )
 
     async def build_indices_and_constraints(
         self,

--- a/tests/driver/test_falkordb_ops_routing.py
+++ b/tests/driver/test_falkordb_ops_routing.py
@@ -24,6 +24,9 @@ from graphiti_core.driver.falkordb.operations.entity_node_ops import (
 from graphiti_core.driver.falkordb.operations.episode_node_ops import (
     FalkorEpisodeNodeOperations,
 )
+from graphiti_core.driver.falkordb.operations.graph_ops import (
+    FalkorGraphMaintenanceOperations,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -117,3 +120,48 @@ async def test_get_by_group_ids_empty_group_ids_does_not_route():
 
     base.clone.assert_not_called()
     base.execute_query.assert_awaited_once()
+
+
+async def test_clear_data_single_group_routes_to_its_graph():
+    ops = FalkorGraphMaintenanceOperations()
+    base, child = _make_falkor_driver()
+
+    await ops.clear_data(base, ['tenant-1'])
+
+    base.clone.assert_called_once_with(database='tenant-1')
+    child.execute_query.assert_awaited_once_with('MATCH (n) DETACH DELETE n')
+    base.execute_query.assert_not_called()
+
+
+async def test_clear_data_multi_group_routes_to_each_graph_once():
+    ops = FalkorGraphMaintenanceOperations()
+    base = MagicMock(spec=GraphDriver)
+    base.provider = GraphProvider.FALKORDB
+    base.execute_query = AsyncMock(return_value=([], None, None))
+    clones = {}
+
+    def _clone(database):
+        child = MagicMock(spec=GraphDriver)
+        child.provider = GraphProvider.FALKORDB
+        child.execute_query = AsyncMock(return_value=([], None, None))
+        clones[database] = child
+        return child
+
+    base.clone = MagicMock(side_effect=_clone)
+
+    await ops.clear_data(base, ['group-a', 'group-b', 'group-a'])
+
+    assert list(clones) == ['group-a', 'group-b']
+    base.execute_query.assert_not_called()
+    for child in clones.values():
+        child.execute_query.assert_awaited_once_with('MATCH (n) DETACH DELETE n')
+
+
+async def test_clear_data_without_group_ids_clears_current_graph():
+    ops = FalkorGraphMaintenanceOperations()
+    base, _ = _make_falkor_driver()
+
+    await ops.clear_data(base)
+
+    base.clone.assert_not_called()
+    base.execute_query.assert_awaited_once_with('MATCH (n) DETACH DELETE n')


### PR DESCRIPTION
## Summary
Fix FalkorDB group-scoped clearing so MCP `clear_graph` deletes the requested tenant graphs instead of filtering the base/default graph and reporting a false success.

FalkorDB stores each `group_id` in a separate physical graph. `FalkorGraphMaintenanceOperations.clear_data` previously executed property-filtered deletes on the executor's current graph, which is normally `default_db`. The fix clones the driver per requested group, clears that physical graph, and preserves the existing transaction-like fallback for executors that cannot be cloned.

Duplicate group IDs are de-duplicated while preserving order, and groups are cleared sequentially to avoid concurrent operations on the shared FalkorDB connection.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
Restore the destructive-operation contract for FalkorDB multi-tenant deployments: a successful group-scoped clear must actually remove data from every requested group graph.

This is the remaining `clear_graph` portion of #1651 after #1670 and #1675 fixed the corresponding read paths. UUID-only lookup/delete tools are intentionally out of scope because their cross-graph lookup contract needs separate design.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

Validated locally:
- `uv run pytest tests/driver/test_falkordb_ops_routing.py -q` — 8 passed
- relevant driver/decorator suite — 37 passed, 1 skipped
- `uv run ruff check` — passed
- `uv run pyright ./graphiti_core` — 0 errors
- `uv run ruff format --check` and `git diff --check` — passed

New unit coverage verifies single-group routing, multi-group routing, duplicate group IDs, and clearing the current graph when no group scope is supplied. The tests use `GraphDriver` mocks and do not require a live FalkorDB.

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` equivalent commands pass)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Addresses the `clear_graph` path in #1651.