### PR TITLE
Report OpenAI failures instead of a bare 500, and keep the ingest worker alive

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# The root Dockerfile builds only server/, so exclude the whole repo and add that one
+# subtree back. An allow-list keeps the context minimal without needing an update every
+# time the repo grows a new top-level directory.
+*
+!server/
+
+# Re-exclude what lives under server/ but never belongs in an image layer: a local
+# virtualenv (larger than the image itself), local secrets, and build droppings.
+server/.venv
+server/.env
+server/.env.*
+server/tests
+server/**/__pycache__
+server/**/*.pyc

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,10 @@
-# The root Dockerfile builds only server/, so exclude the whole repo and add that one
-# subtree back. An allow-list keeps the context minimal without needing an update every
-# time the repo grows a new top-level directory.
+# The root Dockerfile builds only server/, so exclude everything and add that subtree back.
+# An allow-list keeps the context minimal as the repo grows new top-level directories.
 *
 !server/
 
-# Re-exclude what lives under server/ but never belongs in an image layer: a local
-# virtualenv (larger than the image itself), local secrets, and build droppings.
+# Re-exclude what lives under server/ but never belongs in a layer: a local virtualenv
+# (larger than the image), local secrets, and build droppings.
 server/.venv
 server/.env
 server/.env.*

--- a/.env.example
+++ b/.env.example
@@ -38,8 +38,3 @@ SEMAPHORE_LIMIT=10
 # EMBEDDING_MODEL_NAME=
 # Point at an OpenAI-compatible gateway instead of api.openai.com.
 # OPENAI_BASE_URL=
-
-# --- Pinning ----------------------------------------------------------------------
-# The graphiti-core release docker-compose builds against, matching render.yaml. This
-# is a PyPI release number, not this repo's own version in pyproject.toml.
-GRAPHITI_VERSION=0.29.3

--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,45 @@
+# Copy to .env for local development. On Render these are set by render.yaml, except
+# OPENAI_API_KEY, which Render prompts for at deploy time.
+#
+# Optional settings are left commented out rather than assigned an empty value. An
+# empty assignment is not the same as unset: it reaches the app as '' and is taken as
+# a real setting. Uncomment a line to use it.
+
+# --- Required ---------------------------------------------------------------------
+# Graphiti calls an LLM to extract entities and facts. https://platform.openai.com/api-keys
 OPENAI_API_KEY=
 
-# Neo4j database connection
-NEO4J_URI=
-NEO4J_PORT=
-NEO4J_USER=
-NEO4J_PASSWORD=
+# --- Graph backend ----------------------------------------------------------------
+# 'falkordb' (what this template deploys) or 'neo4j'.
+DB_BACKEND=falkordb
 
-# FalkorDB database connection 
-FALKORDB_URI=
-FALKORDB_PORT=
-FALKORDB_USER=
-FALKORDB_PASSWORD=
+# FalkorDB. On Render, FALKORDB_HOST is wired to the private graphiti-falkordb service.
+FALKORDB_HOST=localhost
+FALKORDB_PORT=6379
+FALKORDB_DATABASE=default_db
+# Only if you put FalkorDB behind a password (see the README).
+# FALKORDB_USERNAME=
+# FALKORDB_PASSWORD=
 
-USE_PARALLEL_RUNTIME=
-SEMAPHORE_LIMIT=
-GITHUB_SHA=
-MAX_REFLEXION_ITERATIONS=
-ANTHROPIC_API_KEY=
+# Neo4j, used instead of the FalkorDB block when DB_BACKEND=neo4j.
+# NEO4J_URI=
+# NEO4J_USER=
+# NEO4J_PASSWORD=
+# Bolt port; read by docker-compose.yml, which defaults it to 7687.
+# NEO4J_PORT=
+
+# --- Model ------------------------------------------------------------------------
+# Any OpenAI model id; leave unset to use graphiti-core's default.
+MODEL_NAME=gpt-5.5
+# Concurrent LLM calls during ingestion. graphiti-core defaults to 20; this is lower to
+# stay under the rate limits on a fresh OpenAI account.
+SEMAPHORE_LIMIT=10
+# Embedding model; leave unset for graphiti-core's default (text-embedding-3-small).
+# EMBEDDING_MODEL_NAME=
+# Point at an OpenAI-compatible gateway instead of api.openai.com.
+# OPENAI_BASE_URL=
+
+# --- Pinning ----------------------------------------------------------------------
+# The graphiti-core release docker-compose builds against, matching render.yaml. This
+# is a PyPI release number, not this repo's own version in pyproject.toml.
+GRAPHITI_VERSION=0.29.3

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,17 @@
 # Graphiti calls an LLM to extract entities and facts. https://platform.openai.com/api-keys
 OPENAI_API_KEY=
 
+# --- Auth ---------------------------------------------------------------------------
+# Bearer token required by every endpoint except /healthcheck. Mandatory, with no way to switch
+# auth off; blank counts as missing.
+#
+# Render generates it when the service is first created, and `docker compose` defaults it to
+# insecure-local-dev-key — so leave this unset unless you want your own value, which is then what
+# the local stack and the curl examples expect. Must be 16+ printable-ASCII characters: the server
+# budgets failed attempts, but that can't save a key like `dev`, and header values travel as
+# latin-1 with clients encoding anything outside ASCII inconsistently.
+# GRAPHITI_API_KEY=
+
 # --- Graph backend ----------------------------------------------------------------
 # 'falkordb' (what this template deploys) or 'neo4j'.
 DB_BACKEND=falkordb

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,8 @@
 # Copy to .env for local development. On Render these are set by render.yaml, except
 # OPENAI_API_KEY, which Render prompts for at deploy time.
 #
-# Optional settings are left commented out rather than assigned an empty value. An
-# empty assignment is not the same as unset: it reaches the app as '' and is taken as
-# a real setting. Uncomment a line to use it.
+# Optional settings stay commented out rather than assigned an empty value: '' is not the
+# same as unset, and arrives at the app as a real setting. Uncomment a line to use it.
 
 # --- Required ---------------------------------------------------------------------
 # Graphiti calls an LLM to extract entities and facts. https://platform.openai.com/api-keys
@@ -13,11 +12,10 @@ OPENAI_API_KEY=
 # Bearer token required by every endpoint except /healthcheck. Mandatory, with no way to switch
 # auth off; blank counts as missing.
 #
-# Render generates it when the service is first created, and `docker compose` defaults it to
-# insecure-local-dev-key — so leave this unset unless you want your own value, which is then what
-# the local stack and the curl examples expect. Must be 16+ printable-ASCII characters: the server
-# budgets failed attempts, but that can't save a key like `dev`, and header values travel as
-# latin-1 with clients encoding anything outside ASCII inconsistently.
+# Render generates it on first deploy and `docker compose` defaults it to insecure-local-dev-key,
+# so leave this unset unless you want your own value — which the local stack and the curl examples
+# then expect. Must be 16+ printable-ASCII characters: the server budgets failed attempts, but
+# that can't save a key like `dev`, and headers travel as latin-1.
 # GRAPHITI_API_KEY=
 
 # --- Graph backend ----------------------------------------------------------------
@@ -39,11 +37,17 @@ FALKORDB_DATABASE=default_db
 # Bolt port; read by docker-compose.yml, which defaults it to 7687.
 # NEO4J_PORT=
 
+# --- Serving ----------------------------------------------------------------------
+# The port uvicorn binds to, set for you in render.yaml. Setting it here changes nothing under
+# docker compose: both API services pin it to 8000, which is what their healthchecks and
+# published ports name. Edit docker-compose.yml's mapping to move where the stack is reachable.
+# PORT=8000
+
 # --- Model ------------------------------------------------------------------------
 # Any OpenAI model id; leave unset to use graphiti-core's default.
 MODEL_NAME=gpt-5.5
-# Concurrent LLM calls during ingestion. graphiti-core defaults to 20; this is lower to
-# stay under the rate limits on a fresh OpenAI account.
+# Concurrent LLM calls during ingestion. Below graphiti-core's default of 20, to stay under
+# the rate limits on a fresh OpenAI account.
 SEMAPHORE_LIMIT=10
 # Embedding model; leave unset for graphiti-core's default (text-embedding-3-small).
 # EMBEDDING_MODEL_NAME=

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -1,7 +1,6 @@
 name: Server Tests
 
-# Tests for the Graphiti graph_service (REST API), in two jobs, both on PRs and pushes to
-# main that touch the server:
+# Tests for graph_service (the REST API), on PRs and pushes to main that touch the server:
 #
 # - unit-tests: everything needing no secrets and no database, notably the auth guards in
 #   tests/test_auth.py. Runs on forks too, so a router included without its auth dependency
@@ -24,8 +23,8 @@ on:
 permissions:
   contents: read
 
-# Cancel superseded runs on the same ref so repeated pushes don't keep paying for
-# real OpenAI calls.
+# Cancel superseded runs on the same ref, so repeated pushes don't keep paying for real
+# OpenAI calls.
 concurrency:
   group: server-tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -50,8 +49,8 @@ jobs:
         run: uv sync --extra dev
       - name: Run unit tests
         working-directory: server
-        # By marker, not filename, so a new module is picked up by default and only opts
-        # out by marking itself integration. --strict-markers makes a typo an error.
+        # By marker, not filename, so a new module is picked up by default and opts out only
+        # by marking itself integration. --strict-markers makes a typo an error.
         run: uv run pytest -m "not integration" --strict-markers -p no:cacheprovider
 
   live-server-tests:
@@ -70,9 +69,8 @@ jobs:
         with:
           version: "latest"
       - name: Start FalkorDB
-        # Run the database on the host network rather than a `services:` block: on
-        # the depot-ubuntu runner pool bridge-network NAT silently drops packets to
-        # published service-container ports. Readiness is checked via `docker exec`.
+        # Host network rather than a `services:` block: on the depot-ubuntu runner pool,
+        # bridge-network NAT silently drops packets to published service-container ports.
         run: docker run -d --name falkordb --network host falkordb/falkordb:latest
       - name: Install dependencies
         working-directory: server
@@ -93,21 +91,16 @@ jobs:
           DB_BACKEND: falkordb
           FALKORDB_HOST: localhost
           FALKORDB_PORT: "6379"
-          # gpt-5.5 is the graphiti-core default, but it requires a key/account
-          # with fast gpt-5.5 access; CI pins a lighter, broadly-available model so
-          # the live test stays fast and reliable. It exercises the same pipeline.
+          # graphiti-core defaults to gpt-5.5, which needs an account with fast access to it.
+          # A lighter, broadly-available model exercises the same pipeline.
           MODEL_NAME: gpt-4.1-mini
-          # Raise episode/LLM-call concurrency so the live episode processes quickly.
+          # Raised so the live episode processes quickly.
           SEMAPHORE_LIMIT: "20"
-        # pytest exits 5 when no tests are collected. The legitimate case is a fork
-        # PR with no OPENAI_API_KEY: the suite self-skips at module level. When the
-        # key IS present (same-repo run) exit 5 is unexpected — the live suite should
-        # have run — so fail loudly rather than report a green build that tested
-        # nothing. Likely causes: FalkorDB became unreachable (the suite also skips at
-        # module level when it can't connect, even though the prior step gated it), or
-        # the `integration` marker was renamed/removed so the selection matches
-        # nothing. Real failures (exit 1), import errors (exit 2), and usage errors
-        # such as a renamed test-file path (exit 4) always fail the job too.
+        # pytest exits 5 when nothing is collected. The legitimate case is a fork PR with no
+        # OPENAI_API_KEY, where the suite self-skips at module level. With the key present, exit
+        # 5 means the live suite should have run and didn't — FalkorDB unreachable, or the
+        # `integration` marker renamed — so fail rather than report a green build that tested
+        # nothing. Real failures (1), import errors (2), and usage errors (4) fail the job too.
         run: |
           set +e
           uv run pytest tests/test_live_falkordb_int.py -m integration -p no:cacheprovider

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -1,12 +1,14 @@
 name: Server Tests
 
-# Live end-to-end regression tests for the Graphiti graph_service (REST API)
-# against FalkorDB and a real OpenAI model. Spawns the FastAPI server as a
-# subprocess and exercises the public API end to end (ingest -> async process ->
-# search -> delete). Runs on PRs and pushes to main that touch the server. The
-# OpenAI key comes from the `development` GitHub environment; fork PRs receive no
-# secrets, so the suite skips itself there (the test module skips when
-# OPENAI_API_KEY is unset).
+# Tests for the Graphiti graph_service (REST API), in two jobs, both on PRs and pushes to
+# main that touch the server:
+#
+# - unit-tests: everything needing no secrets and no database, notably the auth guards in
+#   tests/test_auth.py. Runs on forks too, so a router included without its auth dependency
+#   fails the build that adds it rather than the deploy that ships it.
+# - live-server-tests: end to end against FalkorDB and a real OpenAI model (ingest -> async
+#   process -> search -> delete), with the server as a subprocess. The key comes from the
+#   `development` environment; fork PRs get no secrets, so the module skips itself there.
 on:
   push:
     branches: [main]
@@ -29,6 +31,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  unit-tests:
+    runs-on: depot-ubuntu-22.04
+    # No `environment:` and no secrets, which is what lets it run on fork PRs.
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.10"
+      - name: Install uv
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+        with:
+          version: "latest"
+      - name: Install dependencies
+        working-directory: server
+        run: uv sync --extra dev
+      - name: Run unit tests
+        working-directory: server
+        # By marker, not filename, so a new module is picked up by default and only opts
+        # out by marking itself integration. --strict-markers makes a typo an error.
+        run: uv run pytest -m "not integration" --strict-markers -p no:cacheprovider
+
   live-server-tests:
     runs-on: depot-ubuntu-22.04
     environment: development

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Docker has no systemd here — start the daemon manually once per VM: `sudo dock
 
 ### Running the services (dev mode)
 All three run without a valid OpenAI key for startup/health only; real ingest/search (LLM extraction + embeddings) needs a real `OPENAI_API_KEY`.
-- REST API (`server/`): `OPENAI_API_KEY=<placeholder-or-real> DB_BACKEND=falkordb FALKORDB_HOST=localhost FALKORDB_PORT=6379 uv run uvicorn graph_service.main:app --reload --port 8000`. Health at `/healthcheck`, Swagger at `/docs`. `Settings` requires `OPENAI_API_KEY` to be present (any value) or startup fails.
+- REST API (`server/`): `OPENAI_API_KEY=<placeholder-or-real> GRAPHITI_API_KEY=insecure-local-dev-key DB_BACKEND=falkordb FALKORDB_HOST=localhost FALKORDB_PORT=6379 uv run uvicorn graph_service.main:app --reload --port 8000`. Health at `/healthcheck` (the only endpoint that takes no key), Swagger at `/docs`. `Settings` requires `OPENAI_API_KEY` to be present (any value) and `GRAPHITI_API_KEY` to be at least 16 printable-ASCII characters, or startup fails. Every other endpoint needs `Authorization: Bearer $GRAPHITI_API_KEY`; after 10 rejections in a minute the server answers 429 instead of 401.
 - MCP server (`mcp_server/`): `OPENAI_API_KEY=<...> FALKORDB_URI=redis://localhost:6379 uv run python main.py --transport http --host 0.0.0.0 --port 8001 --database-provider falkordb`. Serves streamable HTTP MCP at `/mcp/` (use port 8001 if 8000 is taken by the REST server).
 
 ### Backend gotcha

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
 # syntax=docker/dockerfile:1.9
 FROM python:3.12-slim
 
-# The graphiti-core release installed from PyPI below, and the value of the version
-# labels. This default is the single source of truth for the pin: render.yaml,
-# docker-compose.yml, and local builds all inherit it, so a bump happens here and
-# nowhere else. It is a PyPI release number, not this repo's own version.
+# The graphiti-core PyPI release installed below, and the version labels. Single source of
+# truth for the pin: render.yaml, docker-compose.yml, and local builds all inherit it.
 #
-# 0.29.2 in particular does not work on FalkorDB: it writes episodes fine but reads them
-# back empty, so /search and /episodes return nothing. Verify a write-then-search round
-# trip before bumping. Release CI overrides this with the version it is publishing.
+# 0.29.2 in particular is broken on FalkorDB — it writes episodes but reads them back empty,
+# so /search returns nothing. Verify a write-then-search round trip before bumping.
 ARG GRAPHITI_VERSION=0.29.3
 
 # Inherit build arguments for labels
@@ -49,9 +46,8 @@ WORKDIR /app
 COPY ./server/pyproject.toml ./server/README.md ./server/uv.lock ./
 COPY ./server/graph_service ./graph_service
 
-# Install server dependencies (without graphiti-core from lockfile)
-# Then install graphiti-core from PyPI at the desired version
-# This prevents the stale lockfile from pinning an old graphiti-core version
+# Server deps from the lockfile, then graphiti-core from PyPI, so the stale lockfile
+# can't pin an old graphiti-core.
 ARG INSTALL_FALKORDB=false
 RUN --mount=type=cache,target=/root/.cache/uv \
     : "${GRAPHITI_VERSION:?must be a graphiti-core release from PyPI}" && \
@@ -76,15 +72,11 @@ USER app
 ENV PORT=8000
 EXPOSE $PORT
 
-# Shell form, so $PORT actually reaches uvicorn: the exec form does no variable expansion,
-# which is why this used to hardcode 8000 and ignore the PORT it declares above. `:-8000`
-# covers PORT set but empty, which a dashboard or a .env makes easy and which is not the
-# same as unset. `exec` replaces the shell, so uvicorn is PID 1 and gets SIGTERM directly
-# on deploy or shutdown, rather than the shell absorbing it until the runtime kills us.
+# Shell form, so $PORT reaches uvicorn at all — the exec form does no expansion. `:-8000`
+# covers PORT set but empty, which a dashboard or a .env makes easy. `exec` keeps uvicorn as
+# PID 1, so it gets SIGTERM directly instead of the shell absorbing it.
 #
-# uvicorn straight from the venv, not `uv run --no-sync uvicorn`: uv is installed under
-# /root/.local/bin, and /root is 0700, so the app user cannot resolve it through PATH. The
-# exec form got away with it because the runtime resolves the binary as root before
-# dropping privileges; a shell doing its own PATH lookup gets EACCES. PATH already puts
-# /app/.venv/bin first, so this is the same interpreter uv run would have selected.
+# uvicorn from the venv, not `uv run`: uv lives under /root/.local/bin and /root is 0700, so
+# the app user's PATH lookup gets EACCES. Same interpreter either way — PATH puts
+# /app/.venv/bin first.
 CMD ["sh", "-c", "exec uvicorn graph_service.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,5 +76,15 @@ USER app
 ENV PORT=8000
 EXPOSE $PORT
 
-# Use uv run with --no-sync to avoid re-syncing on startup
-CMD ["uv", "run", "--no-sync", "uvicorn", "graph_service.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Shell form, so $PORT actually reaches uvicorn: the exec form does no variable expansion,
+# which is why this used to hardcode 8000 and ignore the PORT it declares above. `:-8000`
+# covers PORT set but empty, which a dashboard or a .env makes easy and which is not the
+# same as unset. `exec` replaces the shell, so uvicorn is PID 1 and gets SIGTERM directly
+# on deploy or shutdown, rather than the shell absorbing it until the runtime kills us.
+#
+# uvicorn straight from the venv, not `uv run --no-sync uvicorn`: uv is installed under
+# /root/.local/bin, and /root is 0700, so the app user cannot resolve it through PATH. The
+# exec form got away with it because the runtime resolves the binary as root before
+# dropping privileges; a shell doing its own PATH lookup gets EACCES. PATH already puts
+# /app/.venv/bin first, so this is the same interpreter uv run would have selected.
+CMD ["sh", "-c", "exec uvicorn graph_service.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
 # syntax=docker/dockerfile:1.9
 FROM python:3.12-slim
 
+# The graphiti-core release installed from PyPI below, and the value of the version
+# labels. This default is the single source of truth for the pin: render.yaml,
+# docker-compose.yml, and local builds all inherit it, so a bump happens here and
+# nowhere else. It is a PyPI release number, not this repo's own version.
+#
+# 0.29.2 in particular does not work on FalkorDB: it writes episodes fine but reads them
+# back empty, so /search and /episodes return nothing. Verify a write-then-search round
+# trip before bumping. Release CI overrides this with the version it is publishing.
+ARG GRAPHITI_VERSION=0.29.3
+
 # Inherit build arguments for labels
-ARG GRAPHITI_VERSION
 ARG BUILD_DATE
 ARG VCS_REF
 
@@ -45,19 +54,12 @@ COPY ./server/graph_service ./graph_service
 # This prevents the stale lockfile from pinning an old graphiti-core version
 ARG INSTALL_FALKORDB=false
 RUN --mount=type=cache,target=/root/.cache/uv \
+    : "${GRAPHITI_VERSION:?must be a graphiti-core release from PyPI}" && \
     uv sync --frozen --no-dev && \
-    if [ -n "$GRAPHITI_VERSION" ]; then \
-        if [ "$INSTALL_FALKORDB" = "true" ]; then \
-            uv pip install --upgrade "graphiti-core[falkordb]==$GRAPHITI_VERSION"; \
-        else \
-            uv pip install --upgrade "graphiti-core==$GRAPHITI_VERSION"; \
-        fi; \
+    if [ "$INSTALL_FALKORDB" = "true" ]; then \
+        uv pip install --upgrade "graphiti-core[falkordb]==$GRAPHITI_VERSION"; \
     else \
-        if [ "$INSTALL_FALKORDB" = "true" ]; then \
-            uv pip install --upgrade "graphiti-core[falkordb]"; \
-        else \
-            uv pip install --upgrade graphiti-core; \
-        fi; \
+        uv pip install --upgrade "graphiti-core==$GRAPHITI_VERSION"; \
     fi
 
 # Change ownership to app user

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ temporal knowledge-graph API your agents can write memories to and search over t
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Ho1yShif/graphiti)
 
+https://github.com/user-attachments/assets/da4041b7-f59e-4fb3-929b-fae2d6b949b0
+
 ## What you get
 
 Graphiti turns a stream of conversations or events into a knowledge graph, and keeps track of

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ from `graphiti-api` over Render's private network.
    | ----------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
    | `MODEL_NAME`      | `gpt-5.5` | Any OpenAI model id.                                                                                                                                                                                              |
    | `SEMAPHORE_LIMIT` | `10`      | Concurrent LLM calls during ingestion. Deliberately below graphiti-core's default of 20, so a burst of episodes doesn't trip the rate limits on a fresh OpenAI key. Raise it once you know your account's limits. |
+   | `PORT`            | `8000`    | The port uvicorn binds to and the one Render routes to. Declared up front so the first deploy doesn't restart to rewire the network after detecting the port itself. Safe to change.                              |
 
    The rest is wiring you shouldn't need to touch. `DB_BACKEND` selects the FalkorDB code
    path; `FALKORDB_HOST` is filled in from the private service's hostname, with

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ from `graphiti-api` over Render's private network.
 
 Ingestion is asynchronous — `/messages` queues the episode and returns immediately, then
 Graphiti extracts entities and facts in the background. Give it 10–30 seconds before searching.
+`"success": true` means the episode was queued, not that it was ingested: extraction happens
+after the response, so a failure there shows up in the `graphiti-api` logs rather than in the
+reply. Step 3 is how you confirm it actually landed.
 
 Set your URL and key once:
 
@@ -167,6 +170,12 @@ export GRAPHITI_API_KEY=...   # graphiti-api → Environment in the Render Dashb
      -H 'Content-Type: application/json' \
      -d '{"group_ids": ["demo"], "query": "who leads the payments team?", "max_facts": 10}'
    ```
+
+   > `/search` embeds your query before it can search, so it's the first endpoint to fail when
+   > `OPENAI_API_KEY` is unusable — steps 1–3 touch OpenAI either not at all or only in the
+   > background, and keep answering normally. A `429` naming an exhausted quota is billing on
+   > the OpenAI account, not a bad key: a new key on the same account returns the same thing.
+   > A `502` means the key itself was rejected.
 
    Among the results you'll find both sides of the handover, each stamped with when it
    became true:

--- a/README.md
+++ b/README.md
@@ -60,8 +60,15 @@ from `graphiti-api` over Render's private network.
    | Variable          | Default   | Notes                                                                             |
    | ----------------- | --------- | --------------------------------------------------------------------------------- |
    | `MODEL_NAME`      | `gpt-5.5` | Any OpenAI model id.                                                              |
-   | `GRAPHITI_VERSION` | `0.29.3` | The `graphiti-core` release from PyPI the image is built against — not this repo's own version number. Pinned so every fork deploys the same library. Test a write-then-search round trip before bumping it. |
    | `SEMAPHORE_LIMIT` | `10`      | Concurrent LLM calls during ingestion. Deliberately below graphiti-core's default of 20, so a burst of episodes doesn't trip the rate limits on a fresh OpenAI key. Raise it once you know your account's limits. |
+
+   The `graphiti-core` version is pinned in one place: the `GRAPHITI_VERSION` build arg
+   default in [`Dockerfile`](Dockerfile). Every fork therefore deploys the same library,
+   and local `docker compose` builds match Render without a second pin to keep in step.
+   Bump it there, and verify a write-then-search round trip before you do — `0.29.2`, for
+   one, writes episodes on FalkorDB but reads them back empty. To override it for a single
+   Render service without editing the Dockerfile, add `GRAPHITI_VERSION` as an env var on
+   that service; Render passes env vars to the Docker build as build args.
 
 3. Wait for both services to go live. `graphiti-api` passes its health check at `/healthcheck`.
 

--- a/README.md
+++ b/README.md
@@ -80,23 +80,56 @@ from `graphiti-api` over Render's private network.
 
 3. Wait for both services to go live. `graphiti-api` passes its health check at `/healthcheck`.
 
-> **This API has no authentication.** Anyone who knows your URL can write to your graph and
-> spend your OpenAI key. Before you point real traffic at it, put it behind your own auth,
-> an API gateway, or a private network. In the meantime, use a dedicated OpenAI key you can
-> revoke and set a monthly spend cap in the OpenAI console — that cap is your backstop.
+4. **Copy your API key.** Every endpoint except `/healthcheck` requires it, and there's
+   nothing to paste in: Render generated the key when it created the service. Open
+   `graphiti-api` → **Environment** in the Dashboard and copy `GRAPHITI_API_KEY`. Send it as
+   a bearer token:
+
+   ```
+   Authorization: Bearer <GRAPHITI_API_KEY>
+   ```
+
+   Auth is mandatory — the service won't start without a key, so a fork can't go live open by
+   accident. The generated value persists across deploys, so rotating it is up to you: edit it
+   in the Dashboard and Render restarts the service with the new value. The replacement has to
+   be at least 16 printable-ASCII characters, as the generated one is. Length because `dev` is
+   not a key — the service limits failed attempts, but that can't help against one that's
+   guessed on the first try; printable ASCII because HTTP sends header values as latin-1 and
+   clients disagree about how to encode anything outside it, so a key with an accent or an emoji
+   in it would authenticate for some clients and not others. The service refuses to start on
+   either rather than leaving you to discover it as a 401, so a bad rotation fails the deploy and
+   Render keeps serving the previous version.
+
+   A wrong or missing key gets `401` with `WWW-Authenticate: Bearer`. After 10 rejections in a
+   minute the service answers `429` with `Retry-After` instead, so the key can't be worked
+   through and your URL isn't a free target for scanners. Requests carrying the *right* key are
+   never rate limited, so a stranger hammering your service can't lock you out of it.
+
+   The API docs at `/docs` stay open, and you can authorize them in the browser: click
+   **Authorize**, paste the key, and **Try it out** works against your deployment.
+
+> **This key is the only thing in front of your graph.** It's a single shared secret with no
+> scopes and no per-user identity — enough to keep a stranger who finds your URL from writing to
+> your graph and spending your OpenAI key, and not a substitute for real authorization. The
+> rejection limit stops guessing; it does nothing about a caller who *has* the key, and there's
+> no cap on what one of those can spend. Before you point production traffic at it, put it behind
+> your own auth or an API gateway. Either way, use a dedicated OpenAI key you can revoke and set
+> a monthly spend cap in the OpenAI console — that cap is your backstop.
 
 ### Using the app
 
 Ingestion is asynchronous — `/messages` queues the episode and returns immediately, then
 Graphiti extracts entities and facts in the background. Give it 10–30 seconds before searching.
 
-Set your URL once:
+Set your URL and key once:
 
 ```bash
 export GRAPHITI_URL=https://graphiti-api.onrender.com
+export GRAPHITI_API_KEY=...   # graphiti-api → Environment in the Render Dashboard
 ```
 
-1. **Check it's up.**
+1. **Check it's up.** The only endpoint that takes no key — Render polls it to decide the
+   service is live.
 
    ```bash
    curl $GRAPHITI_URL/healthcheck
@@ -112,6 +145,7 @@ export GRAPHITI_URL=https://graphiti-api.onrender.com
 
    ```bash
    curl -X POST $GRAPHITI_URL/messages \
+     -H "Authorization: Bearer $GRAPHITI_API_KEY" \
      -H 'Content-Type: application/json' \
      -d @examples/render/sample-episode.json
    # {"message":"Messages added to processing queue","success":true}
@@ -120,13 +154,15 @@ export GRAPHITI_URL=https://graphiti-api.onrender.com
 3. **Watch the episodes land.**
 
    ```bash
-   curl "$GRAPHITI_URL/episodes/demo?last_n=5"
+   curl "$GRAPHITI_URL/episodes/demo?last_n=5" \
+     -H "Authorization: Bearer $GRAPHITI_API_KEY"
    ```
 
 4. **Search the facts Graphiti extracted.**
 
    ```bash
    curl -X POST $GRAPHITI_URL/search \
+     -H "Authorization: Bearer $GRAPHITI_API_KEY" \
      -H 'Content-Type: application/json' \
      -d '{"group_ids": ["demo"], "query": "who leads the payments team?", "max_facts": 10}'
    ```
@@ -169,9 +205,9 @@ export GRAPHITI_URL=https://graphiti-api.onrender.com
    > here. Don't rely on them to erase a tenant's data.
 
 If you'd rather not paste multi-line `curl` commands, [`examples/render/demo.sh`](examples/render/demo.sh)
-wraps the same endpoints in one-word shell functions. Set `GRAPHITI_URL`, `source` the file (it
-defines functions, so running it won't work), and you get `use_group take1` to pick a group,
-`health`, `ingest` to POST the sample episode with its `group_id` rewritten to match, then
+wraps the same endpoints in one-word shell functions. Set `GRAPHITI_URL` and `GRAPHITI_API_KEY`,
+`source` the file (it defines functions, so running it won't work), and you get `use_group take1`
+to pick a group, `health`, `ingest` to POST the sample episode with its `group_id` rewritten, then
 `watch_ingest` to follow the queue draining, `ask "who owns the ledger migration?"` for the
 current answer, and `timeline "leads the payments"` for every version of a fact oldest-first with
 its relationship label and validity window. It's a thin projection over `/search` — the raw
@@ -207,6 +243,17 @@ too — see the note above on why the private network is what isolates it.
 and run `docker compose --profile falkordb up`. That mirrors this Blueprint — the API on
 `http://localhost:8001`, FalkorDB beside it. A plain `docker compose up` runs the repo's other
 pairing, API plus Neo4j, on port 8000.
+
+Auth is mandatory locally too — there's no off switch — so compose defaults
+`GRAPHITI_API_KEY` to `insecure-local-dev-key`. Export that and every example above works unchanged
+against `http://localhost:8001`; set your own value in `.env` to override it. Running the same
+authenticated path locally as on Render is the point: nothing about auth is left untested until
+you deploy.
+
+That default key is committed to this repo, so it protects nothing — which is why every port in
+`docker-compose.yml` is published to `127.0.0.1` rather than to every interface. The stack is
+reachable from your machine and nowhere else. If you need to reach it from another host, drop the
+`127.0.0.1:` prefix and set a real `GRAPHITI_API_KEY` in the same edit.
 
 ## Learn more
 

--- a/README.md
+++ b/README.md
@@ -1,722 +1,184 @@
-<p align="center">
-  <a href="https://www.getzep.com/">
-    <img src="https://github.com/user-attachments/assets/119c5682-9654-4257-8922-56b7cb8ffd73" width="150" alt="Zep Logo">
-  </a>
-</p>
+# Graphiti on Render
 
-<h1 align="center">
-Graphiti
-</h1>
-<h2 align="center">Build Temporal Context Graphs for AI Agents</h2>
+Deploy [Graphiti](https://github.com/getzep/graphiti) on Render in one click. Get a hosted
+temporal knowledge-graph API your agents can write memories to and search over time.
 
-<div align="center">
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Ho1yShif/graphiti)
 
-[![Lint](https://github.com/getzep/Graphiti/actions/workflows/lint.yml/badge.svg?style=flat)](https://github.com/getzep/Graphiti/actions/workflows/lint.yml)
-[![Unit Tests](https://github.com/getzep/Graphiti/actions/workflows/unit_tests.yml/badge.svg)](https://github.com/getzep/Graphiti/actions/workflows/unit_tests.yml)
-[![MyPy Check](https://github.com/getzep/Graphiti/actions/workflows/typecheck.yml/badge.svg)](https://github.com/getzep/Graphiti/actions/workflows/typecheck.yml)
+## What you get
 
-[![GitHub Repo stars](https://img.shields.io/github/stars/getzep/graphiti)](https://github.com/getzep/graphiti/stargazers)
-[![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?&logo=discord&logoColor=white)](https://discord.com/invite/W8Kw6bsgXQ)
-[![arXiv](https://img.shields.io/badge/arXiv-2501.13956-b31b1b.svg?style=flat)](https://arxiv.org/abs/2501.13956)
-[![Release](https://img.shields.io/github/v/release/getzep/graphiti?style=flat&label=Release&color=limegreen)](https://github.com/getzep/graphiti/releases)
+Graphiti turns a stream of conversations or events into a knowledge graph, and keeps track of
+_when_ each fact was true. When something changes — someone switches teams, a deadline moves —
+it doesn't overwrite the old fact, it invalidates it and records the new one. So an agent can
+ask what's true now, and also what was true last quarter.
 
-</div>
-<div align="center">
+This template deploys the backend for that: a REST API and the graph store behind it. **There
+is no web UI.** The deliverable is a live URL like `https://graphiti-api.onrender.com` that you
+call from your own agent code, a script, or a framework like LangGraph.
 
-<a href="https://trendshift.io/repositories/12986" target="_blank"><img src="https://trendshift.io/api/badge/repositories/12986" alt="getzep%2Fgraphiti | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+### Architecture
 
-</div>
+```
+                       ┌───────────────────────────┐
+   your agent /        │   graphiti-api (docker)   │        ┌──────────────┐
+   script / app  ─────▶│   FastAPI · public HTTPS  │───────▶│  OpenAI API  │
+      HTTPS            │   /messages  /search      │  facts └──────────────┘
+                       └─────────────┬─────────────┘  entities
+                                     │
+                         Redis proto │ private network only
+                                     ▼
+                       ┌───────────────────────────┐
+                       │ graphiti-falkordb (image) │
+                       │ private service · :6379   │
+                       │ 10 GB disk, append-only   │
+                       └───────────────────────────┘
+```
 
-> [!NOTE]
-> **We're Hiring!** Build context graphs that power reliable, personalized, fast production AI agents.
-> Come build with us — we're hiring Engineers and Developer Relations folks. [View open roles](https://www.getzep.com/careers/).
+`graphiti-falkordb` is a **private service**: it has no public address and accepts traffic only
+from `graphiti-api` over Render's private network.
 
-⭐ *Help us reach more developers and grow the Graphiti community. Star this repo!*
+## Deploy
 
-&nbsp;
+1. Click **Deploy to Render** above. Render reads [`render.yaml`](render.yaml) and creates a
+   `graphiti` project containing both services.
+2. Render prompts for one secret on `graphiti-api`:
 
-> [!TIP]
-> Check out the new [MCP server for Graphiti](mcp_server/README.md)! Give Claude, Cursor, and other MCP clients powerful
-> context graph-based memory with temporal awareness.
+   | Variable         | What it's for                                                                                       | Where to get it                                                      |
+   | ---------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+   | `OPENAI_API_KEY` | Graphiti calls an LLM to pull entities and facts out of each episode, and to embed them for search. | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
 
-Graphiti is a framework for building and querying temporal context graphs for AI agents. Unlike static knowledge graphs,
-Graphiti's context graphs track how facts change over time, maintain provenance to source data, and support both
-prescribed and learned ontology — making them purpose-built for agents operating on evolving, real-world data.
+   If you use a **restricted** OpenAI key, this deployment needs exactly two of the
+   permissions under **Model capabilities**, both write:
 
-Unlike traditional retrieval-augmented generation (RAG) methods, Graphiti continuously integrates user interactions,
-structured and unstructured enterprise data, and external information into a coherent, queryable graph. The framework
-supports incremental data updates, efficient retrieval, and precise historical queries without requiring complete graph
-recomputation, making it suitable for developing interactive, context-aware AI applications.
+   | Permission     | Used for                                                                           |
+   | -------------- | ---------------------------------------------------------------------------------- |
+   | **Responses**  | Write access on `/v1/responses` — extracting entities and facts from each episode. |
+   | **Embeddings** | Write access on `/v1/embeddings` — embedding nodes, edges, and search queries.     |
 
-Use Graphiti to:
+   Everything else is set for you in `render.yaml`. The ones worth knowing about:
 
-- Build context graphs that evolve with every interaction — tracking what's true now and what was true before.
-- Give agents rich, structured context instead of flat document chunks or raw chat history.
-- Query across time, meaning, and relationships with hybrid retrieval (semantic + keyword + graph traversal).
+   | Variable          | Default   | Notes                                                                             |
+   | ----------------- | --------- | --------------------------------------------------------------------------------- |
+   | `MODEL_NAME`      | `gpt-5.5` | Any OpenAI model id.                                                              |
+   | `GRAPHITI_VERSION` | `0.29.3` | The `graphiti-core` release from PyPI the image is built against — not this repo's own version number. Pinned so every fork deploys the same library. Test a write-then-search round trip before bumping it. |
+   | `SEMAPHORE_LIMIT` | `10`      | Concurrent LLM calls during ingestion. Deliberately below graphiti-core's default of 20, so a burst of episodes doesn't trip the rate limits on a fresh OpenAI key. Raise it once you know your account's limits. |
 
-&nbsp;
+3. Wait for both services to go live. `graphiti-api` passes its health check at `/healthcheck`.
 
-<p align="center">
-    <img src="images/graphiti-graph-intro.gif" alt="Graphiti temporal walkthrough" width="700px">
-</p>
+> **This API has no authentication.** Anyone who knows your URL can write to your graph and
+> spend your OpenAI key. Before you point real traffic at it, put it behind your own auth,
+> an API gateway, or a private network. In the meantime, use a dedicated OpenAI key you can
+> revoke and set a monthly spend cap in the OpenAI console — that cap is your backstop.
 
-&nbsp;
+### Using the app
 
-## What is a Context Graph?
+Ingestion is asynchronous — `/messages` queues the episode and returns immediately, then
+Graphiti extracts entities and facts in the background. Give it 10–30 seconds before searching.
 
-A **context graph** is a temporal graph of entities, relationships, and facts — like *"Kendra loves Adidas shoes (as of
-March 2026)."* Unlike traditional knowledge graphs, each fact in a context graph has a validity window: when it became
-true, and when (if ever) it was superseded. Entities evolve over time with updated summaries. Everything traces back to
-**episodes** — the raw data that produced it.
-
-What makes Graphiti unique is its ability to autonomously build context graphs from unstructured and structured data,
-handling changing relationships while preserving full temporal history.
-
-A context graph contains:
-
-| Component | What it stores |
-|-----------|---------------|
-| **Entities** (nodes) | People, products, policies, concepts — with summaries that evolve over time |
-| **Facts / Relationships** (edges) | Triplets (Entity → Relationship → Entity) with temporal validity windows |
-| **Episodes** (provenance) | Raw data as ingested — the ground truth stream. Every derived fact traces back here |
-| **Custom Types** (ontology) | Developer-defined entity and edge types via Pydantic models |
-
-## Graphiti and Zep
-
-Graphiti is the open-source temporal context graph engine at the core of
-[Zep's](https://www.getzep.com) context infrastructure for AI agents. Zep manages context graphs at scale, providing
-governed, low-latency context retrieval and assembly for production agent deployments.
-
-Under the hood, Zep is powered by a proprietary graph database — the
-[Context Graph Engine](https://www.getzep.com/platform/context-graph-engine/) — built for millions of context graphs
-with low-latency retrieval, so production deployments don't require a separate third-party graph database.
-
-Using Graphiti, we've demonstrated Zep is
-the [State of the Art in Agent Memory](https://blog.getzep.com/state-of-the-art-agent-memory/).
-
-Read our paper: [Zep: A Temporal Knowledge Graph Architecture for Agent Memory](https://arxiv.org/abs/2501.13956).
-
-We're excited to open-source Graphiti, believing its potential as a context graph engine reaches far beyond memory
-applications.
-
-<p align="center">
-    <a href="https://arxiv.org/abs/2501.13956"><img src="images/arxiv-screenshot.png" alt="Zep: A Temporal Knowledge Graph Architecture for Agent Memory" width="700px"></a>
-</p>
-
-## Zep vs Graphiti
-
-| Aspect | Zep | Graphiti |
-|--------|-----|---------|
-| **What they are** | Managed context graph infrastructure for AI agents | Open-source temporal context graph engine |
-| **Context graphs** | Manages vast numbers of per-user/entity context graphs with governance | Build and query individual context graphs |
-| **Graph database** | Proprietary [Context Graph Engine](https://www.getzep.com/platform/context-graph-engine/) — built for millions of context graphs with low-latency retrieval; no third-party graph database vendor required | Bring your own third-party graph database |
-| **User & conversation management** | Built-in users, threads, and message storage | Build your own |
-| **Retrieval & performance** | Pre-configured, production-ready retrieval with sub-200ms performance at scale | Custom implementation required; performance depends on your setup |
-| **Developer tools** | Dashboard with graph visualization, debug logs, API logs; SDKs for Python, TypeScript, and Go | Build your own tools |
-| **Enterprise features** | SLAs, support, security guarantees | Self-managed |
-| **Deployment** | Fully managed or in your cloud | Self-hosted only |
-
-### When to choose which
-
-**Choose Zep** if you want a turnkey, enterprise-grade platform with security, performance, and support baked in.
-
-**Choose Graphiti** if you want a flexible OSS core and you're comfortable building/operating the surrounding system.
-
-## Why Graphiti?
-
-Traditional RAG approaches often rely on batch processing and static data summarization, making them inefficient for
-frequently changing data. Graphiti addresses these challenges by providing:
-
-- **Temporal Fact Management:** Facts have validity windows. When information changes, old facts are
-  invalidated — not deleted. Query what's true now, or what was true at any point in time.
-- **Episodes & Provenance:** Every entity and relationship traces back to the episodes (raw data) that produced it.
-  Full lineage from derived fact to source.
-- **Prescribed & Learned Ontology:** Define entity and edge types upfront via Pydantic models (prescribed), or let
-  structure emerge from your data (learned). Start simple, evolve as patterns appear.
-- **Incremental Graph Construction:** New data integrates immediately without batch recomputation. The graph evolves
-  in real-time as episodes are ingested.
-- **Hybrid Retrieval:** Combines semantic embeddings, keyword (BM25), and graph traversal for low-latency,
-  high-precision queries without reliance on LLM summarization.
-- **Scalability:** Efficiently manages large datasets with parallel processing, pluggable graph backends, suitable
-  for enterprise workloads.
-
-<p align="center">
-    <img src="/images/graphiti-intro-slides-stock-2.gif" alt="Graphiti structured + unstructured demo" width="700px">
-</p>
-
-## Graphiti vs. GraphRAG
-
-| Aspect | GraphRAG | Graphiti |
-|--------|----------|---------|
-| **Primary Use** | Static document summarization | Dynamic, evolving context for agents |
-| **Data Handling** | Batch-oriented processing | Continuous, incremental updates |
-| **Knowledge Structure** | Entity clusters & community summaries | Temporal context graph — entities, facts with validity windows, episodes, communities |
-| **Retrieval Method** | Sequential LLM summarization | Hybrid semantic, keyword, and graph-based search |
-| **Adaptability** | Low | High |
-| **Temporal Handling** | Basic timestamp tracking | Explicit bi-temporal tracking with automatic fact invalidation |
-| **Contradiction Handling** | LLM-driven summarization judgments | Automatic fact invalidation with temporal history preserved |
-| **Query Latency** | Seconds to tens of seconds | Typically sub-second latency |
-| **Custom Entity Types** | No | Yes, customizable via Pydantic models |
-| **Scalability** | Moderate | High, optimized for large datasets |
-
-Graphiti is specifically designed to address the challenges of dynamic and frequently updated datasets, making it
-particularly suitable for applications requiring real-time interaction and precise historical queries.
-
-## Installation
-
-Requirements:
-
-- Python 3.10 or higher
-- Neo4j 5.26 / FalkorDB 1.1.2 / Amazon Neptune Database Cluster or Neptune Analytics Graph + Amazon OpenSearch
-  Serverless collection (serves as the full text search backend) / Kuzu 0.11.2 (**deprecated**, see below)
-- OpenAI API key (Graphiti defaults to OpenAI for LLM inference and embedding)
-
-> [!IMPORTANT]
-> Graphiti works best with LLM services that support Structured Output (such as OpenAI, Anthropic, and Gemini).
-> Using other services may result in incorrect output schemas and ingestion failures. This is particularly
-> problematic when using smaller models.
-
-Optional:
-
-- Google Gemini, Anthropic, or Groq API key (for alternative LLM providers)
-
-> [!TIP]
-> The simplest way to install Neo4j is via [Neo4j Desktop](https://neo4j.com/download/). It provides a user-friendly
-> interface to manage Neo4j instances and databases.
-> Alternatively, you can use FalkorDB on-premises via Docker and instantly start with the quickstart example:
-> ```
-> docker run -p 6379:6379 -p 3000:3000 -it --rm falkordb/falkordb:latest
-> ```
+Set your URL once:
 
 ```bash
-pip install graphiti-core
+export GRAPHITI_URL=https://graphiti-api.onrender.com
 ```
 
-or
-
-```bash
-uv add graphiti-core
-```
-
-### Installing with FalkorDB Support
-
-If you plan to use FalkorDB as your graph database backend, install with the FalkorDB extra:
-
-```bash
-pip install graphiti-core[falkordb]
-
-# or with uv
-uv add graphiti-core[falkordb]
-
-# or embedded version (requires Python 3.12+)
-pip install graphiti-core[falkordblite]
-# or with uv
-uv add graphiti-core[falkordblite]
-```
-
-### Installing with Kuzu Support
-
-> [!WARNING]
-> **Kuzu is deprecated** and will be removed in a future release — the upstream Kuzu project is no longer
-> maintained. New projects should use Neo4j or FalkorDB. The driver still ships for now but emits a
-> `DeprecationWarning`.
-
-If you plan to use Kuzu as your graph database backend, install with the Kuzu extra:
-
-```bash
-pip install graphiti-core[kuzu]
-
-# or with uv
-uv add graphiti-core[kuzu]
-```
-
-### Installing with Amazon Neptune Support
-
-If you plan to use Amazon Neptune as your graph database backend, install with the Amazon Neptune extra:
-
-```bash
-pip install graphiti-core[neptune]
-
-# or with uv
-uv add graphiti-core[neptune]
-```
-
-### You can also install optional LLM providers as extras:
-
-```bash
-# Install with Anthropic support
-pip install graphiti-core[anthropic]
-
-# Install with Groq support
-pip install graphiti-core[groq]
-
-# Install with Google Gemini support
-pip install graphiti-core[google-genai]
-
-# Install with multiple providers
-pip install graphiti-core[anthropic,groq,google-genai]
-
-# Install with FalkorDB and LLM providers
-pip install graphiti-core[falkordb,anthropic,google-genai]
-
-# Install with Amazon Neptune
-pip install graphiti-core[neptune]
-```
-
-## Default to Low Concurrency; LLM Provider 429 Rate Limit Errors
-
-Graphiti's ingestion pipelines are designed for high concurrency. By default, concurrency is set low to avoid LLM
-Provider 429 Rate Limit Errors. If you find Graphiti slow, please increase concurrency as described below.
-
-Concurrency controlled by the `SEMAPHORE_LIMIT` environment variable. By default, `SEMAPHORE_LIMIT` is set to `10`
-concurrent operations to help prevent `429` rate limit errors from your LLM provider. If you encounter such errors, try
-lowering this value.
-
-If your LLM provider allows higher throughput, you can increase `SEMAPHORE_LIMIT` to boost episode ingestion
-performance.
-
-## Quick Start
-
-> [!IMPORTANT]
-> Graphiti defaults to using OpenAI for LLM inference and embedding. Ensure that an `OPENAI_API_KEY` is set in your
-> environment.
-> Support for Anthropic, Gemini, and Groq is available, too. Other LLM providers — both hosted OpenAI-compatible APIs
-> (DeepSeek, Together, OpenRouter, …) and local servers (Ollama, vLLM, llama.cpp, LM Studio) — may be used via their
-> OpenAI-compatible endpoints; see
-> [Using Graphiti with OpenAI-compatible providers and local LLMs](#using-graphiti-with-openai-compatible-providers-and-local-llms).
-
-For a complete working example, see the [Quickstart Example](examples/quickstart/README.md) in the examples directory.
-The quickstart demonstrates:
-
-1. Connecting to a Neo4j, Amazon Neptune, FalkorDB, or Kuzu database
-2. Initializing Graphiti indices and constraints
-3. Adding episodes to the graph (both text and structured JSON)
-4. Searching for relationships (edges) using hybrid search
-5. Reranking search results using graph distance
-6. Searching for nodes using predefined search recipes
-
-The example is fully documented with clear explanations of each functionality and includes a comprehensive README with
-setup instructions and next steps.
-
-### Running with Docker Compose
-
-You can use Docker Compose to quickly start the required services:
-
-- **Neo4j Docker:**
-
-  ```bash
-  docker compose up
-  ```
-
-  This will start the Neo4j Docker service and related components.
-
-- **FalkorDB Docker:**
-
-  ```bash
-  docker compose --profile falkordb up
-  ```
-
-  This will start the FalkorDB Docker service and related components.
-
-## MCP Server
-
-The `mcp_server` directory contains a Model Context Protocol (MCP) server implementation for Graphiti. This server
-allows AI assistants to interact with Graphiti's context graph capabilities through the MCP protocol.
-
-Key features of the MCP server include:
-
-- Episode management (add, retrieve, delete)
-- Entity management and relationship handling
-- Semantic and hybrid search capabilities
-- Group management for organizing related data
-- Graph maintenance operations
-
-The MCP server can be deployed using Docker with Neo4j, making it easy to integrate Graphiti into your AI assistant
-workflows.
-
-For detailed setup instructions and usage examples, see the [MCP server README](mcp_server/README.md).
-
-## REST Service
-
-The `server` directory contains an API service for interacting with the Graphiti API. It is built using FastAPI.
-
-Please see the [server README](server/README.md) for more information.
-
-## Optional Environment Variables
-
-In addition to the Neo4j and OpenAi-compatible credentials, Graphiti also has a few optional environment variables.
-If you are using one of our supported models, such as Anthropic or Voyage models, the necessary environment variables
-must be set.
-
-### Database Configuration
-
-Database names are configured directly in the driver constructors:
-
-- **Neo4j**: Database name defaults to `neo4j` (hardcoded in Neo4jDriver)
-- **FalkorDB**: Database name defaults to `default_db` (hardcoded in FalkorDriver)
-
-As of v0.17.0, if you need to customize your database configuration, you can instantiate a database driver and pass it
-to the Graphiti constructor using the `graph_driver` parameter.
-
-#### Neo4j with Custom Database Name
-
-```python
-from graphiti_core import Graphiti
-from graphiti_core.driver.neo4j_driver import Neo4jDriver
-
-# Create a Neo4j driver with custom database name
-driver = Neo4jDriver(
-    uri="bolt://localhost:7687",
-    user="neo4j",
-    password="password",
-    database="my_custom_database"  # Custom database name
-)
-
-# Pass the driver to Graphiti
-graphiti = Graphiti(graph_driver=driver)
-```
-
-#### FalkorDB with Custom Database Name
-
-```python
-from graphiti_core import Graphiti
-from graphiti_core.driver.falkordb_driver import FalkorDriver
-
-# Create a FalkorDB driver with custom database name
-driver = FalkorDriver(
-    host="localhost",
-    port=6379,
-    username="falkor_user",  # Optional
-    password="falkor_password",  # Optional
-    database="my_custom_graph"  # Custom database name
-)
-
-# Or use embedded FalkorDB Lite (requires Python 3.12+)
-# from redislite.async_falkordb_client import AsyncFalkorDB
-# falkordb_client = AsyncFalkorDB(dbfilename='/path/to/database.db')
-# driver = FalkorDriver(falkor_db=falkordb_client)
-
-# Pass the driver to Graphiti
-graphiti = Graphiti(graph_driver=driver)
-```
-
-#### Kuzu
-
-> [!WARNING]
-> Kuzu is **deprecated** (upstream project unmaintained) and will be removed in a future release. Prefer Neo4j or
-> FalkorDB.
-
-```python
-from graphiti_core import Graphiti
-from graphiti_core.driver.kuzu_driver import KuzuDriver
-
-# Create a Kuzu driver
-driver = KuzuDriver(db="/tmp/graphiti.kuzu")
-
-# Pass the driver to Graphiti
-graphiti = Graphiti(graph_driver=driver)
-```
-
-#### Amazon Neptune
-
-```python
-from graphiti_core import Graphiti
-from graphiti_core.driver.neptune_driver import NeptuneDriver
-
-# Create a Neptune driver
-driver = NeptuneDriver(
-    host='<NEPTUNE_ENDPOINT>',
-    aoss_host='<AMAZON_OPENSEARCH_SERVERLESS_HOST>',
-    port=8182,      # Optional, defaults to 8182
-    aoss_port=443,  # Optional, defaults to 443
-)
-
-# Pass the driver to Graphiti
-graphiti = Graphiti(graph_driver=driver)
-```
-
-Contributing a new graph backend? See [Adding a graph driver](CONTRIBUTING.md#adding-a-graph-driver).
-
-## Using Graphiti with Azure OpenAI
-
-Graphiti supports Azure OpenAI for both LLM inference and embeddings using Azure's OpenAI v1 API compatibility layer.
-
-### Quick Start
-
-```python
-from openai import AsyncOpenAI
-from graphiti_core import Graphiti
-from graphiti_core.llm_client.azure_openai_client import AzureOpenAILLMClient
-from graphiti_core.llm_client.config import LLMConfig
-from graphiti_core.embedder.azure_openai import AzureOpenAIEmbedderClient
-
-# Initialize Azure OpenAI client using the standard OpenAI client
-# with Azure's v1 API endpoint
-azure_client = AsyncOpenAI(
-    base_url="https://your-resource-name.openai.azure.com/openai/v1/",
-    api_key="your-api-key",
-)
-
-# Create LLM and Embedder clients
-llm_client = AzureOpenAILLMClient(
-    azure_client=azure_client,
-    config=LLMConfig(model="gpt-5-mini", small_model="gpt-5-mini")  # Your Azure deployment name
-)
-embedder_client = AzureOpenAIEmbedderClient(
-    azure_client=azure_client,
-    model="text-embedding-3-small"  # Your Azure embedding deployment name
-)
-
-# Initialize Graphiti with Azure OpenAI clients
-graphiti = Graphiti(
-    "bolt://localhost:7687",
-    "neo4j",
-    "password",
-    llm_client=llm_client,
-    embedder=embedder_client,
-)
-
-# Now you can use Graphiti with Azure OpenAI
-```
-
-**Key Points:**
-
-- Use the standard `AsyncOpenAI` client with Azure's v1 API endpoint format:
-  `https://your-resource-name.openai.azure.com/openai/v1/`
-- The deployment names (e.g., `gpt-5-mini`, `text-embedding-3-small`) should match your Azure OpenAI deployment names
-- See `examples/azure-openai/` for a complete working example
-
-Make sure to replace the placeholder values with your actual Azure OpenAI credentials and deployment names.
-
-## Using Graphiti with Google Gemini
-
-Graphiti supports Google's Gemini models for LLM inference, embeddings, and cross-encoding/reranking. To use Gemini,
-you'll need to configure the LLM client, embedder, and the cross-encoder with your Google API key.
-
-Install Graphiti:
-
-```bash
-uv add "graphiti-core[google-genai]"
-
-# or
-
-pip install "graphiti-core[google-genai]"
-```
-
-```python
-from graphiti_core import Graphiti
-from graphiti_core.llm_client.gemini_client import GeminiClient, LLMConfig
-from graphiti_core.embedder.gemini import GeminiEmbedder, GeminiEmbedderConfig
-from graphiti_core.cross_encoder.gemini_reranker_client import GeminiRerankerClient
-
-# Google API key configuration
-api_key = "<your-google-api-key>"
-
-# Initialize Graphiti with Gemini clients
-graphiti = Graphiti(
-    "bolt://localhost:7687",
-    "neo4j",
-    "password",
-    llm_client=GeminiClient(
-        config=LLMConfig(
-            api_key=api_key,
-            model="gemini-2.0-flash"
-        )
-    ),
-    embedder=GeminiEmbedder(
-        config=GeminiEmbedderConfig(
-            api_key=api_key,
-            embedding_model="embedding-001"
-        )
-    ),
-    cross_encoder=GeminiRerankerClient(
-        config=LLMConfig(
-            api_key=api_key,
-            model="gemini-2.5-flash-lite"
-        )
-    )
-)
-
-# Now you can use Graphiti with Google Gemini for all components
-```
-
-The Gemini reranker uses the `gemini-2.5-flash-lite` model by default, which is optimized for
-cost-effective and low-latency classification tasks. It uses the same boolean classification approach as the OpenAI
-reranker, leveraging Gemini's log probabilities feature to rank passage relevance.
-
-## Using Graphiti with OpenAI-compatible providers and local LLMs
-
-Graphiti can use any OpenAI-compatible `/v1` endpoint for LLM inference via `OpenAIGenericClient` — both **hosted
-providers** (DeepSeek, Together, OpenRouter, Fireworks, etc.) and **local servers** (Ollama, vLLM, llama.cpp, LM
-Studio). Local servers are ideal for privacy-focused applications or avoiding API costs. The example below uses Ollama;
-for any other provider, point `base_url` at its endpoint and set the appropriate `api_key` and `model`.
-
-**Note:** Use `OpenAIGenericClient` (not `OpenAIClient`) for these endpoints. It is optimized for local models with a
-higher default max token limit (16K vs 8K) and handles structured outputs across compatible providers.
-
-Install the models:
-
-```bash
-ollama pull deepseek-r1:7b # LLM
-ollama pull nomic-embed-text # embeddings
-```
-
-```python
-from graphiti_core import Graphiti
-from graphiti_core.llm_client.config import LLMConfig
-from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
-from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig
-from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient
-
-# Configure Ollama LLM client
-llm_config = LLMConfig(
-    api_key="ollama",  # Ollama doesn't require a real API key, but some placeholder is needed
-    model="deepseek-r1:7b",
-    small_model="deepseek-r1:7b",
-    base_url="http://localhost:11434/v1",  # Ollama's OpenAI-compatible endpoint
-)
-
-llm_client = OpenAIGenericClient(config=llm_config)
-
-# Initialize Graphiti with Ollama clients
-graphiti = Graphiti(
-    "bolt://localhost:7687",
-    "neo4j",
-    "password",
-    llm_client=llm_client,
-    embedder=OpenAIEmbedder(
-        config=OpenAIEmbedderConfig(
-            api_key="ollama",  # Placeholder API key
-            embedding_model="nomic-embed-text",
-            embedding_dim=768,
-            base_url="http://localhost:11434/v1",
-        )
-    ),
-    cross_encoder=OpenAIRerankerClient(client=llm_client, config=llm_config),
-)
-
-# Now you can use Graphiti with local Ollama models
-```
-
-Ensure Ollama is running (`ollama serve`) and that you have pulled the models you want to use.
-
-### Structured output and small models
-
-Graphiti depends on structured (JSON) output for entity/edge extraction and deduplication, and works best with models
-and providers that reliably honor it (OpenAI, Anthropic, Gemini). Reliability varies across OpenAI-compatible providers and
-especially on smaller or local models, so `OpenAIGenericClient` exposes a `structured_output_mode`:
-
-- `"json_schema"` (default): requests native structured output via `response_format`. Best on capable models and
-  providers that enforce the schema via constrained decoding.
-- `"json_object"`: requests plain-JSON mode and injects the schema into the prompt instead. Use this for
-  providers/models that don't reliably honor `json_schema` — including some local servers that accept the `json_schema`
-  request but don't actually constrain output to it, where `json_object` can be *more* reliable.
-
-When using smaller or local models:
-
-- Prefer the most capable model you can run. Very small models frequently emit JSON that doesn't match the requested
-  schema, which surfaces as extraction failures.
-- Responses wrapped in Markdown ` ```json ` code fences are stripped automatically.
-- Keep `SEMAPHORE_LIMIT` low (see [above](#default-to-low-concurrency-llm-provider-429-rate-limit-errors)) — local
-  servers and some providers have limited concurrency.
-
-## Documentation
-
-- [Guides and API documentation](https://help.getzep.com/graphiti).
-- [Quick Start](https://help.getzep.com/graphiti/graphiti/quick-start)
-- [Building an agent with LangChain's LangGraph and Graphiti](https://help.getzep.com/graphiti/integrations/lang-graph-agent)
-
-## Telemetry
-
-Graphiti collects anonymous usage statistics to help us understand how the framework is being used and improve it for
-everyone. We believe transparency is important, so here's exactly what we collect and why.
-
-### What We Collect
-
-When you initialize a Graphiti instance, we collect:
-
-- **Anonymous identifier**: A randomly generated UUID stored locally in `~/.cache/graphiti/telemetry_anon_id`
-- **System information**: Operating system, Python version, and system architecture
-- **Graphiti version**: The version you're using
-- **Configuration choices**:
-  - LLM provider type (OpenAI, Azure, Anthropic, etc.)
-  - Database backend (Neo4j, FalkorDB, Kuzu, Amazon Neptune Database or Neptune Analytics)
-  - Embedder provider (OpenAI, Azure, Voyage, etc.)
-
-### What We Don't Collect
-
-We are committed to protecting your privacy. We **never** collect:
-
-- Personal information or identifiers
-- API keys or credentials
-- Your actual data, queries, or graph content
-- IP addresses or hostnames
-- File paths or system-specific information
-- Any content from your episodes, nodes, or edges
-
-### Why We Collect This Data
-
-This information helps us:
-
-- Understand which configurations are most popular to prioritize support and testing
-- Identify which LLM and database providers to focus development efforts on
-- Track adoption patterns to guide our roadmap
-- Ensure compatibility across different Python versions and operating systems
-
-By sharing this anonymous information, you help us make Graphiti better for everyone in the community.
-
-### View the Telemetry Code
-
-The Telemetry code [may be found here](graphiti_core/telemetry/telemetry.py).
-
-### How to Disable Telemetry
-
-Telemetry is **opt-out** and can be disabled at any time. To disable telemetry collection:
-
-**Option 1: Environment Variable**
-
-```bash
-export GRAPHITI_TELEMETRY_ENABLED=false
-```
-
-**Option 2: Set in your shell profile**
-
-```bash
-# For bash users (~/.bashrc or ~/.bash_profile)
-echo 'export GRAPHITI_TELEMETRY_ENABLED=false' >> ~/.bashrc
-
-# For zsh users (~/.zshrc)
-echo 'export GRAPHITI_TELEMETRY_ENABLED=false' >> ~/.zshrc
-```
-
-**Option 3: Set for a specific Python session**
-
-```python
-import os
-
-os.environ['GRAPHITI_TELEMETRY_ENABLED'] = 'false'
-
-# Then initialize Graphiti as usual
-from graphiti_core import Graphiti
-
-graphiti = Graphiti(...)
-```
-
-Telemetry is automatically disabled during test runs (when `pytest` is detected).
-
-### Technical Details
-
-- Telemetry uses PostHog for anonymous analytics collection
-- All telemetry operations are designed to fail silently - they will never interrupt your application or affect Graphiti
-  functionality
-- The anonymous ID is stored locally and is not tied to any personal information
-
-## Contributing
-
-We encourage and appreciate all forms of contributions, whether it's code, documentation, addressing GitHub Issues, or
-answering questions in the Graphiti Discord channel. For detailed guidelines on code contributions, please refer
-to [CONTRIBUTING](CONTRIBUTING.md).
-
-## Support
-
-Join the [Zep Discord server](https://discord.com/invite/W8Kw6bsgXQ) and make your way to the **#Graphiti** channel!
+1. **Check it's up.**
+
+   ```bash
+   curl $GRAPHITI_URL/healthcheck
+   # {"status":"healthy"}
+   ```
+
+2. **Ingest the sample episode** that ships in this repo
+   ([`examples/render/sample-episode.json`](examples/render/sample-episode.json)). It's a short
+   conversation where Alex leads the payments team in May and hands it to Priya in July. The
+   messages carry explicit `timestamp` fields — that spread is what gives Graphiti something to
+   be temporal about. Omit them and every message is stamped with the time it arrived, so the
+   facts all land at once and nothing supersedes anything:
+
+   ```bash
+   curl -X POST $GRAPHITI_URL/messages \
+     -H 'Content-Type: application/json' \
+     -d @examples/render/sample-episode.json
+   # {"message":"Messages added to processing queue","success":true}
+   ```
+
+3. **Watch the episodes land.**
+
+   ```bash
+   curl "$GRAPHITI_URL/episodes/demo?last_n=5"
+   ```
+
+4. **Search the facts Graphiti extracted.**
+
+   ```bash
+   curl -X POST $GRAPHITI_URL/search \
+     -H 'Content-Type: application/json' \
+     -d '{"group_ids": ["demo"], "query": "who leads the payments team?", "max_facts": 10}'
+   ```
+
+   Among the results you'll find both sides of the handover, each stamped with when it
+   became true:
+
+   ```
+   Alex leads the payments team at Acme.
+       valid_at: 2026-05-04T14:00:00+00:00   invalid_at: None
+   Priya now leads the payments team at Acme.
+       valid_at: 2026-07-13T10:15:00+00:00   invalid_at: None
+   ```
+
+   That's the point of the graph. Alex's fact wasn't overwritten when Priya took over — both
+   are stored, each anchored to the message that asserted it, so you can ask who led the team
+   in June and get an answer. The `valid_at` values come straight from the message timestamps
+   and are reliable.
+
+   `invalid_at` is the other half: when Graphiti recognizes that a new fact contradicts an
+   older one, it closes the old one off at that moment, and you'd see
+   `invalid_at: 2026-07-13T10:15:00+00:00` on Alex's fact. Whether that fires is an LLM
+   judgment call made during ingestion, and on this three-message sample it happens on some
+   runs and not others. Treat it as opportunistic: real workloads give the model far more
+   signal than three messages do. The extracted wording, the capitalization, and the result
+   ordering vary between runs too.
+
+5. **Clean up** when you're done experimenting. On FalkorDB each `group_id` is a separate
+   graph, so deleting the group means deleting that graph. Open a shell on
+   `graphiti-falkordb` from the Render Dashboard and run:
+
+   ```bash
+   redis-cli GRAPH.DELETE demo
+   ```
+
+   > The HTTP endpoints `DELETE /group/{group_id}` and `POST /clear` do **not** work on this
+   > deployment. Both return `{"success": true}` and delete nothing: they query the default
+   > graph, while the data lives in a graph named after the `group_id`. This is a
+   > [graphiti-core](https://github.com/getzep/graphiti) driver issue, not a misconfiguration
+   > here. Don't rely on them to erase a tenant's data.
+
+Full endpoint list at `$GRAPHITI_URL/docs` (FastAPI's generated OpenAPI docs).
+
+`group_id` partitions the graph. Use one per user, per tenant, or per agent, and search stays
+scoped to it. On FalkorDB each one is a distinct graph held in memory, so the instance plan —
+not the disk — is what bounds how many you can keep.
+
+## Configuration notes
+
+**FalkorDB has no password.** It's a private service with no public address, so isolation comes
+from the network. To add one anyway, set `REDIS_ARGS` to `--appendonly yes --requirepass <your
+password>` on `graphiti-falkordb`, and set `FALKORDB_PASSWORD` to the same value on
+`graphiti-api`. Render can't interpolate one env var into another, so this is a manual step.
+
+**Using Neo4j instead.** Set `DB_BACKEND=neo4j` and supply `NEO4J_URI`, `NEO4J_USER`, and
+`NEO4J_PASSWORD` (e.g. from Neo4j Aura), then drop the `graphiti-falkordb` service from
+`render.yaml`.
+
+**Local development.** Copy [`.env.example`](.env.example) to `.env`, fill in `OPENAI_API_KEY`,
+and run `docker compose --profile falkordb up`. That mirrors this Blueprint — the API on
+`http://localhost:8001`, FalkorDB beside it. A plain `docker compose up` runs the repo's other
+pairing, API plus Neo4j, on port 8000.
+
+## Learn more
+
+This repo is a fork of [getzep/graphiti](https://github.com/getzep/graphiti) with a Render
+Blueprint added. For how Graphiti works — custom entity types, search strategies, the MCP
+server, the Python library — see the
+[upstream README](https://github.com/getzep/graphiti#readme) and
+[the paper](https://arxiv.org/abs/2501.13956).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Deploy [Graphiti](https://github.com/getzep/graphiti) on Render in one click. Get a hosted
 temporal knowledge-graph API your agents can write memories to and search over time.
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/graphiti)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/graphiti-render)
 
 https://github.com/user-attachments/assets/da4041b7-f59e-4fb3-929b-fae2d6b949b0
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ from `graphiti-api` over Render's private network.
    | `MODEL_NAME`      | `gpt-5.5` | Any OpenAI model id.                                                              |
    | `SEMAPHORE_LIMIT` | `10`      | Concurrent LLM calls during ingestion. Deliberately below graphiti-core's default of 20, so a burst of episodes doesn't trip the rate limits on a fresh OpenAI key. Raise it once you know your account's limits. |
 
+   The rest is wiring you shouldn't need to touch. `DB_BACKEND` selects the FalkorDB code
+   path; `FALKORDB_HOST` is filled in from the private service's hostname, with
+   `FALKORDB_PORT` and `FALKORDB_DATABASE` fixed to match it. `INSTALL_FALKORDB` is a build
+   arg that pulls in the `graphiti-core[falkordb]` extra, and `BROWSER=0` turns off the
+   FalkorDB Browser UI so `6379` is the only port the graph store listens on.
+
    The `graphiti-core` version is pinned in one place: the `GRAPHITI_VERSION` build arg
    default in [`Dockerfile`](Dockerfile). Every fork therefore deploys the same library,
    and local `docker compose` builds match Render without a second pin to keep in step.
@@ -172,6 +178,14 @@ not the disk — is what bounds how many you can keep.
 from the network. To add one anyway, set `REDIS_ARGS` to `--appendonly yes --requirepass <your
 password>` on `graphiti-falkordb`, and set `FALKORDB_PASSWORD` to the same value on
 `graphiti-api`. Render can't interpolate one env var into another, so this is a manual step.
+
+**`graphiti-falkordb` logs a security warning while it starts.** For the first few minutes
+you'll see `Possible SECURITY ATTACK detected ... Connection from 127.0.0.1 aborted` about
+once a minute. That's Render's port scanner sending an HTTP probe to `6379` to work out which
+port the service listens on; FalkorDB speaks the Redis protocol, so it reports the HTTP
+request as a cross-protocol attempt and drops it. It stops once the port is detected, and
+nothing reaches the graph. The startup line about Redis having no authentication is expected
+too — see the note above on why the private network is what isolates it.
 
 **Using Neo4j instead.** Set `DB_BACKEND=neo4j` and supply `NEO4J_URI`, `NEO4J_USER`, and
 `NEO4J_PASSWORD` (e.g. from Neo4j Aura), then drop the `graphiti-falkordb` service from

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Deploy [Graphiti](https://github.com/getzep/graphiti) on Render in one click. Get a hosted
 temporal knowledge-graph API your agents can write memories to and search over time.
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Ho1yShif/graphiti)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/graphiti)
 
 https://github.com/user-attachments/assets/da4041b7-f59e-4fb3-929b-fae2d6b949b0
 
@@ -59,9 +59,9 @@ from `graphiti-api` over Render's private network.
 
    Everything else is set for you in `render.yaml`. The ones worth knowing about:
 
-   | Variable          | Default   | Notes                                                                             |
-   | ----------------- | --------- | --------------------------------------------------------------------------------- |
-   | `MODEL_NAME`      | `gpt-5.5` | Any OpenAI model id.                                                              |
+   | Variable          | Default   | Notes                                                                                                                                                                                                             |
+   | ----------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | `MODEL_NAME`      | `gpt-5.5` | Any OpenAI model id.                                                                                                                                                                                              |
    | `SEMAPHORE_LIMIT` | `10`      | Concurrent LLM calls during ingestion. Deliberately below graphiti-core's default of 20, so a burst of episodes doesn't trip the rate limits on a fresh OpenAI key. Raise it once you know your account's limits. |
 
    The rest is wiring you shouldn't need to touch. `DB_BACKEND` selects the FalkorDB code

--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ export GRAPHITI_URL=https://graphiti-api.onrender.com
    > [graphiti-core](https://github.com/getzep/graphiti) driver issue, not a misconfiguration
    > here. Don't rely on them to erase a tenant's data.
 
+If you'd rather not paste multi-line `curl` commands, [`examples/render/demo.sh`](examples/render/demo.sh)
+wraps the same endpoints in one-word shell functions. Set `GRAPHITI_URL`, `source` the file (it
+defines functions, so running it won't work), and you get `use_group take1` to pick a group,
+`health`, `ingest` to POST the sample episode with its `group_id` rewritten to match, then
+`watch_ingest` to follow the queue draining, `ask "who owns the ledger migration?"` for the
+current answer, and `timeline "leads the payments"` for every version of a fact oldest-first with
+its relationship label and validity window. It's a thin projection over `/search` — the raw
+endpoint returns more fields than it prints. Use a new group per run rather than re-ingesting into
+one that already holds facts: they dedupe into what's there and nothing appears to happen.
+
 Full endpoint list at `$GRAPHITI_URL/docs` (FastAPI's generated OpenAPI docs).
 
 `group_id` partitions the graph. Use one per user, per tenant, or per agent, and search stays

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,8 +1,9 @@
 services:
   graph:
     image: graphiti-service:${GITHUB_SHA}
+    # Localhost-bound, as in docker-compose.yml: the key below is committed to this repo.
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     healthcheck:
       test:
         [
@@ -19,6 +20,8 @@ services:
         condition: service_healthy
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      # Auth is mandatory, so the service needs a key to boot.
+      - GRAPHITI_API_KEY=${GRAPHITI_API_KEY:-insecure-local-dev-key}
       - NEO4J_URI=bolt://neo4j:${NEO4J_PORT}
       - NEO4J_USER=${NEO4J_USER}
       - NEO4J_PASSWORD=${NEO4J_PASSWORD}
@@ -26,9 +29,10 @@ services:
 
   neo4j:
     image: neo4j:5.26.2
+    # Localhost-bound: Bolt is unmediated write access. `graph` uses the compose network.
     ports:
-      - "7474:7474"
-      - "${NEO4J_PORT}:${NEO4J_PORT}"
+      - "127.0.0.1:7474:7474"
+      - "127.0.0.1:${NEO4J_PORT}:${NEO4J_PORT}"
     healthcheck:
       test: wget "http://localhost:${NEO4J_PORT}" || exit 1
       interval: 1s

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 services:
   graph:
     image: graphiti-service:${GITHUB_SHA}
-    # Localhost-bound, as in docker-compose.yml: the key below is committed to this repo.
+    # Localhost-bound, as in docker-compose.yml: the key below is committed.
     ports:
       - "127.0.0.1:8000:8000"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ services:
     profiles: [""]
     build:
       context: .
-    # Localhost-bound, not the bare "8000:8000": the key below is committed to this repo, so
-    # publishing on every interface would hand the graph to anyone on a shared network. Drop the
-    # prefix to reach this from another machine, and set your own key in the same edit.
+    # Localhost-bound, not the bare "8000:8000": the key below is committed, so publishing on
+    # every interface would hand the graph to anyone on the network. Drop the prefix to reach
+    # this from another machine, and set your own key in the same edit.
     ports:
       - "127.0.0.1:8000:8000"
     healthcheck:
@@ -22,16 +22,15 @@ services:
     depends_on:
       neo4j:
         condition: service_healthy
-    # Everything else the app reads comes straight from .env, so the settings documented
-    # in .env.example reach the container instead of being silently dropped. Listing them
-    # here one by one would mean a blank value for each one the user left out, and a blank
-    # is not the same as unset: SEMAPHORE_LIMIT is read as int(os.getenv(...)), so '' is a
-    # crash on import. Absent from .env means absent from the environment.
+    # Everything else comes straight from .env, so the settings documented in .env.example
+    # reach the container. Listing them individually would pass a blank for each one left
+    # out, and blank is not unset: SEMAPHORE_LIMIT is read as int(os.getenv(...)), so '' is a
+    # crash on import.
     env_file:
       - path: .env
         required: false
-    # Compose-specific wiring, which has to win over whatever .env says: these hostnames
-    # only make sense on the compose network. environment takes precedence over env_file.
+    # Compose-specific wiring, which has to win over .env — these hostnames only exist on the
+    # compose network. environment takes precedence over env_file.
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       # Mandatory, so the stack needs one to boot. Named insecure- because it is committed and
@@ -41,10 +40,9 @@ services:
       - NEO4J_USER=${NEO4J_USER:-neo4j}
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:-password}
       - DB_BACKEND=neo4j
-      # Now that the Dockerfile's CMD honours PORT, pin it: the mapping above and the
-      # healthcheck below both name 8000 literally, so a PORT inherited from .env would
-      # move the server out from under them. Change the left-hand side of the mapping to
-      # publish somewhere else.
+      # Pinned because the CMD honours PORT: the mapping and healthcheck both name 8000, so a
+      # PORT inherited from .env would move the server out from under them. To publish
+      # elsewhere, change the left-hand side of the mapping.
       - PORT=8000
   neo4j:
     image: neo4j:5.26.2
@@ -59,7 +57,7 @@ services:
       timeout: 10s
       retries: 10
       start_period: 3s
-    # Localhost-bound, as above, with more at stake: NEO4J_PASSWORD defaults to `password` and
+    # Localhost-bound, as above, with more at stake: the password defaults to `password` and
     # Bolt is unmediated write access.
     ports:
       - "127.0.0.1:7474:7474" # HTTP
@@ -73,16 +71,16 @@ services:
     # Kept in step with render.yaml so local dev matches what Render runs.
     image: falkordb/falkordb:v4.20.1
     profiles: ["falkordb"]
-    # Localhost-bound, as above. FalkorDB has no password at all; on Render it is a pserv
-    # reachable only from graphiti-api, and this is the closest local equivalent.
+    # Localhost-bound, as above, and FalkorDB has no password at all. On Render it's a pserv
+    # reachable only from graphiti-api; this is the closest local equivalent.
     ports:
       - "127.0.0.1:6379:6379"
     volumes:
       - falkordb_data:/var/lib/falkordb/data
     environment:
-      # REDIS_ARGS goes to redis-server; FALKORDB_ARGS goes to the module. The flags that
-      # used to sit in FALKORDB_ARGS were redis-server flags in the module's slot, and
-      # both were already the defaults. Append-only matches what render.yaml runs.
+      # REDIS_ARGS goes to redis-server, FALKORDB_ARGS to the module. The flags that used to
+      # sit in FALKORDB_ARGS were redis-server flags in the module's slot, and both were
+      # already the defaults. Append-only matches render.yaml.
       - REDIS_ARGS=--appendonly yes
     healthcheck:
       test: ["CMD", "redis-cli", "-p", "6379", "ping"]
@@ -119,8 +117,8 @@ services:
       - FALKORDB_PORT=6379
       - FALKORDB_DATABASE=default_db
       - DB_BACKEND=falkordb
-      # Pinned for the same reason as the graph service above. Published on 8001 to leave
-      # 8000 free for the neo4j profile; the container still listens on 8000.
+      # Pinned as on the graph service above. Published on 8001 to leave 8000 free for the
+      # neo4j profile; the container still listens on 8000.
       - PORT=8000
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,16 @@ services:
     depends_on:
       neo4j:
         condition: service_healthy
+    # Everything else the app reads comes straight from .env, so the settings documented
+    # in .env.example reach the container instead of being silently dropped. Listing them
+    # here one by one would mean a blank value for each one the user left out, and a blank
+    # is not the same as unset: SEMAPHORE_LIMIT is read as int(os.getenv(...)), so '' is a
+    # crash on import. Absent from .env means absent from the environment.
+    env_file:
+      - path: .env
+        required: false
+    # Compose-specific wiring, which has to win over whatever .env says: these hostnames
+    # only make sense on the compose network. environment takes precedence over env_file.
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - NEO4J_URI=bolt://neo4j:${NEO4J_PORT:-7687}
@@ -81,6 +91,10 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    # See the note on the graph service above.
+    env_file:
+      - path: .env
+        required: false
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - FALKORDB_HOST=falkordb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,7 @@ services:
       - NEO4J_URI=bolt://neo4j:${NEO4J_PORT:-7687}
       - NEO4J_USER=${NEO4J_USER:-neo4j}
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:-password}
-      - PORT=8000
-      - db_backend=neo4j
+      - DB_BACKEND=neo4j
   neo4j:
     image: neo4j:5.26.2
     profiles: [""]
@@ -70,10 +69,6 @@ services:
     build:
       args:
         INSTALL_FALKORDB: "true"
-        # Same pin as render.yaml. Left unset, the Dockerfile installs whatever
-        # graphiti-core is newest at build time, so local dev would drift off the
-        # version Render runs — the thing pinning was meant to prevent.
-        GRAPHITI_VERSION: ${GRAPHITI_VERSION:-0.29.3}
       context: .
     profiles: ["falkordb"]
     ports:
@@ -91,8 +86,7 @@ services:
       - FALKORDB_HOST=falkordb
       - FALKORDB_PORT=6379
       - FALKORDB_DATABASE=default_db
-      - PORT=8000
-      - db_backend=falkordb
+      - DB_BACKEND=falkordb
 
 volumes:
   neo4j_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,11 @@ services:
       - NEO4J_USER=${NEO4J_USER:-neo4j}
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:-password}
       - DB_BACKEND=neo4j
+      # Now that the Dockerfile's CMD honours PORT, pin it: the mapping above and the
+      # healthcheck below both name 8000 literally, so a PORT inherited from .env would
+      # move the server out from under them. Change the left-hand side of the mapping to
+      # publish somewhere else.
+      - PORT=8000
   neo4j:
     image: neo4j:5.26.2
     profiles: [""]
@@ -114,6 +119,9 @@ services:
       - FALKORDB_PORT=6379
       - FALKORDB_DATABASE=default_db
       - DB_BACKEND=falkordb
+      # Pinned for the same reason as the graph service above. Published on 8001 to leave
+      # 8000 free for the neo4j profile; the container still listens on 8000.
+      - PORT=8000
 
 volumes:
   neo4j_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,14 +48,18 @@ services:
       - NEO4J_AUTH=${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD:-password}
 
   falkordb:
-    image: falkordb/falkordb:latest
+    # Kept in step with render.yaml so local dev matches what Render runs.
+    image: falkordb/falkordb:v4.20.1
     profiles: ["falkordb"]
     ports:
       - "6379:6379"
     volumes:
-      - falkordb_data:/data
+      - falkordb_data:/var/lib/falkordb/data
     environment:
-      - FALKORDB_ARGS=--port 6379 --cluster-enabled no
+      # REDIS_ARGS goes to redis-server; FALKORDB_ARGS goes to the module. The flags that
+      # used to sit in FALKORDB_ARGS were redis-server flags in the module's slot, and
+      # both were already the defaults. Append-only matches what render.yaml runs.
+      - REDIS_ARGS=--appendonly yes
     healthcheck:
       test: ["CMD", "redis-cli", "-p", "6379", "ping"]
       interval: 1s
@@ -66,6 +70,10 @@ services:
     build:
       args:
         INSTALL_FALKORDB: "true"
+        # Same pin as render.yaml. Left unset, the Dockerfile installs whatever
+        # graphiti-core is newest at build time, so local dev would drift off the
+        # version Render runs — the thing pinning was meant to prevent.
+        GRAPHITI_VERSION: ${GRAPHITI_VERSION:-0.29.3}
       context: .
     profiles: ["falkordb"]
     ports:
@@ -83,7 +91,6 @@ services:
       - FALKORDB_HOST=falkordb
       - FALKORDB_PORT=6379
       - FALKORDB_DATABASE=default_db
-      - GRAPHITI_BACKEND=falkordb
       - PORT=8000
       - db_backend=falkordb
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,11 @@ services:
     profiles: [""]
     build:
       context: .
+    # Localhost-bound, not the bare "8000:8000": the key below is committed to this repo, so
+    # publishing on every interface would hand the graph to anyone on a shared network. Drop the
+    # prefix to reach this from another machine, and set your own key in the same edit.
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     healthcheck:
       test:
         [
@@ -31,6 +34,9 @@ services:
     # only make sense on the compose network. environment takes precedence over env_file.
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      # Mandatory, so the stack needs one to boot. Named insecure- because it is committed and
+      # protects nothing; the localhost binding above is what does.
+      - GRAPHITI_API_KEY=${GRAPHITI_API_KEY:-insecure-local-dev-key}
       - NEO4J_URI=bolt://neo4j:${NEO4J_PORT:-7687}
       - NEO4J_USER=${NEO4J_USER:-neo4j}
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:-password}
@@ -48,9 +54,11 @@ services:
       timeout: 10s
       retries: 10
       start_period: 3s
+    # Localhost-bound, as above, with more at stake: NEO4J_PASSWORD defaults to `password` and
+    # Bolt is unmediated write access.
     ports:
-      - "7474:7474" # HTTP
-      - "${NEO4J_PORT:-7687}:${NEO4J_PORT:-7687}" # Bolt
+      - "127.0.0.1:7474:7474" # HTTP
+      - "127.0.0.1:${NEO4J_PORT:-7687}:${NEO4J_PORT:-7687}" # Bolt
     volumes:
       - neo4j_data:/data
     environment:
@@ -60,8 +68,10 @@ services:
     # Kept in step with render.yaml so local dev matches what Render runs.
     image: falkordb/falkordb:v4.20.1
     profiles: ["falkordb"]
+    # Localhost-bound, as above. FalkorDB has no password at all; on Render it is a pserv
+    # reachable only from graphiti-api, and this is the closest local equivalent.
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - falkordb_data:/var/lib/falkordb/data
     environment:
@@ -81,8 +91,9 @@ services:
         INSTALL_FALKORDB: "true"
       context: .
     profiles: ["falkordb"]
+    # Localhost-bound, as above.
     ports:
-      - "8001:8000"
+      - "127.0.0.1:8001:8000"
     depends_on:
       falkordb:
         condition: service_healthy
@@ -97,6 +108,8 @@ services:
         required: false
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      # See the note on the graph service above.
+      - GRAPHITI_API_KEY=${GRAPHITI_API_KEY:-insecure-local-dev-key}
       - FALKORDB_HOST=falkordb
       - FALKORDB_PORT=6379
       - FALKORDB_DATABASE=default_db

--- a/examples/render/demo.sh
+++ b/examples/render/demo.sh
@@ -13,25 +13,17 @@
 #   ask "who owns X?"       the current answer, one line
 #   timeline "leads the"    every version of that fact, oldest first
 #
-# There is deliberately no clear helper. DELETE /group and POST /clear return
-# {"success": true} on this deployment and delete nothing — they query the default
-# graph while the data lives in a graph named after the group_id. To actually erase a
-# group, open a shell on graphiti-falkordb and run `redis-cli GRAPH.DELETE <group>`;
-# to start clean without deleting anything, just `use_group` a new name.
+# These wrap POST /search and /messages and project the response down to the interesting
+# fields; see $GRAPHITI_URL/docs for the full shape.
 #
-# Every command is one word with no quoting or line continuations, because a
-# multi-line curl that loses its -H flag mid-paste sends the body without a JSON
-# content type and the API replies 422 about a string it can't read as an object.
-#
-# These wrap POST /search and /messages and project the response down to the
-# interesting fields. The raw endpoints return uuid/created_at/expired_at too —
-# see $GRAPHITI_URL/docs for the full shape.
+# There is deliberately no clear helper: DELETE /group and POST /clear return
+# {"success": true} and delete nothing, because they query the default graph while the data
+# lives in a graph named after the group_id. To actually erase a group, run
+# `redis-cli GRAPH.DELETE <group>` on graphiti-falkordb; to start clean, use_group a new name.
 
-# Executing this file would define the functions in a subshell that exits
-# immediately, so catch that and say so rather than appearing to do nothing.
-# zsh needs its own test: ZSH_VERSION being set says nothing about how the file
-# was loaded, so `zsh demo.sh` would slip past a bash-only check. ZSH_EVAL_CONTEXT
-# gains a :file component when sourced and stays at toplevel when executed.
+# Executing this file would define the functions in a subshell that exits immediately, so say
+# so rather than appear to do nothing. zsh needs its own test: ZSH_VERSION says nothing about
+# how the file was loaded, but ZSH_EVAL_CONTEXT gains a :file component when sourced.
 _graphiti_sourced=0
 if [ -n "$ZSH_VERSION" ]; then
   case "$ZSH_EVAL_CONTEXT" in *:file*) _graphiti_sourced=1 ;; esac
@@ -55,18 +47,18 @@ unset _graphiti_sourced
 
 command -v jq >/dev/null || echo 'demo.sh: jq not found — brew install jq'
 
-# curl with the bearer header attached, built in one place so a new helper cannot forget it.
-# Only health() bypasses it. Read per call, so re-exporting a rotated key needs no re-source.
+# curl with the bearer header attached, in one place so a new helper can't forget it. Only
+# health() bypasses it. Read per call, so a rotated key needs no re-source.
 #
-# -H @- takes the header from stdin, keeping the key out of argv where `ps` would expose it to
-# other users. Needs curl 7.55+ (2017). No helper sends a body on stdin, so stdin is free.
+# -H @- takes the header from stdin, keeping the key out of argv where `ps` would expose it.
+# Needs curl 7.55+ (2017); no helper sends a body on stdin, so stdin is free.
 _graphiti_curl() {
   printf 'Authorization: Bearer %s\n' "$GRAPHITI_API_KEY" | curl -H @- "$@"
 }
 
-# $1 is an HTTP status. Returns 0 on 2xx, else explains on stderr and returns 1, so a caller
-# can end with it or use `|| return 1` mid-function. Keyed off the status, not the body: the
-# 401 wording is auth.py's to change, and matching it would silently misreport.
+# $1 is an HTTP status. Returns 0 on 2xx, else explains on stderr and returns 1, so a caller can
+# end with it or use `|| return 1`. Keyed off the status, not the body, whose wording is auth.py's
+# to change.
 _graphiti_check_status() {
   case "$1" in
     2*) return 0 ;;
@@ -74,8 +66,8 @@ _graphiti_check_status() {
       echo '  401 — GRAPHITI_API_KEY was rejected. Re-copy it from the Render Dashboard:' >&2
       echo '    graphiti-api -> Environment -> GRAPHITI_API_KEY' >&2 ;;
     429)
-      # Only reachable with a wrong key: the service never limits one carrying the right
-      # key. So say what a bare "HTTP 429" would not — this is still the key.
+      # Only reachable with a wrong key, since the service never limits a right one — so say
+      # what a bare "HTTP 429" would not.
       echo '  429 — too many rejected keys; the service is throttling them. The key is' >&2
       echo '  still wrong. Re-copy it, then wait a minute and retry:' >&2
       echo '    graphiti-api -> Environment -> GRAPHITI_API_KEY' >&2 ;;
@@ -87,20 +79,18 @@ _graphiti_check_status() {
   return 1
 }
 
-# Where the sample episode lives, resolved once at source time so the helpers
-# work from any directory afterwards.
+# Resolved once at source time, so the helpers work from any directory afterwards.
 GRAPHITI_EPISODE="${GRAPHITI_EPISODE:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/sample-episode.json}"
 
-# Point every helper at a group. One group per take: re-ingesting into a group
-# that already holds facts dedupes into them, so nothing visibly happens.
-# Named use_group rather than take because oh-my-zsh already defines take.
+# Point every helper at a group. One group per take: re-ingesting into a group that already holds
+# facts dedupes into them, so nothing visibly happens. Not named `take` — oh-my-zsh defines that.
 use_group() {
   if [ -z "$1" ]; then
     echo '  usage: use_group take2' >&2
     return 1
   fi
-  # The name goes into the DELETE /group/{id} path unencoded, so a slash would
-  # silently address a different route and a space would break the URL outright.
+  # The name goes into the DELETE /group/{id} path unencoded, so a slash would address a
+  # different route and a space would break the URL outright.
   case "$1" in
     *[!A-Za-z0-9._-]*)
       echo "  '$1' won't work as a group name — use letters, digits, . _ or - only" >&2
@@ -117,20 +107,19 @@ health() {
   metrics=$(curl -sS -o /dev/null -w '%{http_code} %{time_total}' "$GRAPHITI_URL/healthcheck")
   http_code="${metrics% *}"
   printf '  healthcheck → HTTP %s in %ss\n' "$http_code" "${metrics#* }"
-  # Last, so its status becomes health's: `health && ingest` used to ingest against a
-  # service that never answered.
+  # Last, so its status becomes health's: `health && ingest` used to run against a service
+  # that never answered.
   _graphiti_check_status "$http_code"
 }
 
-# Rewrite the sample episode's group_id to match $GRAPHITI_GROUP and POST it.
-# --data-binary rather than -d: -d strips newlines, which is harmless for JSON
-# but makes the payload unreadable if you ever need to echo it back.
+# Rewrite the sample episode's group_id to match $GRAPHITI_GROUP and POST it. --data-binary
+# rather than -d, which strips newlines and leaves the payload unreadable if echoed back.
 ingest() {
   # http_code, not status: status is read-only in zsh, which most readers are sourcing into.
   local file="${1:-$GRAPHITI_EPISODE}" tmp body metrics http_code
   [ -f "$file" ] || { echo "  no episode file at $file" >&2; return 1; }
-  # An explicit XXXXXX template: macOS accepts a bare prefix after -t, GNU and
-  # BusyBox mktemp reject it, so -t alone would break the helper on Linux.
+  # An explicit XXXXXX template: macOS accepts a bare prefix after -t, GNU and BusyBox
+  # mktemp reject it.
   tmp=$(mktemp "${TMPDIR:-/tmp}/graphiti-episode.XXXXXX") || return 1
   body=$(mktemp "${TMPDIR:-/tmp}/graphiti-ingest.XXXXXX") || { rm -f "$tmp"; return 1; }
   jq --arg g "$GRAPHITI_GROUP" '.group_id = $g' "$file" > "$tmp" || { rm -f "$tmp" "$body"; return 1; }
@@ -140,21 +129,21 @@ ingest() {
     --data-binary @"$tmp")
   http_code="${metrics% *}"
   printf '  ingest → HTTP %s in %ss (group %s)\n' "$http_code" "${metrics#* }" "$GRAPHITI_GROUP"
-  # A 202 body is just an ack, so only surface it on an error — and not on a 401, where the
+  # A 202 body is just an ack, so surface it only on an error — and not on a 401, where the
   # hint below says the same thing with the fix attached.
   case "$http_code" in
     2*|401) ;;
     *) jq -c . "$body" 2>/dev/null || cat "$body" ;;
   esac
   rm -f "$tmp" "$body"
-  # Last, so its status becomes ingest's: a non-2xx is a failure, not a line that scrolls
-  # past looking like progress.
+  # Last, so its status becomes ingest's: a non-2xx is a failure, not a line that scrolls past
+  # looking like progress.
   _graphiti_check_status "$http_code"
 }
 
-# POST /search and emit the body, then the HTTP status on a final line. $1 query, $2
-# max_facts (default 10). Only _graphiti_facts calls this, and it splits the two apart: the
-# status is what tells a rejected key from a service that is simply down.
+# POST /search and emit the body, then the HTTP status on a final line. $1 query, $2 max_facts
+# (default 10). Only _graphiti_facts calls this, and splits the two apart: the status is what
+# tells a rejected key from a service that is simply down.
 _graphiti_search() {
   _graphiti_curl -s -w '\n%{http_code}' -X POST "$GRAPHITI_URL/search" \
     -H 'Content-Type: application/json' \
@@ -162,9 +151,9 @@ _graphiti_search() {
           '{group_ids: [$g], query: $q, max_facts: $n}')"
 }
 
-# Emit the search response only if it is JSON with a facts array, so callers can
-# tell "the service is down" from "the graph knows nothing" and say which.
-# $1 query, $2 max_facts. Diagnoses its own failure on stderr, so callers just propagate.
+# Emit the search response only if it is JSON with a facts array, so callers can tell "the service
+# is down" from "the graph knows nothing". $1 query, $2 max_facts. Diagnoses its own failure on
+# stderr, so callers just propagate.
 _graphiti_facts() {
   local response json http_code detail
   response=$(_graphiti_search "$1" "${2:-10}")
@@ -177,8 +166,8 @@ _graphiti_facts() {
   fi
   # A 401 gets the fix rather than its body, which says the same without one.
   [ "$http_code" = 401 ] && { _graphiti_check_status "$http_code"; return 1; }
-  # FastAPI reports other errors as {"detail": ...}, so a detail field means the service
-  # answered and rejected us — quoting it beats guessing it is down.
+  # FastAPI reports other errors as {"detail": ...}, so a detail field means the service answered
+  # and rejected us — quoting it beats guessing it is down.
   detail=$(printf '%s' "$json" | jq -r 'if (.detail|type) == "string" then .detail else empty end' 2>/dev/null)
   if [ -n "$detail" ]; then
     echo "  $GRAPHITI_URL/search refused the request: $detail" >&2
@@ -189,23 +178,19 @@ _graphiti_facts() {
   return 1
 }
 
-# How many facts the current group returns for $1, or empty if the service did not answer
-# with usable JSON. Callers must handle empty: a cold start or a 502 yields no output, and
-# feeding that to [ ] produces "integer expression expected" instead of anything a reader
-# can act on.
+# How many facts the current group returns for $1, or empty if the service did not answer with
+# usable JSON. Callers must handle empty: feeding it to [ ] gives "integer expression expected".
 #
-# The quiet variant of _graphiti_facts: watch_ingest's loop carries the last count forward on
-# a dropped request, and a diagnostic per blip would scroll past. Its baseline call has
-# already made any noise.
+# The quiet variant of _graphiti_facts, because watch_ingest's loop carries the last count forward
+# on a dropped request and a diagnostic per blip would scroll past.
 _graphiti_count() {
   _graphiti_facts "$1" 50 2>/dev/null | jq -e '.facts | length' 2>/dev/null
 }
 
-# The current answer, on one line, rendered as the graph edge it came from so it
-# reads the same as timeline output. /search returns facts in relevance order, so
-# narrow to the newest valid_at first and then keep the most relevant of those:
-# sorting on valid_at alone tie-breaks arbitrarily between same-day facts and can
-# answer a different question than the one asked.
+# The current answer, on one line, rendered as the graph edge it came from so it reads like
+# timeline output. /search returns facts in relevance order, so narrow to the newest valid_at and
+# then keep the most relevant of those: sorting on valid_at alone tie-breaks arbitrarily between
+# same-day facts and can answer a different question than the one asked.
 ask() {
   local out json
   if [ -z "$1" ]; then
@@ -226,16 +211,13 @@ ask() {
   printf '%s\n' "$out"
 }
 
-# Every version of a fact, oldest first, as the graph edge behind it: the
-# relationship label and the window the edge is valid for. $1 is a regex matched
-# against fact text. unique_by guards against the same episode having been
-# ingested twice. Named timeline, not history, so it doesn't shadow the builtin.
+# Every version of a fact, oldest first, as the graph edge behind it: the relationship label and
+# the window it is valid for. $1 is a regex matched against fact text; unique_by guards against
+# the same episode being ingested twice. Not named history, which would shadow the builtin.
 #
-# This stops short of drawing (Alex) ──LEADS──▶ (payments team) because /search
-# returns no node names: FactResult has the edge label and text but not the
-# edge's two endpoints, and the API exposes no node getter to resolve them. For
-# real endpoints, add source/target to FactResult in
-# server/graph_service/dto/retrieve.py and resolve the names in
+# Stops short of drawing (Alex) ──LEADS──▶ (payments team) because /search returns no node names:
+# FactResult carries the edge label and text but not its endpoints. To get real ones, add
+# source/target to FactResult in server/graph_service/dto/retrieve.py and resolve the names in
 # get_fact_result_from_edge.
 timeline() {
   local out json
@@ -250,15 +232,13 @@ timeline() {
     | if length == 0 then ["  (no facts match \($pat))"] | .[]
       else .[]
         | (if .valid_at then .valid_at[0:10] else "undated   " end) as $from
-        # Only claim an end date when the edge actually carries one. Printing
-        # "→ now" for a null invalid_at asserts the superseded fact is still
-        # live, which contradicts the fact that replaced it.
+        # Only claim an end date when the edge carries one: printing "→ now" for a null
+        # invalid_at would assert a superseded fact is still live.
         | (if .invalid_at then " → \(.invalid_at[0:10])" else "" end) as $to
         | "  \($from)\($to)  ──\(.name)──▶  \(.fact)"
       end' 2>/dev/null)
-  # The service answered, so empty output here means jq itself failed — and the
-  # only way that happens is an invalid regex in $1, since a zero-match search
-  # takes the length == 0 branch above and prints its own line.
+  # The service answered, so empty output means jq failed — and the only way that happens is an
+  # invalid regex in $1, since a zero-match search takes the length == 0 branch above.
   if [ -z "$out" ]; then
     echo "  '$1' is not a valid regex — try plain words:" >&2
     echo '    timeline "leads the payments"' >&2
@@ -267,15 +247,12 @@ timeline() {
   printf '%s\n' "$out"
 }
 
-# Poll until the fact count stops changing. Prints only when it moves, so the
-# output stays short. Ingestion is serial and LLM-bound, so expect ~30s for the
-# three-message sample.
+# Poll until the fact count stops changing, printing only when it moves. Ingestion is serial and
+# LLM-bound, so expect ~30s for the three-message sample.
 #
-# The count has to rise above whatever the group already held, not just above
-# zero: re-ingesting into a group that still has the previous run's facts
-# dedupes into them, so the count can sit flat at its starting value and the
-# watcher would otherwise declare victory on the *old* data. Start each take in
-# an empty group.
+# The count has to rise above what the group already held, not just above zero: a re-ingest dedupes
+# into the previous run's facts, so the count can sit flat and the watcher would declare victory on
+# the *old* data. Start each take in an empty group.
 watch_ingest() {
   local force=''
   # Consume --force before reading the query, or it would become the query.
@@ -284,13 +261,12 @@ watch_ingest() {
   local t0 last count stable=0 elapsed baseline json
   t0=$(date +%s)
 
-  # Via _graphiti_facts, not the silent _graphiti_count: without a baseline there is no
-  # telling new facts from old, so this is the point to stop and say why — a rejected key
-  # surfaces here rather than as three minutes of polling that never moves.
+  # Via _graphiti_facts, not the silent _graphiti_count: without a baseline there is no telling
+  # new facts from old, so a rejected key surfaces here rather than as three minutes of polling.
   json=$(_graphiti_facts "$query" 50) || return 1
   baseline=$(printf '%s' "$json" | jq '.facts | length')
-  # Refuse rather than poll for three minutes and time out: on a populated group
-  # the count legitimately may never move, so there is nothing to wait for.
+  # Refuse rather than poll for three minutes and time out: on a populated group the count may
+  # legitimately never move, so there is nothing to wait for.
   if [ "$baseline" -gt 0 ] && [ -z "$force" ]; then
     echo "  group '$GRAPHITI_GROUP' already holds $baseline facts — nothing to watch," >&2
     echo "  since a re-ingest dedupes into them and the count never moves." >&2
@@ -303,8 +279,8 @@ watch_ingest() {
   last=-1
   while true; do
     count=$(_graphiti_count "$query")
-    # A dropped poll is not a change in the graph. Carry the last known count
-    # forward, or a blip would reset the stability counter and stall the watcher.
+    # A dropped poll is not a change in the graph: carry the last count forward, or a blip
+    # resets the stability counter and stalls the watcher.
     [ -n "$count" ] || count=$last
     elapsed=$(( $(date +%s) - t0 ))
     if [ "$count" != "$last" ]; then
@@ -314,14 +290,12 @@ watch_ingest() {
     else
       stable=$(( stable + 1 ))
     fi
-    # Episodes are processed one at a time, and the gap between one finishing and
-    # the next producing facts runs to ~22s, so a short plateau is not the end of
-    # the queue — it is the middle of it. 8 polls x 4s = 32s of no movement gives
-    # enough margin; anything less declares victory on a half-built graph and the
-    # answers come out of date.
+    # Episodes are processed one at a time and the gap between one finishing and the next
+    # producing facts runs to ~22s, so a short plateau is the middle of the queue, not the end
+    # of it. 8 polls x 4s = 32s of no movement gives enough margin; less declares victory on a
+    # half-built graph.
     [ "$stable" -ge 8 ] && [ "$count" -gt "$baseline" ] && break
-    # Timing out is a failure, not a finish — don't follow it with "done", which
-    # would read as a successful drain in the recording.
+    # Timing out is a failure, not a finish — don't follow it with "done".
     if [ "$elapsed" -gt 180 ]; then
       printf '  gave up after 180s at %s facts (started from %s)\n' "$count" "$baseline" >&2
       return 1

--- a/examples/render/demo.sh
+++ b/examples/render/demo.sh
@@ -2,6 +2,7 @@
 # Demo helpers for a deployed Graphiti API. Source it, don't run it:
 #
 #   export GRAPHITI_URL=https://your-service.onrender.com
+#   export GRAPHITI_API_KEY=...   # graphiti-api -> Environment in the Render Dashboard
 #   source examples/render/demo.sh
 #
 # Then:
@@ -45,11 +46,46 @@ fi
 unset _graphiti_sourced
 
 : "${GRAPHITI_URL:?set GRAPHITI_URL first, e.g. export GRAPHITI_URL=https://graphiti-api.onrender.com}"
+# Refuse up front rather than 401 six times. A local compose stack defaults to
+# insecure-local-dev-key.
+: "${GRAPHITI_API_KEY:?set GRAPHITI_API_KEY first — graphiti-api -> Environment in the Render Dashboard}"
 : "${GRAPHITI_GROUP:=demo}"
 # The default search string watch_ingest counts facts against.
 : "${GRAPHITI_QUERY:=payments team ledger migration}"
 
 command -v jq >/dev/null || echo 'demo.sh: jq not found — brew install jq'
+
+# curl with the bearer header attached, built in one place so a new helper cannot forget it.
+# Only health() bypasses it. Read per call, so re-exporting a rotated key needs no re-source.
+#
+# -H @- takes the header from stdin, keeping the key out of argv where `ps` would expose it to
+# other users. Needs curl 7.55+ (2017). No helper sends a body on stdin, so stdin is free.
+_graphiti_curl() {
+  printf 'Authorization: Bearer %s\n' "$GRAPHITI_API_KEY" | curl -H @- "$@"
+}
+
+# $1 is an HTTP status. Returns 0 on 2xx, else explains on stderr and returns 1, so a caller
+# can end with it or use `|| return 1` mid-function. Keyed off the status, not the body: the
+# 401 wording is auth.py's to change, and matching it would silently misreport.
+_graphiti_check_status() {
+  case "$1" in
+    2*) return 0 ;;
+    401)
+      echo '  401 — GRAPHITI_API_KEY was rejected. Re-copy it from the Render Dashboard:' >&2
+      echo '    graphiti-api -> Environment -> GRAPHITI_API_KEY' >&2 ;;
+    429)
+      # Only reachable with a wrong key: the service never limits one carrying the right
+      # key. So say what a bare "HTTP 429" would not — this is still the key.
+      echo '  429 — too many rejected keys; the service is throttling them. The key is' >&2
+      echo '  still wrong. Re-copy it, then wait a minute and retry:' >&2
+      echo '    graphiti-api -> Environment -> GRAPHITI_API_KEY' >&2 ;;
+    000)
+      echo "  no response from $GRAPHITI_URL — is the service up? try: health" >&2 ;;
+    *)
+      echo "  HTTP $1 from $GRAPHITI_URL" >&2 ;;
+  esac
+  return 1
+}
 
 # Where the sample episode lives, resolved once at source time so the helpers
 # work from any directory afterwards.
@@ -74,59 +110,95 @@ use_group() {
   echo "  group: $GRAPHITI_GROUP"
 }
 
+# Plain curl: /healthcheck takes no key, and calling it without one is what proves that.
 health() {
-  curl -sS -o /dev/null -w '  healthcheck → HTTP %{http_code} in %{time_total}s\n' \
-    "$GRAPHITI_URL/healthcheck"
+  # http_code, not status: status is read-only in zsh. Same as ingest below.
+  local metrics http_code
+  metrics=$(curl -sS -o /dev/null -w '%{http_code} %{time_total}' "$GRAPHITI_URL/healthcheck")
+  http_code="${metrics% *}"
+  printf '  healthcheck → HTTP %s in %ss\n' "$http_code" "${metrics#* }"
+  # Last, so its status becomes health's: `health && ingest` used to ingest against a
+  # service that never answered.
+  _graphiti_check_status "$http_code"
 }
 
 # Rewrite the sample episode's group_id to match $GRAPHITI_GROUP and POST it.
 # --data-binary rather than -d: -d strips newlines, which is harmless for JSON
 # but makes the payload unreadable if you ever need to echo it back.
 ingest() {
-  local file="${1:-$GRAPHITI_EPISODE}" tmp body code
+  # http_code, not status: status is read-only in zsh, which most readers are sourcing into.
+  local file="${1:-$GRAPHITI_EPISODE}" tmp body metrics http_code
   [ -f "$file" ] || { echo "  no episode file at $file" >&2; return 1; }
   # An explicit XXXXXX template: macOS accepts a bare prefix after -t, GNU and
   # BusyBox mktemp reject it, so -t alone would break the helper on Linux.
   tmp=$(mktemp "${TMPDIR:-/tmp}/graphiti-episode.XXXXXX") || return 1
   body=$(mktemp "${TMPDIR:-/tmp}/graphiti-ingest.XXXXXX") || { rm -f "$tmp"; return 1; }
   jq --arg g "$GRAPHITI_GROUP" '.group_id = $g' "$file" > "$tmp" || { rm -f "$tmp" "$body"; return 1; }
-  code=$(curl -sS -o "$body" -w '%{http_code} %{time_total}' \
+  metrics=$(_graphiti_curl -sS -o "$body" -w '%{http_code} %{time_total}' \
     -X POST "$GRAPHITI_URL/messages" \
     -H 'Content-Type: application/json' \
     --data-binary @"$tmp")
-  printf '  ingest → HTTP %s in %ss (group %s)\n' "${code% *}" "${code#* }" "$GRAPHITI_GROUP"
-  # A 202 body is just an ack, so only surface it when something went wrong.
-  case "${code% *}" in
-    2*) ;;
+  http_code="${metrics% *}"
+  printf '  ingest → HTTP %s in %ss (group %s)\n' "$http_code" "${metrics#* }" "$GRAPHITI_GROUP"
+  # A 202 body is just an ack, so only surface it on an error — and not on a 401, where the
+  # hint below says the same thing with the fix attached.
+  case "$http_code" in
+    2*|401) ;;
     *) jq -c . "$body" 2>/dev/null || cat "$body" ;;
   esac
   rm -f "$tmp" "$body"
+  # Last, so its status becomes ingest's: a non-2xx is a failure, not a line that scrolls
+  # past looking like progress.
+  _graphiti_check_status "$http_code"
 }
 
-# POST /search and emit the raw JSON. $1 query, $2 max_facts (default 10).
+# POST /search and emit the body, then the HTTP status on a final line. $1 query, $2
+# max_facts (default 10). Only _graphiti_facts calls this, and it splits the two apart: the
+# status is what tells a rejected key from a service that is simply down.
 _graphiti_search() {
-  curl -s -X POST "$GRAPHITI_URL/search" \
+  _graphiti_curl -s -w '\n%{http_code}' -X POST "$GRAPHITI_URL/search" \
     -H 'Content-Type: application/json' \
     -d "$(jq -nc --arg g "$GRAPHITI_GROUP" --arg q "$1" --argjson n "${2:-10}" \
           '{group_ids: [$g], query: $q, max_facts: $n}')"
 }
 
-# How many facts the current group returns for $1, or empty if the service did
-# not answer with usable JSON. Callers must handle empty: a cold start or a 502
-# yields no output, and feeding that to [ ] produces "integer expression
-# expected" instead of anything a reader can act on.
-_graphiti_count() {
-  _graphiti_search "$1" 50 | jq -e '.facts | length' 2>/dev/null
-}
-
 # Emit the search response only if it is JSON with a facts array, so callers can
 # tell "the service is down" from "the graph knows nothing" and say which.
-# $1 query, $2 max_facts.
+# $1 query, $2 max_facts. Diagnoses its own failure on stderr, so callers just propagate.
 _graphiti_facts() {
-  local json
-  json=$(_graphiti_search "$1" "${2:-10}")
-  printf '%s' "$json" | jq -e 'has("facts")' >/dev/null 2>&1 || return 1
-  printf '%s' "$json"
+  local response json http_code detail
+  response=$(_graphiti_search "$1" "${2:-10}")
+  # Both anchor on the *last* newline, so a pretty-printed body survives intact.
+  http_code="${response##*$'\n'}"
+  json="${response%$'\n'*}"
+  if printf '%s' "$json" | jq -e 'has("facts")' >/dev/null 2>&1; then
+    printf '%s' "$json"
+    return 0
+  fi
+  # A 401 gets the fix rather than its body, which says the same without one.
+  [ "$http_code" = 401 ] && { _graphiti_check_status "$http_code"; return 1; }
+  # FastAPI reports other errors as {"detail": ...}, so a detail field means the service
+  # answered and rejected us — quoting it beats guessing it is down.
+  detail=$(printf '%s' "$json" | jq -r 'if (.detail|type) == "string" then .detail else empty end' 2>/dev/null)
+  if [ -n "$detail" ]; then
+    echo "  $GRAPHITI_URL/search refused the request: $detail" >&2
+  else
+    _graphiti_check_status "$http_code"
+  fi
+  # Unconditional: this is the failure path, whatever the status was.
+  return 1
+}
+
+# How many facts the current group returns for $1, or empty if the service did not answer
+# with usable JSON. Callers must handle empty: a cold start or a 502 yields no output, and
+# feeding that to [ ] produces "integer expression expected" instead of anything a reader
+# can act on.
+#
+# The quiet variant of _graphiti_facts: watch_ingest's loop carries the last count forward on
+# a dropped request, and a diagnostic per blip would scroll past. Its baseline call has
+# already made any noise.
+_graphiti_count() {
+  _graphiti_facts "$1" 50 2>/dev/null | jq -e '.facts | length' 2>/dev/null
 }
 
 # The current answer, on one line, rendered as the graph edge it came from so it
@@ -140,10 +212,8 @@ ask() {
     echo '  usage: ask "who owns the ledger migration?"' >&2
     return 1
   fi
-  json=$(_graphiti_facts "$1" 10) || {
-    echo "  no usable response from $GRAPHITI_URL/search — is the service up? try: health" >&2
-    return 1
-  }
+  # _graphiti_facts has already said what went wrong.
+  json=$(_graphiti_facts "$1" 10) || return 1
   out=$(printf '%s' "$json" | jq -r '
     (.facts | map(select(.valid_at != null))) as $dated
     | if (.facts | length) == 0 then "  (no facts matched)"
@@ -173,10 +243,8 @@ timeline() {
     echo '  usage: timeline "leads the payments"' >&2
     return 1
   fi
-  json=$(_graphiti_facts "$1" 50) || {
-    echo "  no usable response from $GRAPHITI_URL/search — is the service up? try: health" >&2
-    return 1
-  }
+  # _graphiti_facts has already said what went wrong.
+  json=$(_graphiti_facts "$1" 50) || return 1
   out=$(printf '%s' "$json" | jq -r --arg pat "$1" '
     .facts | map(select(.fact | test($pat; "i"))) | unique_by(.fact) | sort_by(.valid_at)
     | if length == 0 then ["  (no facts match \($pat))"] | .[]
@@ -213,16 +281,14 @@ watch_ingest() {
   # Consume --force before reading the query, or it would become the query.
   [ "$1" = '--force' ] && { force=1; shift; }
   local query="${1:-$GRAPHITI_QUERY}"
-  local t0 last count stable=0 elapsed baseline
+  local t0 last count stable=0 elapsed baseline json
   t0=$(date +%s)
 
-  baseline=$(_graphiti_count "$query")
-  # Without a baseline there is no way to tell new facts from old ones, so stop
-  # rather than poll against an unknown starting point.
-  if [ -z "$baseline" ]; then
-    echo "  no usable response from $GRAPHITI_URL/search — is the service up? try: health" >&2
-    return 1
-  fi
+  # Via _graphiti_facts, not the silent _graphiti_count: without a baseline there is no
+  # telling new facts from old, so this is the point to stop and say why — a rejected key
+  # surfaces here rather than as three minutes of polling that never moves.
+  json=$(_graphiti_facts "$query" 50) || return 1
+  baseline=$(printf '%s' "$json" | jq '.facts | length')
   # Refuse rather than poll for three minutes and time out: on a populated group
   # the count legitimately may never move, so there is nothing to wait for.
   if [ "$baseline" -gt 0 ] && [ -z "$force" ]; then

--- a/examples/render/demo.sh
+++ b/examples/render/demo.sh
@@ -11,7 +11,12 @@
 #   watch_ingest            follow the ingestion queue draining
 #   ask "who owns X?"       the current answer, one line
 #   timeline "leads the"    every version of that fact, oldest first
-#   clear_group             delete everything in the current group
+#
+# There is deliberately no clear helper. DELETE /group and POST /clear return
+# {"success": true} on this deployment and delete nothing — they query the default
+# graph while the data lives in a graph named after the group_id. To actually erase a
+# group, open a shell on graphiti-falkordb and run `redis-cli GRAPH.DELETE <group>`;
+# to start clean without deleting anything, just `use_group` a new name.
 #
 # Every command is one word with no quoting or line continuations, because a
 # multi-line curl that loses its -H flag mid-paste sends the body without a JSON
@@ -41,8 +46,7 @@ unset _graphiti_sourced
 
 : "${GRAPHITI_URL:?set GRAPHITI_URL first, e.g. export GRAPHITI_URL=https://graphiti-api.onrender.com}"
 : "${GRAPHITI_GROUP:=demo}"
-# The default search string, shared by watch_ingest and clear_group so the fact
-# counts they report are counts of the same thing.
+# The default search string watch_ingest counts facts against.
 : "${GRAPHITI_QUERY:=payments team ledger migration}"
 
 command -v jq >/dev/null || echo 'demo.sh: jq not found — brew install jq'
@@ -97,23 +101,6 @@ ingest() {
     *) jq -c . "$body" 2>/dev/null || cat "$body" ;;
   esac
   rm -f "$tmp" "$body"
-}
-
-# Delete everything in the current group, then report what is left rather than
-# assuming. Named clear_group, not reset or clear, both of which are real
-# terminal commands.
-#
-# Only removes what is in the graph now: anything still on the ingestion queue
-# lands afterwards, so a fresh use_group is the more reliable reset.
-clear_group() {
-  local code left
-  code=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE "$GRAPHITI_URL/group/$GRAPHITI_GROUP")
-  case "$code" in
-    2*) ;;
-    *) printf '  delete failed on group %s (HTTP %s)\n' "$GRAPHITI_GROUP" "$code" >&2; return 1 ;;
-  esac
-  left=$(_graphiti_count "$GRAPHITI_QUERY")
-  printf '  cleared group %s (now %s facts)\n' "$GRAPHITI_GROUP" "${left:-?}"
 }
 
 # POST /search and emit the raw JSON. $1 query, $2 max_facts (default 10).
@@ -242,7 +229,8 @@ watch_ingest() {
     echo "  group '$GRAPHITI_GROUP' already holds $baseline facts — nothing to watch," >&2
     echo "  since a re-ingest dedupes into them and the count never moves." >&2
     echo "  Start a clean take:  use_group take2 && ingest && watch_ingest" >&2
-    echo "  Or clear this one:   clear_group && ingest && watch_ingest" >&2
+    echo "  (Emptying this group instead needs redis-cli GRAPH.DELETE on" >&2
+    echo "   graphiti-falkordb — the HTTP delete endpoints don't work here.)" >&2
     return 1
   fi
 

--- a/examples/render/demo.sh
+++ b/examples/render/demo.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# Demo helpers for a deployed Graphiti API. Source it, don't run it:
+#
+#   export GRAPHITI_URL=https://your-service.onrender.com
+#   source examples/render/demo.sh
+#
+# Then:
+#   use_group take1         point everything at a group, one take per group
+#   health                  is the service up
+#   ingest                  POST the sample episode into the current group
+#   watch_ingest            follow the ingestion queue draining
+#   ask "who owns X?"       the current answer, one line
+#   timeline "leads the"    every version of that fact, oldest first
+#   clear_group             delete everything in the current group
+#
+# Every command is one word with no quoting or line continuations, because a
+# multi-line curl that loses its -H flag mid-paste sends the body without a JSON
+# content type and the API replies 422 about a string it can't read as an object.
+#
+# These wrap POST /search and /messages and project the response down to the
+# interesting fields. The raw endpoints return uuid/created_at/expired_at too —
+# see $GRAPHITI_URL/docs for the full shape.
+
+# Executing this file would define the functions in a subshell that exits
+# immediately, so catch that and say so rather than appearing to do nothing.
+# zsh needs its own test: ZSH_VERSION being set says nothing about how the file
+# was loaded, so `zsh demo.sh` would slip past a bash-only check. ZSH_EVAL_CONTEXT
+# gains a :file component when sourced and stays at toplevel when executed.
+_graphiti_sourced=0
+if [ -n "$ZSH_VERSION" ]; then
+  case "$ZSH_EVAL_CONTEXT" in *:file*) _graphiti_sourced=1 ;; esac
+elif [ -n "$BASH_VERSION" ]; then
+  [ "${BASH_SOURCE[0]}" != "$0" ] && _graphiti_sourced=1
+fi
+if [ "$_graphiti_sourced" = 0 ]; then
+  echo 'demo.sh defines shell functions, so it has to be sourced:' >&2
+  echo '  source examples/render/demo.sh' >&2
+  exit 1
+fi
+unset _graphiti_sourced
+
+: "${GRAPHITI_URL:?set GRAPHITI_URL first, e.g. export GRAPHITI_URL=https://graphiti-api.onrender.com}"
+: "${GRAPHITI_GROUP:=demo}"
+# The default search string, shared by watch_ingest and clear_group so the fact
+# counts they report are counts of the same thing.
+: "${GRAPHITI_QUERY:=payments team ledger migration}"
+
+command -v jq >/dev/null || echo 'demo.sh: jq not found — brew install jq'
+
+# Where the sample episode lives, resolved once at source time so the helpers
+# work from any directory afterwards.
+GRAPHITI_EPISODE="${GRAPHITI_EPISODE:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/sample-episode.json}"
+
+# Point every helper at a group. One group per take: re-ingesting into a group
+# that already holds facts dedupes into them, so nothing visibly happens.
+# Named use_group rather than take because oh-my-zsh already defines take.
+use_group() {
+  if [ -z "$1" ]; then
+    echo '  usage: use_group take2' >&2
+    return 1
+  fi
+  # The name goes into the DELETE /group/{id} path unencoded, so a slash would
+  # silently address a different route and a space would break the URL outright.
+  case "$1" in
+    *[!A-Za-z0-9._-]*)
+      echo "  '$1' won't work as a group name — use letters, digits, . _ or - only" >&2
+      return 1 ;;
+  esac
+  GRAPHITI_GROUP="$1"
+  echo "  group: $GRAPHITI_GROUP"
+}
+
+health() {
+  curl -sS -o /dev/null -w '  healthcheck → HTTP %{http_code} in %{time_total}s\n' \
+    "$GRAPHITI_URL/healthcheck"
+}
+
+# Rewrite the sample episode's group_id to match $GRAPHITI_GROUP and POST it.
+# --data-binary rather than -d: -d strips newlines, which is harmless for JSON
+# but makes the payload unreadable if you ever need to echo it back.
+ingest() {
+  local file="${1:-$GRAPHITI_EPISODE}" tmp body code
+  [ -f "$file" ] || { echo "  no episode file at $file" >&2; return 1; }
+  # An explicit XXXXXX template: macOS accepts a bare prefix after -t, GNU and
+  # BusyBox mktemp reject it, so -t alone would break the helper on Linux.
+  tmp=$(mktemp "${TMPDIR:-/tmp}/graphiti-episode.XXXXXX") || return 1
+  body=$(mktemp "${TMPDIR:-/tmp}/graphiti-ingest.XXXXXX") || { rm -f "$tmp"; return 1; }
+  jq --arg g "$GRAPHITI_GROUP" '.group_id = $g' "$file" > "$tmp" || { rm -f "$tmp" "$body"; return 1; }
+  code=$(curl -sS -o "$body" -w '%{http_code} %{time_total}' \
+    -X POST "$GRAPHITI_URL/messages" \
+    -H 'Content-Type: application/json' \
+    --data-binary @"$tmp")
+  printf '  ingest → HTTP %s in %ss (group %s)\n' "${code% *}" "${code#* }" "$GRAPHITI_GROUP"
+  # A 202 body is just an ack, so only surface it when something went wrong.
+  case "${code% *}" in
+    2*) ;;
+    *) jq -c . "$body" 2>/dev/null || cat "$body" ;;
+  esac
+  rm -f "$tmp" "$body"
+}
+
+# Delete everything in the current group, then report what is left rather than
+# assuming. Named clear_group, not reset or clear, both of which are real
+# terminal commands.
+#
+# Only removes what is in the graph now: anything still on the ingestion queue
+# lands afterwards, so a fresh use_group is the more reliable reset.
+clear_group() {
+  local code left
+  code=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE "$GRAPHITI_URL/group/$GRAPHITI_GROUP")
+  case "$code" in
+    2*) ;;
+    *) printf '  delete failed on group %s (HTTP %s)\n' "$GRAPHITI_GROUP" "$code" >&2; return 1 ;;
+  esac
+  left=$(_graphiti_count "$GRAPHITI_QUERY")
+  printf '  cleared group %s (now %s facts)\n' "$GRAPHITI_GROUP" "${left:-?}"
+}
+
+# POST /search and emit the raw JSON. $1 query, $2 max_facts (default 10).
+_graphiti_search() {
+  curl -s -X POST "$GRAPHITI_URL/search" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg g "$GRAPHITI_GROUP" --arg q "$1" --argjson n "${2:-10}" \
+          '{group_ids: [$g], query: $q, max_facts: $n}')"
+}
+
+# How many facts the current group returns for $1, or empty if the service did
+# not answer with usable JSON. Callers must handle empty: a cold start or a 502
+# yields no output, and feeding that to [ ] produces "integer expression
+# expected" instead of anything a reader can act on.
+_graphiti_count() {
+  _graphiti_search "$1" 50 | jq -e '.facts | length' 2>/dev/null
+}
+
+# Emit the search response only if it is JSON with a facts array, so callers can
+# tell "the service is down" from "the graph knows nothing" and say which.
+# $1 query, $2 max_facts.
+_graphiti_facts() {
+  local json
+  json=$(_graphiti_search "$1" "${2:-10}")
+  printf '%s' "$json" | jq -e 'has("facts")' >/dev/null 2>&1 || return 1
+  printf '%s' "$json"
+}
+
+# The current answer, on one line, rendered as the graph edge it came from so it
+# reads the same as timeline output. /search returns facts in relevance order, so
+# narrow to the newest valid_at first and then keep the most relevant of those:
+# sorting on valid_at alone tie-breaks arbitrarily between same-day facts and can
+# answer a different question than the one asked.
+ask() {
+  local out json
+  if [ -z "$1" ]; then
+    echo '  usage: ask "who owns the ledger migration?"' >&2
+    return 1
+  fi
+  json=$(_graphiti_facts "$1" 10) || {
+    echo "  no usable response from $GRAPHITI_URL/search — is the service up? try: health" >&2
+    return 1
+  }
+  out=$(printf '%s' "$json" | jq -r '
+    (.facts | map(select(.valid_at != null))) as $dated
+    | if (.facts | length) == 0 then "  (no facts matched)"
+      elif ($dated | length) == 0 then "  ──\(.facts[0].name)──▶  \(.facts[0].fact)  (undated)"
+      else ($dated | map(.valid_at) | max) as $newest
+           | $dated | map(select(.valid_at == $newest)) | .[0]
+           | "  ──\(.name)──▶  \(.fact)  (as of \(.valid_at[0:10]))"
+      end' 2>/dev/null)
+  [ -n "$out" ] || { echo '  (no facts matched)'; return 0; }
+  printf '%s\n' "$out"
+}
+
+# Every version of a fact, oldest first, as the graph edge behind it: the
+# relationship label and the window the edge is valid for. $1 is a regex matched
+# against fact text. unique_by guards against the same episode having been
+# ingested twice. Named timeline, not history, so it doesn't shadow the builtin.
+#
+# This stops short of drawing (Alex) ──LEADS──▶ (payments team) because /search
+# returns no node names: FactResult has the edge label and text but not the
+# edge's two endpoints, and the API exposes no node getter to resolve them. For
+# real endpoints, add source/target to FactResult in
+# server/graph_service/dto/retrieve.py and resolve the names in
+# get_fact_result_from_edge.
+timeline() {
+  local out json
+  if [ -z "$1" ]; then
+    echo '  usage: timeline "leads the payments"' >&2
+    return 1
+  fi
+  json=$(_graphiti_facts "$1" 50) || {
+    echo "  no usable response from $GRAPHITI_URL/search — is the service up? try: health" >&2
+    return 1
+  }
+  out=$(printf '%s' "$json" | jq -r --arg pat "$1" '
+    .facts | map(select(.fact | test($pat; "i"))) | unique_by(.fact) | sort_by(.valid_at)
+    | if length == 0 then ["  (no facts match \($pat))"] | .[]
+      else .[]
+        | (if .valid_at then .valid_at[0:10] else "undated   " end) as $from
+        # Only claim an end date when the edge actually carries one. Printing
+        # "→ now" for a null invalid_at asserts the superseded fact is still
+        # live, which contradicts the fact that replaced it.
+        | (if .invalid_at then " → \(.invalid_at[0:10])" else "" end) as $to
+        | "  \($from)\($to)  ──\(.name)──▶  \(.fact)"
+      end' 2>/dev/null)
+  # The service answered, so empty output here means jq itself failed — and the
+  # only way that happens is an invalid regex in $1, since a zero-match search
+  # takes the length == 0 branch above and prints its own line.
+  if [ -z "$out" ]; then
+    echo "  '$1' is not a valid regex — try plain words:" >&2
+    echo '    timeline "leads the payments"' >&2
+    return 1
+  fi
+  printf '%s\n' "$out"
+}
+
+# Poll until the fact count stops changing. Prints only when it moves, so the
+# output stays short. Ingestion is serial and LLM-bound, so expect ~30s for the
+# three-message sample.
+#
+# The count has to rise above whatever the group already held, not just above
+# zero: re-ingesting into a group that still has the previous run's facts
+# dedupes into them, so the count can sit flat at its starting value and the
+# watcher would otherwise declare victory on the *old* data. Start each take in
+# an empty group.
+watch_ingest() {
+  local force=''
+  # Consume --force before reading the query, or it would become the query.
+  [ "$1" = '--force' ] && { force=1; shift; }
+  local query="${1:-$GRAPHITI_QUERY}"
+  local t0 last count stable=0 elapsed baseline
+  t0=$(date +%s)
+
+  baseline=$(_graphiti_count "$query")
+  # Without a baseline there is no way to tell new facts from old ones, so stop
+  # rather than poll against an unknown starting point.
+  if [ -z "$baseline" ]; then
+    echo "  no usable response from $GRAPHITI_URL/search — is the service up? try: health" >&2
+    return 1
+  fi
+  # Refuse rather than poll for three minutes and time out: on a populated group
+  # the count legitimately may never move, so there is nothing to wait for.
+  if [ "$baseline" -gt 0 ] && [ -z "$force" ]; then
+    echo "  group '$GRAPHITI_GROUP' already holds $baseline facts — nothing to watch," >&2
+    echo "  since a re-ingest dedupes into them and the count never moves." >&2
+    echo "  Start a clean take:  use_group take2 && ingest && watch_ingest" >&2
+    echo "  Or clear this one:   clear_group && ingest && watch_ingest" >&2
+    return 1
+  fi
+
+  last=-1
+  while true; do
+    count=$(_graphiti_count "$query")
+    # A dropped poll is not a change in the graph. Carry the last known count
+    # forward, or a blip would reset the stability counter and stall the watcher.
+    [ -n "$count" ] || count=$last
+    elapsed=$(( $(date +%s) - t0 ))
+    if [ "$count" != "$last" ]; then
+      printf '  t=%-6s facts in graph: %s\n' "${elapsed}s" "$count"
+      last=$count
+      stable=0
+    else
+      stable=$(( stable + 1 ))
+    fi
+    # Episodes are processed one at a time, and the gap between one finishing and
+    # the next producing facts runs to ~22s, so a short plateau is not the end of
+    # the queue — it is the middle of it. 8 polls x 4s = 32s of no movement gives
+    # enough margin; anything less declares victory on a half-built graph and the
+    # answers come out of date.
+    [ "$stable" -ge 8 ] && [ "$count" -gt "$baseline" ] && break
+    # Timing out is a failure, not a finish — don't follow it with "done", which
+    # would read as a successful drain in the recording.
+    if [ "$elapsed" -gt 180 ]; then
+      printf '  gave up after 180s at %s facts (started from %s)\n' "$count" "$baseline" >&2
+      return 1
+    fi
+    sleep 4
+  done
+  printf '  done in %ss\n' "$(( $(date +%s) - t0 ))"
+}

--- a/examples/render/sample-episode.json
+++ b/examples/render/sample-episode.json
@@ -1,0 +1,29 @@
+{
+  "group_id": "demo",
+  "messages": [
+    {
+      "name": "kickoff",
+      "role_type": "user",
+      "role": "alex",
+      "timestamp": "2026-05-04T14:00:00Z",
+      "content": "I'm Alex, I lead the payments team at Acme. We're migrating our billing service off Stripe Billing and onto our own ledger by the end of Q3.",
+      "source_description": "Render template sample episode"
+    },
+    {
+      "name": "kickoff-reply",
+      "role_type": "assistant",
+      "role": "assistant",
+      "timestamp": "2026-05-04T14:01:00Z",
+      "content": "Got it. So Alex leads the payments team at Acme, and the ledger migration is due end of Q3.",
+      "source_description": "Render template sample episode"
+    },
+    {
+      "name": "handover",
+      "role_type": "user",
+      "role": "alex",
+      "timestamp": "2026-07-13T10:15:00Z",
+      "content": "Update: I've moved to the infrastructure team. Priya now leads the payments team at Acme, and she owns the ledger migration.",
+      "source_description": "Render template sample episode"
+    }
+  ]
+}

--- a/render.yaml
+++ b/render.yaml
@@ -67,11 +67,12 @@ projects:
               - key: GRAPHITI_API_KEY
                 generateValue: true
 
-              # The Dockerfile's CMD binds uvicorn to 8000 rather than reading $PORT, so
-              # tell Render the same number up front. Without this it starts out expecting
-              # its default 10000, discovers 8000, and restarts the deploy to rewire the
-              # network — a slower first deploy and a "Restarting deploy" line that reads
-              # like a failure. Keep in step with the CMD and docker-compose.yml.
+              # The port uvicorn binds to, and the one Render routes to. Declared rather
+              # than left to Render's detection: without it Render starts out expecting its
+              # default 10000, discovers the real port, and restarts the deploy to rewire
+              # the network — a slower first deploy and a "Restarting deploy" line that
+              # reads like a failure. Safe to change, as the Dockerfile's CMD passes this
+              # through to uvicorn; nothing else has to be edited to match.
               - key: PORT
                 value: '8000'
 

--- a/render.yaml
+++ b/render.yaml
@@ -3,11 +3,12 @@
 # graphiti-api      public REST service, built from the repo's root Dockerfile
 # graphiti-falkordb the graph store, private: reachable only from graphiti-api
 #
-# Secrets are never written here. OPENAI_API_KEY is declared sync: false, so Render
-# prompts for it at deploy time and stores it outside the repo.
+# No secrets here: OPENAI_API_KEY is sync: false, so Render prompts at deploy time.
 
 previews:
-  generation: off
+  # Quoted, because bare off is a YAML boolean and the schema types this field as a string
+  # enum — unquoted it fails `render blueprints validate`.
+  generation: 'off'
 
 projects:
   - name: graphiti
@@ -18,12 +19,10 @@ projects:
             name: graphiti-falkordb
             runtime: image
             region: oregon
-            # FalkorDB keeps the whole graph in RAM and only writes the append-only file
-            # to disk, so this plan is the real ceiling on graph size. Standard (2 GB) is
-            # the smallest that leaves room to grow; the disk below just has to outlast it.
+            # FalkorDB keeps the whole graph in RAM, so the plan is the real ceiling on
+            # graph size. Standard (2 GB) is the smallest with room to grow.
             plan: standard
-            # Pinned, not :latest — every fork deploys this exact version, so an upstream
-            # bump can't break new deploys out from under you. Bump it deliberately.
+            # Pinned, not :latest, so an upstream bump can't break new deploys.
             image:
               url: docker.io/falkordb/falkordb:v4.20.1
             disk:
@@ -34,9 +33,8 @@ projects:
               # Append-only file, so the graph survives a restart or redeploy.
               - key: REDIS_ARGS
                 value: --appendonly yes
-              # The image otherwise also serves the FalkorDB Browser UI on :3000. Nothing
-              # uses it here, and leaving it on gives Render's port scanner a second port
-              # to choose from. Off, so 6379 is the only thing listening.
+              # The image also serves the FalkorDB Browser on :3000. Unused here, and off
+              # leaves 6379 as the only port Render's scanner can pick.
               - key: BROWSER
                 value: '0'
 
@@ -44,46 +42,40 @@ projects:
             name: graphiti-api
             runtime: docker
             region: oregon
-            # The API idles near 100 MB and spends most of each request waiting on OpenAI,
-            # so it needs far less than the graph store does.
+            # The API idles near 100 MB and spends most of each request waiting on OpenAI.
             plan: starter
             dockerfilePath: ./Dockerfile
             dockerContext: .
             healthCheckPath: /healthcheck
             envVars:
-              # Declared on the service, not in an env var group: sync: false is silently
-              # ignored inside a group, so Render would never prompt for the value.
+              # On the service, not in an env var group: sync: false is silently ignored
+              # inside a group, so Render would never prompt for the value.
               - key: OPENAI_API_KEY
                 sync: false
 
-              # Bearer token for every endpoint except /healthcheck, and the server will not
-              # start without it, so a fork is closed from the moment it goes live. Read the
-              # value from the Dashboard (Environment tab) after the first deploy.
+              # Bearer token for every endpoint except /healthcheck; the server won't start
+              # without it, so a fork is closed from the moment it goes live. Read the value
+              # from the Dashboard (Environment tab) after the first deploy.
               #
-              # generateValue rather than sync: false keeps the one-click path one click.
-              # Generated once and persistent across syncs, so rotation is a manual edit here or
-              # in the Dashboard; a replacement must be 16+ printable-ASCII characters or the
-              # service refuses to start — see graph_service/config.py.
+              # generateValue rather than sync: false keeps the one-click path one click. It
+              # persists across syncs, so rotation is a manual edit here or in the Dashboard;
+              # a replacement must be 16+ printable-ASCII characters (see config.py).
               - key: GRAPHITI_API_KEY
                 generateValue: true
 
-              # The port uvicorn binds to, and the one Render routes to. Declared rather
-              # than left to Render's detection: without it Render starts out expecting its
-              # default 10000, discovers the real port, and restarts the deploy to rewire
-              # the network — a slower first deploy and a "Restarting deploy" line that
-              # reads like a failure. Safe to change, as the Dockerfile's CMD passes this
-              # through to uvicorn; nothing else has to be edited to match.
+              # The port uvicorn binds to and the one Render routes to. Declared so the first
+              # deploy doesn't start on Render's default 10000, detect the real port, and
+              # restart to rewire the network. Safe to change: the CMD passes it through.
               - key: PORT
                 value: '8000'
 
-              # Render exposes env vars to the Docker build as build args, which is how
-              # the root Dockerfile picks up the graphiti-core FalkorDB extra.
+              # Render passes env vars to the Docker build as build args, which is how the
+              # root Dockerfile picks up the graphiti-core FalkorDB extra.
               - key: INSTALL_FALKORDB
                 value: 'true'
-              # The graphiti-core version is deliberately not set here. It is pinned once,
-              # as the GRAPHITI_VERSION build arg default in the Dockerfile, so a bump is
-              # a one-line change rather than three configs to keep in step. Setting it
-              # here would override that pin for this service only.
+              # GRAPHITI_VERSION is deliberately unset: it's pinned once as the Dockerfile's
+              # build-arg default, so a bump is one line. Setting it here overrides that pin
+              # for this service only.
 
               - key: DB_BACKEND
                 value: falkordb
@@ -100,8 +92,7 @@ projects:
               # The model Graphiti uses to extract entities and facts. Any OpenAI model id.
               - key: MODEL_NAME
                 value: gpt-5.5
-              # Concurrent LLM calls during ingestion. Held below graphiti-core's default
-              # of 20 so a burst of episodes doesn't trip OpenAI rate limits on a new key.
-              # Raise it once you know your account's limits.
+              # Concurrent LLM calls during ingestion. Below graphiti-core's default of 20 so
+              # a burst of episodes doesn't trip rate limits on a new OpenAI key.
               - key: SEMAPHORE_LIMIT
                 value: '10'

--- a/render.yaml
+++ b/render.yaml
@@ -56,6 +56,14 @@ projects:
               - key: OPENAI_API_KEY
                 sync: false
 
+              # The Dockerfile's CMD binds uvicorn to 8000 rather than reading $PORT, so
+              # tell Render the same number up front. Without this it starts out expecting
+              # its default 10000, discovers 8000, and restarts the deploy to rewire the
+              # network — a slower first deploy and a "Restarting deploy" line that reads
+              # like a failure. Keep in step with the CMD and docker-compose.yml.
+              - key: PORT
+                value: '8000'
+
               # Render exposes env vars to the Docker build as build args, which is how
               # the root Dockerfile picks up the graphiti-core FalkorDB extra.
               - key: INSTALL_FALKORDB

--- a/render.yaml
+++ b/render.yaml
@@ -56,6 +56,17 @@ projects:
               - key: OPENAI_API_KEY
                 sync: false
 
+              # Bearer token for every endpoint except /healthcheck, and the server will not
+              # start without it, so a fork is closed from the moment it goes live. Read the
+              # value from the Dashboard (Environment tab) after the first deploy.
+              #
+              # generateValue rather than sync: false keeps the one-click path one click.
+              # Generated once and persistent across syncs, so rotation is a manual edit here or
+              # in the Dashboard; a replacement must be 16+ printable-ASCII characters or the
+              # service refuses to start — see graph_service/config.py.
+              - key: GRAPHITI_API_KEY
+                generateValue: true
+
               # The Dockerfile's CMD binds uvicorn to 8000 rather than reading $PORT, so
               # tell Render the same number up front. Without this it starts out expecting
               # its default 10000, discovers 8000, and restarts the deploy to rewire the

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,94 @@
+# Graphiti on Render — a temporal knowledge graph API backed by FalkorDB.
+#
+# graphiti-api      public REST service, built from the repo's root Dockerfile
+# graphiti-falkordb the graph store, private: reachable only from graphiti-api
+#
+# Secrets are never written here. OPENAI_API_KEY is declared sync: false, so Render
+# prompts for it at deploy time and stores it outside the repo.
+
+previews:
+  generation: off
+
+projects:
+  - name: graphiti
+    environments:
+      - name: production
+        services:
+          - type: pserv
+            name: graphiti-falkordb
+            runtime: image
+            region: oregon
+            # FalkorDB keeps the whole graph in RAM and only writes the append-only file
+            # to disk, so this plan is the real ceiling on graph size. Standard (2 GB) is
+            # the smallest that leaves room to grow; the disk below just has to outlast it.
+            plan: standard
+            # Pinned, not :latest — every fork deploys this exact version, so an upstream
+            # bump can't break new deploys out from under you. Bump it deliberately.
+            image:
+              url: docker.io/falkordb/falkordb:v4.20.1
+            disk:
+              name: falkordb-data
+              mountPath: /var/lib/falkordb/data
+              sizeGB: 10
+            envVars:
+              # Append-only file, so the graph survives a restart or redeploy.
+              - key: REDIS_ARGS
+                value: --appendonly yes
+              # The image otherwise also serves the FalkorDB Browser UI on :3000. Nothing
+              # uses it here, and leaving it on gives Render's port scanner a second port
+              # to choose from. Off, so 6379 is the only thing listening.
+              - key: BROWSER
+                value: '0'
+
+          - type: web
+            name: graphiti-api
+            runtime: docker
+            region: oregon
+            # The API idles near 100 MB and spends most of each request waiting on OpenAI,
+            # so it needs far less than the graph store does.
+            plan: starter
+            dockerfilePath: ./Dockerfile
+            dockerContext: .
+            healthCheckPath: /healthcheck
+            envVars:
+              # Declared on the service, not in an env var group: sync: false is silently
+              # ignored inside a group, so Render would never prompt for the value.
+              - key: OPENAI_API_KEY
+                sync: false
+
+              # Render exposes env vars to the Docker build as build args, which is how
+              # the root Dockerfile picks up the graphiti-core FalkorDB extra.
+              - key: INSTALL_FALKORDB
+                value: 'true'
+              # Pinned for the same reason the FalkorDB image is: left unset, the
+              # Dockerfile installs whatever graphiti-core is newest at build time, so two
+              # forks deployed a month apart run different libraries.
+              #
+              # This is the graphiti-core release to install from PyPI. It is not the same
+              # number as this repo's own version in pyproject.toml, and 0.29.2 in
+              # particular does not work here: on FalkorDB it writes episodes fine but
+              # reads them back empty, so /search and /episodes return nothing. Verify a
+              # round trip before bumping this.
+              - key: GRAPHITI_VERSION
+                value: 0.29.3
+
+              - key: DB_BACKEND
+                value: falkordb
+              - key: FALKORDB_HOST
+                fromService:
+                  name: graphiti-falkordb
+                  type: pserv
+                  property: host
+              - key: FALKORDB_PORT
+                value: '6379'
+              - key: FALKORDB_DATABASE
+                value: default_db
+
+              # The model Graphiti uses to extract entities and facts. Any OpenAI model id.
+              - key: MODEL_NAME
+                value: gpt-5.5
+              # Concurrent LLM calls during ingestion. Held below graphiti-core's default
+              # of 20 so a burst of episodes doesn't trip OpenAI rate limits on a new key.
+              # Raise it once you know your account's limits.
+              - key: SEMAPHORE_LIMIT
+                value: '10'

--- a/render.yaml
+++ b/render.yaml
@@ -60,17 +60,10 @@ projects:
               # the root Dockerfile picks up the graphiti-core FalkorDB extra.
               - key: INSTALL_FALKORDB
                 value: 'true'
-              # Pinned for the same reason the FalkorDB image is: left unset, the
-              # Dockerfile installs whatever graphiti-core is newest at build time, so two
-              # forks deployed a month apart run different libraries.
-              #
-              # This is the graphiti-core release to install from PyPI. It is not the same
-              # number as this repo's own version in pyproject.toml, and 0.29.2 in
-              # particular does not work here: on FalkorDB it writes episodes fine but
-              # reads them back empty, so /search and /episodes return nothing. Verify a
-              # round trip before bumping this.
-              - key: GRAPHITI_VERSION
-                value: 0.29.3
+              # The graphiti-core version is deliberately not set here. It is pinned once,
+              # as the GRAPHITI_VERSION build arg default in the Dockerfile, so a bump is
+              # a one-line change rather than three configs to keep in step. Setting it
+              # here would override that pin for this service only.
 
               - key: DB_BACKEND
                 value: falkordb

--- a/server/graph_service/auth.py
+++ b/server/graph_service/auth.py
@@ -1,8 +1,8 @@
 """Bearer-token auth for the graph endpoints.
 
 Every endpoint except /healthcheck requires GRAPHITI_API_KEY, with no way to switch it off: the
-API writes to a shared graph and spends the deployment's OpenAI key on every episode. config.py
-requires the key at startup, so this module can assume there is one.
+API writes to a shared graph and spends the deployment's OpenAI key. config.py requires the key
+at startup, so this module can assume there is one.
 """
 
 import hashlib
@@ -16,22 +16,22 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from graph_service.config import ZepEnvDep
 
-# auto_error=False so a missing or non-Bearer header arrives as None: HTTPBearer answers 403 on
-# its own, and the right answer is a 401 naming the scheme to retry with.
+# auto_error=False so a missing or non-Bearer header arrives as None: HTTPBearer would answer 403
+# on its own, and the right answer is a 401 naming the scheme to retry with.
 _bearer = HTTPBearer(auto_error=False, description='The GRAPHITI_API_KEY set on this service.')
 
 # Rejections allowed per window before answering 429, so the key can't be worked through.
 #
 # Global, not per-IP: behind Render's proxy every request carries the proxy's address, and
-# trusting X-Forwarded-For would hand an attacker the bucket key. It can't lock out a real client
+# trusting X-Forwarded-For would hand an attacker the bucket key. It can't lock out a real client,
 # because require_api_key checks the key before the budget. In-process, so N instances allow N
 # times this — a shared counter would put FalkorDB on the auth path.
 MAX_FAILED_AUTH = 10
 FAILED_AUTH_WINDOW_SECONDS = 60
 
-# The last MAX_FAILED_AUTH rejection times, oldest first. maxlen does the eviction, so the budget
-# is spent exactly when the deque is full and its oldest entry is still in the window. monotonic,
-# so an NTP correction can't resize the window. No lock: single event loop.
+# The last MAX_FAILED_AUTH rejection times, oldest first, so the budget is spent exactly when the
+# deque is full and its oldest entry is still in the window. monotonic, so an NTP correction can't
+# resize the window. No lock: single event loop.
 _recent_rejections: deque[float] = deque(maxlen=MAX_FAILED_AUTH)
 
 

--- a/server/graph_service/auth.py
+++ b/server/graph_service/auth.py
@@ -1,0 +1,85 @@
+"""Bearer-token auth for the graph endpoints.
+
+Every endpoint except /healthcheck requires GRAPHITI_API_KEY, with no way to switch it off: the
+API writes to a shared graph and spends the deployment's OpenAI key on every episode. config.py
+requires the key at startup, so this module can assume there is one.
+"""
+
+import hashlib
+import secrets
+import time
+from collections import deque
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from graph_service.config import ZepEnvDep
+
+# auto_error=False so a missing or non-Bearer header arrives as None: HTTPBearer answers 403 on
+# its own, and the right answer is a 401 naming the scheme to retry with.
+_bearer = HTTPBearer(auto_error=False, description='The GRAPHITI_API_KEY set on this service.')
+
+# Rejections allowed per window before answering 429, so the key can't be worked through.
+#
+# Global, not per-IP: behind Render's proxy every request carries the proxy's address, and
+# trusting X-Forwarded-For would hand an attacker the bucket key. It can't lock out a real client
+# because require_api_key checks the key before the budget. In-process, so N instances allow N
+# times this — a shared counter would put FalkorDB on the auth path.
+MAX_FAILED_AUTH = 10
+FAILED_AUTH_WINDOW_SECONDS = 60
+
+# The last MAX_FAILED_AUTH rejection times, oldest first. maxlen does the eviction, so the budget
+# is spent exactly when the deque is full and its oldest entry is still in the window. monotonic,
+# so an NTP correction can't resize the window. No lock: single event loop.
+_recent_rejections: deque[float] = deque(maxlen=MAX_FAILED_AUTH)
+
+
+def _seconds_until_budget_frees(now: float) -> float | None:
+    """Time until the next rejection is allowed, or None if it already is.
+
+    Positive only when the budget is spent, so it serves as both the check and Retry-After.
+    """
+    if len(_recent_rejections) < MAX_FAILED_AUTH:
+        return None
+    elapsed = now - _recent_rejections[0]
+    return FAILED_AUTH_WINDOW_SECONDS - elapsed if elapsed < FAILED_AUTH_WINDOW_SECONDS else None
+
+
+def _digest(value: str) -> bytes:
+    """A fixed-width, constant-time-comparable stand-in for the key.
+
+    Encoded because Starlette decodes headers as latin-1, so this can be any str. Hashed so both
+    sides are 32 bytes: compare_digest returns early on a length mismatch, leaking key length.
+    """
+    return hashlib.sha256(value.encode()).digest()
+
+
+async def require_api_key(
+    settings: ZepEnvDep,
+    credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(_bearer)],
+) -> None:
+    # Before the budget, so the right key is never rate limited — see MAX_FAILED_AUTH.
+    # compare_digest so timing can't leak the key; it needs both sides, hence the guard.
+    if credentials is not None and secrets.compare_digest(
+        _digest(credentials.credentials), _digest(settings.graphiti_api_key)
+    ):
+        return
+
+    now = time.monotonic()
+    retry_after = _seconds_until_budget_frees(now)
+    if retry_after is not None:
+        # Not recorded: counting refused requests would hold the window open under sustained
+        # traffic, so a wrong key would never get its 401 back.
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail='Too many failed authentication attempts. Try again shortly.',
+            headers={'Retry-After': str(int(retry_after) + 1)},  # ceil: never advertise 0s
+        )
+
+    _recent_rejections.append(now)
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail='Invalid or missing API key. Send it as: Authorization: Bearer <GRAPHITI_API_KEY>',
+        headers={'WWW-Authenticate': 'Bearer'},  # required on a 401 by RFC 9110
+    )

--- a/server/graph_service/config.py
+++ b/server/graph_service/config.py
@@ -18,30 +18,29 @@ def _strip(value: Any) -> Any:
     return value.strip() if isinstance(value, str) else value
 
 
-# A .env file and a dashboard UI both make it easy to define a variable with an empty
-# value, which is not the same thing as leaving it out: '' arrives here as a real setting
-# and gets passed on to the clients. A blank model_name would be sent to OpenAI as the
-# model to use, and a blank falkordb_port would fail validation before the app can boot.
+# A .env file and a dashboard UI both make an empty value easy, which is not the same as
+# leaving it out: '' arrives as a real setting and is passed on to the clients. A blank
+# model_name would be sent to OpenAI as the model to use.
 #
-# One case this cannot reach: the OpenAI SDK falls back to reading OPENAI_BASE_URL from
-# the environment when it is handed base_url=None, so a blank OPENAI_BASE_URL still ends
-# up as '' inside the client, and requests go out with no host. Leave it unset, not empty.
+# One case this can't reach: the OpenAI SDK falls back to reading OPENAI_BASE_URL from the
+# environment when handed base_url=None, so a blank one still ends up as '' inside the client
+# and requests go out with no host. Leave it unset, not empty.
 OptionalStr = Annotated[str | None, BeforeValidator(_blank_to_none)]
 OptionalInt = Annotated[int | None, BeforeValidator(_blank_to_none)]
 
-# The same idea for a setting that has to be present: strip first, so whitespace fails min_length
+# Same idea for a setting that has to be present: strip first, so whitespace fails min_length
 # rather than passing as a one-space secret, and a key pasted with a trailing newline survives.
 RequiredStr = Annotated[str, BeforeValidator(_strip)]
 
-# Entropy floor for graphiti_api_key. auth.py's budget stops a stranger working through the
-# keyspace; this stops a key already at the front of it. Named so tests/test_auth.py can pin the
-# boundary against it rather than restating the number.
+# Entropy floor for graphiti_api_key: auth.py's budget stops a stranger working through the
+# keyspace, this stops a key already at the front of it. Named so tests/test_auth.py can pin the
+# boundary without restating the number.
 MIN_API_KEY_LENGTH = 16
 
 
 class Settings(BaseSettings):
-    # Rejected when blank rather than defaulted, so a missing key fails the deploy at
-    # startup instead of turning every background ingestion into a 401 nobody is watching.
+    # Rejected when blank rather than defaulted, so a missing key fails the deploy instead of
+    # turning every background ingestion into a 401 nobody is watching.
     openai_api_key: RequiredStr = Field(min_length=1)
     openai_base_url: OptionalStr = None
     model_name: OptionalStr = None
@@ -54,17 +53,17 @@ class Settings(BaseSettings):
     falkordb_username: OptionalStr = None
     falkordb_password: OptionalStr = None
     falkordb_database: OptionalStr = None
-    # Only these two backends are wired up in zep_graphiti, so a typo should be a startup
-    # error naming the valid values, not a silent fall-through to the Neo4j branch.
+    # Only these two are wired up in zep_graphiti, so a typo should be a startup error naming the
+    # valid values, not a silent fall-through to the Neo4j branch.
     db_backend: Literal['neo4j', 'falkordb'] = 'neo4j'
     # Bearer token for every endpoint except /healthcheck, mandatory: this API writes to a shared
-    # graph and spends openai_api_key on every episode. Missing fails startup, because an open
-    # service and one that 401s everything both look healthy to Render.
+    # graph and spends openai_api_key. Missing fails startup, because an open service and one that
+    # 401s everything both look healthy to Render.
     #
     # Printable ASCII is what survives an HTTP header: values travel as latin-1 and clients
-    # disagree about encoding anything outside it, so a key with an accent authenticates for some
-    # and not others. Enforced here rather than in auth.py so a bad rotation fails the deploy
-    # naming the problem, instead of 401ing the operator who set it.
+    # disagree about anything outside it, so an accented key authenticates for some clients and
+    # not others. Enforced here, not in auth.py, so a bad rotation fails the deploy naming the
+    # problem instead of 401ing the operator who set it.
     #
     # Caveat: pydantic echoes the offending value into the deploy log. Only ever a key that never
     # authenticated, and scrubbing it means catching ValidationError and degrading every other

--- a/server/graph_service/config.py
+++ b/server/graph_service/config.py
@@ -1,23 +1,48 @@
 from functools import lru_cache
-from typing import Annotated
+from typing import Annotated, Any, Literal
 
 from fastapi import Depends
-from pydantic import Field
+from pydantic import BeforeValidator, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict  # type: ignore
 
 
+def _blank_to_none(value: Any) -> Any:
+    """Treat an env var that is set but empty as unset."""
+    if isinstance(value, str) and not value.strip():
+        return None
+    return value
+
+
+# A .env file and a dashboard UI both make it easy to define a variable with an empty
+# value, which is not the same thing as leaving it out: '' arrives here as a real setting
+# and gets passed on to the clients. A blank model_name would be sent to OpenAI as the
+# model to use, and a blank falkordb_port would fail validation before the app can boot.
+#
+# One case this cannot reach: the OpenAI SDK falls back to reading OPENAI_BASE_URL from
+# the environment when it is handed base_url=None, so a blank OPENAI_BASE_URL still ends
+# up as '' inside the client, and requests go out with no host. Leave it unset, not empty.
+OptionalStr = Annotated[str | None, BeforeValidator(_blank_to_none)]
+OptionalInt = Annotated[int | None, BeforeValidator(_blank_to_none)]
+
+
 class Settings(BaseSettings):
-    openai_api_key: str
-    openai_base_url: str | None = Field(None)
-    model_name: str | None = Field(None)
-    embedding_model_name: str | None = Field(None)
-    neo4j_uri: str | None = Field(None)
-    neo4j_user: str | None = Field(None)
-    neo4j_password: str | None = Field(None)
-    falkordb_host: str | None = Field(None)
-    falkordb_port: int | None = Field(None)
-    falkordb_database: str | None = Field(None)
-    db_backend: str = Field('neo4j')
+    # Rejected when blank rather than defaulted, so a missing key fails the deploy at
+    # startup instead of turning every background ingestion into a 401 nobody is watching.
+    openai_api_key: str = Field(min_length=1)
+    openai_base_url: OptionalStr = None
+    model_name: OptionalStr = None
+    embedding_model_name: OptionalStr = None
+    neo4j_uri: OptionalStr = None
+    neo4j_user: OptionalStr = None
+    neo4j_password: OptionalStr = None
+    falkordb_host: OptionalStr = None
+    falkordb_port: OptionalInt = None
+    falkordb_username: OptionalStr = None
+    falkordb_password: OptionalStr = None
+    falkordb_database: OptionalStr = None
+    # Only these two backends are wired up in zep_graphiti, so a typo should be a startup
+    # error naming the valid values, not a silent fall-through to the Neo4j branch.
+    db_backend: Literal['neo4j', 'falkordb'] = 'neo4j'
 
     model_config = SettingsConfigDict(env_file='.env', extra='ignore')
 

--- a/server/graph_service/config.py
+++ b/server/graph_service/config.py
@@ -13,6 +13,11 @@ def _blank_to_none(value: Any) -> Any:
     return value
 
 
+def _strip(value: Any) -> Any:
+    """Trim surrounding whitespace from an env var that has to be present."""
+    return value.strip() if isinstance(value, str) else value
+
+
 # A .env file and a dashboard UI both make it easy to define a variable with an empty
 # value, which is not the same thing as leaving it out: '' arrives here as a real setting
 # and gets passed on to the clients. A blank model_name would be sent to OpenAI as the
@@ -24,11 +29,20 @@ def _blank_to_none(value: Any) -> Any:
 OptionalStr = Annotated[str | None, BeforeValidator(_blank_to_none)]
 OptionalInt = Annotated[int | None, BeforeValidator(_blank_to_none)]
 
+# The same idea for a setting that has to be present: strip first, so whitespace fails min_length
+# rather than passing as a one-space secret, and a key pasted with a trailing newline survives.
+RequiredStr = Annotated[str, BeforeValidator(_strip)]
+
+# Entropy floor for graphiti_api_key. auth.py's budget stops a stranger working through the
+# keyspace; this stops a key already at the front of it. Named so tests/test_auth.py can pin the
+# boundary against it rather than restating the number.
+MIN_API_KEY_LENGTH = 16
+
 
 class Settings(BaseSettings):
     # Rejected when blank rather than defaulted, so a missing key fails the deploy at
     # startup instead of turning every background ingestion into a 401 nobody is watching.
-    openai_api_key: str = Field(min_length=1)
+    openai_api_key: RequiredStr = Field(min_length=1)
     openai_base_url: OptionalStr = None
     model_name: OptionalStr = None
     embedding_model_name: OptionalStr = None
@@ -43,6 +57,19 @@ class Settings(BaseSettings):
     # Only these two backends are wired up in zep_graphiti, so a typo should be a startup
     # error naming the valid values, not a silent fall-through to the Neo4j branch.
     db_backend: Literal['neo4j', 'falkordb'] = 'neo4j'
+    # Bearer token for every endpoint except /healthcheck, mandatory: this API writes to a shared
+    # graph and spends openai_api_key on every episode. Missing fails startup, because an open
+    # service and one that 401s everything both look healthy to Render.
+    #
+    # Printable ASCII is what survives an HTTP header: values travel as latin-1 and clients
+    # disagree about encoding anything outside it, so a key with an accent authenticates for some
+    # and not others. Enforced here rather than in auth.py so a bad rotation fails the deploy
+    # naming the problem, instead of 401ing the operator who set it.
+    #
+    # Caveat: pydantic echoes the offending value into the deploy log. Only ever a key that never
+    # authenticated, and scrubbing it means catching ValidationError and degrading every other
+    # setting's message.
+    graphiti_api_key: RequiredStr = Field(min_length=MIN_API_KEY_LENGTH, pattern=r'^[\x20-\x7e]+$')
 
     model_config = SettingsConfigDict(env_file='.env', extra='ignore')
 

--- a/server/graph_service/main.py
+++ b/server/graph_service/main.py
@@ -1,12 +1,16 @@
+import logging
 from contextlib import asynccontextmanager
 
-from fastapi import Depends, FastAPI
+import openai
+from fastapi import Depends, FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from graph_service.auth import require_api_key
 from graph_service.config import get_settings
 from graph_service.routers import ingest, retrieve
 from graph_service.zep_graphiti import initialize_graphiti, shutdown_graphiti
+
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
@@ -34,3 +38,46 @@ app.include_router(ingest.router, dependencies=[Depends(require_api_key)])
 @app.get('/healthcheck')
 async def healthcheck():
     return JSONResponse(content={'status': 'healthy'}, status_code=200)
+
+
+def _upstream_failure(exc: openai.APIError) -> tuple[int, str]:
+    """Map an OpenAI failure to a status and a message that names what to go and fix.
+
+    Every retrieval endpoint embeds its query before it can search, so an unusable
+    OPENAI_API_KEY surfaces here rather than at ingestion time. Unmapped, it reached the client
+    as a bare 500 `Internal Server Error`, which reads as a bug in the graph query — the actual
+    cause was only in the service logs, and only as a traceback.
+    """
+    if isinstance(exc, openai.RateLimitError):
+        # 429 either way, because OpenAI returns 429 for a real rate limit and for
+        # insufficient_quota alike, and only the caller can tell whether retrying is worth it.
+        # The distinction that matters to the operator is in the message, so pass it through.
+        return 429, (
+            'OpenAI rejected the request: either a rate limit, or the quota on the account '
+            f'behind OPENAI_API_KEY is exhausted. Upstream said: {exc}'
+        )
+
+    if isinstance(exc, openai.AuthenticationError | openai.PermissionDeniedError):
+        # 502, not 401/403: the caller's GRAPHITI_API_KEY was accepted, and echoing OpenAI's
+        # status would tell them to go fix a credential they do not hold.
+        return 502, (
+            "OpenAI rejected this service's credentials. Check that OPENAI_API_KEY is set to a "
+            f'valid key with access to the configured model. Upstream said: {exc}'
+        )
+
+    if isinstance(exc, openai.APIStatusError):
+        return 502, f'OpenAI returned an error. Upstream said: {exc}'
+
+    # Everything else is a connection failure or a timeout: no response ever arrived.
+    return 504, f'Could not reach OpenAI. Upstream said: {exc}'
+
+
+# Registered on the base class, so a subclass the SDK adds later is still mapped rather than
+# falling through to a 500. Starlette resolves handlers along the MRO.
+@app.exception_handler(openai.APIError)
+async def handle_openai_error(_: Request, exc: openai.APIError) -> JSONResponse:
+    status_code, detail = _upstream_failure(exc)
+    # Logged as well as returned: the response goes to whoever made the request, and the operator
+    # reading logs is usually someone else.
+    logger.error('OpenAI call failed, returning %s: %s', status_code, exc)
+    return JSONResponse(content={'detail': detail}, status_code=status_code)

--- a/server/graph_service/main.py
+++ b/server/graph_service/main.py
@@ -5,7 +5,7 @@ from fastapi.responses import JSONResponse
 
 from graph_service.config import get_settings
 from graph_service.routers import ingest, retrieve
-from graph_service.zep_graphiti import initialize_graphiti
+from graph_service.zep_graphiti import initialize_graphiti, shutdown_graphiti
 
 
 @asynccontextmanager
@@ -13,8 +13,7 @@ async def lifespan(_: FastAPI):
     settings = get_settings()
     await initialize_graphiti(settings)
     yield
-    # Shutdown
-    # No need to close Graphiti here, as it's handled per-request
+    await shutdown_graphiti()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/server/graph_service/main.py
+++ b/server/graph_service/main.py
@@ -17,10 +17,10 @@ async def lifespan(_: FastAPI):
     await shutdown_graphiti()
 
 
-# /docs, /redoc and /openapi.json stay public, departing from the usual advice to gate them: this
-# template's source is public, so the schema is the same map routers/ are, and a browser can't put
-# an Authorization header on a plain navigation. Swagger's Authorize button picks the scheme up
-# from the dependency below. Revisit if this ever ships as a private service.
+# /docs, /redoc and /openapi.json stay public, against the usual advice: this template's source is
+# public, so the schema maps nothing routers/ doesn't, and a browser can't put an Authorization
+# header on a plain navigation. Swagger's Authorize button picks the scheme up from the dependency
+# below. Revisit if this ever ships as a private service.
 app = FastAPI(title='Graphiti API', lifespan=lifespan)
 
 

--- a/server/graph_service/main.py
+++ b/server/graph_service/main.py
@@ -1,8 +1,9 @@
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.responses import JSONResponse
 
+from graph_service.auth import require_api_key
 from graph_service.config import get_settings
 from graph_service.routers import ingest, retrieve
 from graph_service.zep_graphiti import initialize_graphiti, shutdown_graphiti
@@ -16,13 +17,20 @@ async def lifespan(_: FastAPI):
     await shutdown_graphiti()
 
 
-app = FastAPI(lifespan=lifespan)
+# /docs, /redoc and /openapi.json stay public, departing from the usual advice to gate them: this
+# template's source is public, so the schema is the same map routers/ are, and a browser can't put
+# an Authorization header on a plain navigation. Swagger's Authorize button picks the scheme up
+# from the dependency below. Revisit if this ever ships as a private service.
+app = FastAPI(title='Graphiti API', lifespan=lifespan)
 
 
-app.include_router(retrieve.router)
-app.include_router(ingest.router)
+# At the router, not per-route, so a new endpoint is closed by default and anything public is an
+# explicit declaration below. tests/test_auth.py holds the whole route table to that.
+app.include_router(retrieve.router, dependencies=[Depends(require_api_key)])
+app.include_router(ingest.router, dependencies=[Depends(require_api_key)])
 
 
+# Public: Render polls this to decide whether the service is live.
 @app.get('/healthcheck')
 async def healthcheck():
     return JSONResponse(content={'status': 'healthy'}, status_code=200)

--- a/server/graph_service/main.py
+++ b/server/graph_service/main.py
@@ -7,6 +7,7 @@ from fastapi.responses import JSONResponse
 
 from graph_service.auth import require_api_key
 from graph_service.config import get_settings
+from graph_service.openai_errors import describe_failure
 from graph_service.routers import ingest, retrieve
 from graph_service.zep_graphiti import initialize_graphiti, shutdown_graphiti
 
@@ -40,43 +41,12 @@ async def healthcheck():
     return JSONResponse(content={'status': 'healthy'}, status_code=200)
 
 
-def _upstream_failure(exc: openai.APIError) -> tuple[int, str]:
-    """Map an OpenAI failure to a status and a message that names what to go and fix.
-
-    Every retrieval endpoint embeds its query before it can search, so an unusable
-    OPENAI_API_KEY surfaces here rather than at ingestion time. Unmapped, it reached the client
-    as a bare 500 `Internal Server Error`, which reads as a bug in the graph query — the actual
-    cause was only in the service logs, and only as a traceback.
-    """
-    if isinstance(exc, openai.RateLimitError):
-        # 429 either way, because OpenAI returns 429 for a real rate limit and for
-        # insufficient_quota alike, and only the caller can tell whether retrying is worth it.
-        # The distinction that matters to the operator is in the message, so pass it through.
-        return 429, (
-            'OpenAI rejected the request: either a rate limit, or the quota on the account '
-            f'behind OPENAI_API_KEY is exhausted. Upstream said: {exc}'
-        )
-
-    if isinstance(exc, openai.AuthenticationError | openai.PermissionDeniedError):
-        # 502, not 401/403: the caller's GRAPHITI_API_KEY was accepted, and echoing OpenAI's
-        # status would tell them to go fix a credential they do not hold.
-        return 502, (
-            "OpenAI rejected this service's credentials. Check that OPENAI_API_KEY is set to a "
-            f'valid key with access to the configured model. Upstream said: {exc}'
-        )
-
-    if isinstance(exc, openai.APIStatusError):
-        return 502, f'OpenAI returned an error. Upstream said: {exc}'
-
-    # Everything else is a connection failure or a timeout: no response ever arrived.
-    return 504, f'Could not reach OpenAI. Upstream said: {exc}'
-
-
 # Registered on the base class, so a subclass the SDK adds later is still mapped rather than
-# falling through to a 500. Starlette resolves handlers along the MRO.
+# falling through to a 500. Starlette resolves handlers along the MRO; openai_errors.py decides
+# which status each failure becomes.
 @app.exception_handler(openai.APIError)
 async def handle_openai_error(_: Request, exc: openai.APIError) -> JSONResponse:
-    status_code, detail = _upstream_failure(exc)
+    status_code, detail = describe_failure(exc)
     # Logged as well as returned: the response goes to whoever made the request, and the operator
     # reading logs is usually someone else.
     logger.error('OpenAI call failed, returning %s: %s', status_code, exc)

--- a/server/graph_service/openai_errors.py
+++ b/server/graph_service/openai_errors.py
@@ -1,0 +1,40 @@
+"""Maps OpenAI's failures onto HTTP statuses, so they don't reach the caller as a bare 500.
+
+Every retrieval endpoint embeds its query before it can search, so an unusable OPENAI_API_KEY
+surfaces on `/search` rather than at ingestion time. Unmapped, it reached the client as a bare 500
+`Internal Server Error`, which reads as a bug in the graph query — the actual cause was only in
+the service logs, and only as a traceback.
+
+main.py registers the handler against openai.APIError, the base class, so a subclass the SDK adds
+later is still mapped. openai.OpenAIError siblings that aren't APIError (LengthFinishReasonError,
+ContentFilterFinishReasonError) stay 500s deliberately: they describe a response that arrived, not
+an upstream that refused us.
+"""
+
+import openai
+
+
+def describe_failure(exc: openai.APIError) -> tuple[int, str]:
+    """Map an OpenAI failure to a status and a message that names what to go and fix."""
+    if isinstance(exc, openai.RateLimitError):
+        # 429 either way, because OpenAI returns 429 for a real rate limit and for
+        # insufficient_quota alike, and only the caller can tell whether retrying is worth it.
+        # The distinction that matters to the operator is in the message, so pass it through.
+        return 429, (
+            'OpenAI rejected the request: either a rate limit, or the quota on the account '
+            f'behind OPENAI_API_KEY is exhausted. Upstream said: {exc}'
+        )
+
+    if isinstance(exc, openai.AuthenticationError | openai.PermissionDeniedError):
+        # 502, not 401/403: the caller's GRAPHITI_API_KEY was accepted, and echoing OpenAI's
+        # status would tell them to go fix a credential they do not hold.
+        return 502, (
+            "OpenAI rejected this service's credentials. Check that OPENAI_API_KEY is set to a "
+            f'valid key with access to the configured model. Upstream said: {exc}'
+        )
+
+    if isinstance(exc, openai.APIStatusError):
+        return 502, f'OpenAI returned an error. Upstream said: {exc}'
+
+    # Everything else is a connection failure or a timeout: no response ever arrived.
+    return 504, f'Could not reach OpenAI. Upstream said: {exc}'

--- a/server/graph_service/routers/ingest.py
+++ b/server/graph_service/routers/ingest.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from contextlib import asynccontextmanager
 from functools import partial
 
@@ -9,6 +10,8 @@ from graphiti_core.utils.maintenance.graph_data_operations import clear_data  # 
 from graph_service.dto import AddEntityNodeRequest, AddMessagesRequest, Message, Result
 from graph_service.zep_graphiti import ZepGraphitiDep
 
+logger = logging.getLogger(__name__)
+
 
 class AsyncWorker:
     def __init__(self):
@@ -18,11 +21,24 @@ class AsyncWorker:
     async def worker(self):
         while True:
             try:
-                print(f'Got a job: (size of remaining queue: {self.queue.qsize()})')
                 job = await self.queue.get()
+                # print, not logger.info: uvicorn leaves the root logger at WARNING, so an
+                # info-level line here never reaches the Render log. Reported after the get,
+                # rather than before it, so it means a job arrived instead of one being awaited.
+                print(f'Got a job: (size of remaining queue: {self.queue.qsize()})')
                 await job()
             except asyncio.CancelledError:
                 break
+            except Exception:
+                # Drop the episode and keep going. This loop is started once per process, so an
+                # exception escaping it ended ingestion for the life of the service — and nothing
+                # awaits self.task, so the traceback went nowhere: /messages carried on answering
+                # 202 into a queue with no reader. An exhausted OPENAI_API_KEY quota was enough
+                # to trigger it.
+                #
+                # No retry: add_episode is not idempotent, and a burst of failures on a dead key
+                # would be retried forever. A caller that needs the episode re-posts it.
+                logger.exception('Episode ingestion failed, dropping the job and continuing')
 
     async def start(self):
         self.task = asyncio.create_task(self.worker())

--- a/server/graph_service/routers/ingest.py
+++ b/server/graph_service/routers/ingest.py
@@ -23,21 +23,20 @@ class AsyncWorker:
             try:
                 job = await self.queue.get()
                 # print, not logger.info: uvicorn leaves the root logger at WARNING, so an
-                # info-level line here never reaches the Render log. Reported after the get,
-                # rather than before it, so it means a job arrived instead of one being awaited.
+                # info-level line here never reaches the Render log. After the get, so it reports
+                # a job that arrived rather than one being awaited.
                 print(f'Got a job: (size of remaining queue: {self.queue.qsize()})')
                 await job()
             except asyncio.CancelledError:
                 break
             except Exception:
-                # Drop the episode and keep going. This loop is started once per process, so an
-                # exception escaping it ended ingestion for the life of the service — and nothing
-                # awaits self.task, so the traceback went nowhere: /messages carried on answering
-                # 202 into a queue with no reader. An exhausted OPENAI_API_KEY quota was enough
-                # to trigger it.
+                # Drop the episode and keep going. This loop runs once per process, so an escaping
+                # exception ended ingestion for the life of the service — silently, since nothing
+                # awaits self.task — while /messages carried on answering 202 into a queue with no
+                # reader. An exhausted OPENAI_API_KEY quota was enough to trigger it.
                 #
-                # No retry: add_episode is not idempotent, and a burst of failures on a dead key
-                # would be retried forever. A caller that needs the episode re-posts it.
+                # No retry: add_episode is not idempotent, and a dead key would be retried
+                # forever. A caller that needs the episode re-posts it.
                 logger.exception('Episode ingestion failed, dropping the job and continuing')
 
     async def start(self):

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -93,9 +93,9 @@ def _create_openai_clients(
     base_url = settings.openai_base_url
 
     embedder_config = OpenAIEmbedderConfig(api_key=api_key, base_url=base_url)
-    # Assigned only when set, rather than passed to the constructor: embedding_model
-    # defaults to a real model name, so handing it None would overwrite that default.
-    # LLMConfig.model below defaults to None, which is why it can be passed straight in.
+    # Assigned only when set, rather than passed to the constructor: embedding_model is
+    # typed str (defaulting to a real model name), so passing None would fail validation.
+    # LLMConfig.model below is str | None, which is why it can be passed straight in.
     if settings.embedding_model_name is not None:
         embedder_config.embedding_model = settings.embedding_model_name
 
@@ -155,7 +155,7 @@ async def get_graphiti(settings: ZepEnvDep):
         await client.close()
 
 
-async def initialize_graphiti(settings: ZepEnvDep):
+async def initialize_graphiti(settings: Settings):
     client = _create_graphiti_client(settings)
     try:
         await client.build_indices_and_constraints()

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -85,17 +85,16 @@ def _create_openai_clients(
 ) -> tuple[OpenAIClient, OpenAIEmbedder, OpenAIRerankerClient]:
     """Build the OpenAI-backed clients Graphiti needs, configured from settings.
 
-    These have to be constructed with the settings rather than patched afterwards: each
-    client builds its AsyncOpenAI in __init__ out of config.api_key and config.base_url,
-    so assigning to the config later leaves the already-built client pointing elsewhere.
+    Constructed with the settings rather than patched afterwards: each client builds its
+    AsyncOpenAI in __init__ from config.api_key and config.base_url, so assigning to the
+    config later leaves the built client pointing elsewhere.
     """
     api_key = settings.openai_api_key
     base_url = settings.openai_base_url
 
     embedder_config = OpenAIEmbedderConfig(api_key=api_key, base_url=base_url)
-    # Assigned only when set, rather than passed to the constructor: embedding_model is
-    # typed str (defaulting to a real model name), so passing None would fail validation.
-    # LLMConfig.model below is str | None, which is why it can be passed straight in.
+    # Assigned only when set, rather than passed to the constructor: embedding_model is typed
+    # str, so None fails validation. LLMConfig.model below is str | None, so it goes straight in.
     if settings.embedding_model_name is not None:
         embedder_config.embedding_model = settings.embedding_model_name
 
@@ -104,8 +103,8 @@ def _create_openai_clients(
             config=LLMConfig(api_key=api_key, base_url=base_url, model=settings.model_name)
         ),
         OpenAIEmbedder(config=embedder_config),
-        # No model override here. The reranker scores passages off logprobs on a one-token
-        # completion, which is a different job from extraction — leave it on its default.
+        # No model override: the reranker scores passages off logprobs on a one-token
+        # completion, a different job from extraction. Leave it on its default.
         OpenAIRerankerClient(config=LLMConfig(api_key=api_key, base_url=base_url)),
     )
 
@@ -131,7 +130,6 @@ def _create_graphiti_client(settings: Settings) -> ZepGraphiti:
             cross_encoder=cross_encoder,
         )
     else:
-        # Validate Neo4j settings are present
         if not all([settings.neo4j_uri, settings.neo4j_user, settings.neo4j_password]):
             raise ValueError(
                 'Neo4j configuration (neo4j_uri, neo4j_user, neo4j_password) is required '
@@ -149,17 +147,14 @@ def _create_graphiti_client(settings: Settings) -> ZepGraphiti:
 
 # One client for the life of the process, rather than one per request.
 #
-# Both graph drivers fire off build_indices_and_constraints() as an unawaited background task
-# from their constructor. Building a client per request therefore started an index build per
-# request, and closing that client when the request ended cut the task's connection mid-query
-# — which is where the 'Connection closed by server' tracebacks came from. The same close also
-# broke /messages, which hands its ingestion work to the async worker: those jobs outlive the
-# request, so they ran against a client that had already been closed and only survived on the
-# redis client's transparent reconnect.
+# Both graph drivers fire off build_indices_and_constraints() as an unawaited background task from
+# their constructor, so a client per request meant an index build per request — and closing that
+# client at the end of the request cut the task's connection mid-query, which is where the
+# 'Connection closed by server' tracebacks came from. It also broke /messages, whose ingestion
+# outlives the request and only survived on the redis client's transparent reconnect.
 #
-# Sharing one client fixes both: the index build happens once, awaited, at startup, and queued
-# jobs keep a client that stays open. It also stops rebuilding the OpenAI clients and the
-# connection pool on every request.
+# Sharing one client fixes both: the index build happens once, awaited, at startup, and queued jobs
+# keep a client that stays open. It also stops rebuilding the OpenAI clients per request.
 _graphiti_client: ZepGraphiti | None = None
 
 

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -10,7 +10,7 @@ from graphiti_core.errors import EdgeNotFoundError, GroupsEdgesNotFoundError, No
 from graphiti_core.llm_client import LLMClient, LLMConfig, OpenAIClient  # type: ignore
 from graphiti_core.nodes import EntityNode, EpisodicNode  # type: ignore
 
-from graph_service.config import Settings, ZepEnvDep
+from graph_service.config import Settings
 from graph_service.dto import FactResult
 
 logger = logging.getLogger(__name__)
@@ -147,20 +147,39 @@ def _create_graphiti_client(settings: Settings) -> ZepGraphiti:
         )
 
 
-async def get_graphiti(settings: ZepEnvDep):
-    client = _create_graphiti_client(settings)
-    try:
-        yield client
-    finally:
-        await client.close()
+# One client for the life of the process, rather than one per request.
+#
+# Both graph drivers fire off build_indices_and_constraints() as an unawaited background task
+# from their constructor. Building a client per request therefore started an index build per
+# request, and closing that client when the request ended cut the task's connection mid-query
+# — which is where the 'Connection closed by server' tracebacks came from. The same close also
+# broke /messages, which hands its ingestion work to the async worker: those jobs outlive the
+# request, so they ran against a client that had already been closed and only survived on the
+# redis client's transparent reconnect.
+#
+# Sharing one client fixes both: the index build happens once, awaited, at startup, and queued
+# jobs keep a client that stays open. It also stops rebuilding the OpenAI clients and the
+# connection pool on every request.
+_graphiti_client: ZepGraphiti | None = None
+
+
+async def get_graphiti() -> ZepGraphiti:
+    if _graphiti_client is None:
+        raise RuntimeError('Graphiti client requested before startup completed')
+    return _graphiti_client
 
 
 async def initialize_graphiti(settings: Settings):
-    client = _create_graphiti_client(settings)
-    try:
-        await client.build_indices_and_constraints()
-    finally:
-        await client.close()
+    global _graphiti_client
+    _graphiti_client = _create_graphiti_client(settings)
+    await _graphiti_client.build_indices_and_constraints()
+
+
+async def shutdown_graphiti():
+    global _graphiti_client
+    if _graphiti_client is not None:
+        await _graphiti_client.close()
+        _graphiti_client = None
 
 
 def get_fact_result_from_edge(edge: EntityEdge):

--- a/server/graph_service/zep_graphiti.py
+++ b/server/graph_service/zep_graphiti.py
@@ -3,12 +3,14 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException
 from graphiti_core import Graphiti  # type: ignore
+from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient  # type: ignore
 from graphiti_core.edges import EntityEdge  # type: ignore
+from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig  # type: ignore
 from graphiti_core.errors import EdgeNotFoundError, GroupsEdgesNotFoundError, NodeNotFoundError
-from graphiti_core.llm_client import LLMClient  # type: ignore
+from graphiti_core.llm_client import LLMClient, LLMConfig, OpenAIClient  # type: ignore
 from graphiti_core.nodes import EntityNode, EpisodicNode  # type: ignore
 
-from graph_service.config import ZepEnvDep
+from graph_service.config import Settings, ZepEnvDep
 from graph_service.dto import FactResult
 
 logger = logging.getLogger(__name__)
@@ -78,17 +80,56 @@ class ZepGraphiti(Graphiti):
             raise HTTPException(status_code=404, detail=e.message) from e
 
 
-def _create_graphiti_client(settings: ZepEnvDep) -> ZepGraphiti:
+def _create_openai_clients(
+    settings: Settings,
+) -> tuple[OpenAIClient, OpenAIEmbedder, OpenAIRerankerClient]:
+    """Build the OpenAI-backed clients Graphiti needs, configured from settings.
+
+    These have to be constructed with the settings rather than patched afterwards: each
+    client builds its AsyncOpenAI in __init__ out of config.api_key and config.base_url,
+    so assigning to the config later leaves the already-built client pointing elsewhere.
+    """
+    api_key = settings.openai_api_key
+    base_url = settings.openai_base_url
+
+    embedder_config = OpenAIEmbedderConfig(api_key=api_key, base_url=base_url)
+    # Assigned only when set, rather than passed to the constructor: embedding_model
+    # defaults to a real model name, so handing it None would overwrite that default.
+    # LLMConfig.model below defaults to None, which is why it can be passed straight in.
+    if settings.embedding_model_name is not None:
+        embedder_config.embedding_model = settings.embedding_model_name
+
+    return (
+        OpenAIClient(
+            config=LLMConfig(api_key=api_key, base_url=base_url, model=settings.model_name)
+        ),
+        OpenAIEmbedder(config=embedder_config),
+        # No model override here. The reranker scores passages off logprobs on a one-token
+        # completion, which is a different job from extraction — leave it on its default.
+        OpenAIRerankerClient(config=LLMConfig(api_key=api_key, base_url=base_url)),
+    )
+
+
+def _create_graphiti_client(settings: Settings) -> ZepGraphiti:
     """Create a ZepGraphiti client based on the configured database backend."""
+    llm_client, embedder, cross_encoder = _create_openai_clients(settings)
+
     if settings.db_backend == 'falkordb':
         from graphiti_core.driver.falkordb_driver import FalkorDriver
 
-        driver = FalkorDriver(  # type: ignore
-            host=settings.falkordb_host or 'localhost',  # type: ignore
-            port=settings.falkordb_port or 6379,  # type: ignore
-            database=settings.falkordb_database or 'default_db',  # type: ignore
+        driver = FalkorDriver(
+            host=settings.falkordb_host or 'localhost',
+            port=settings.falkordb_port or 6379,
+            username=settings.falkordb_username,
+            password=settings.falkordb_password,
+            database=settings.falkordb_database or 'default_db',
         )
-        return ZepGraphiti(graph_driver=driver)  # type: ignore
+        return ZepGraphiti(
+            graph_driver=driver,
+            llm_client=llm_client,
+            embedder=embedder,
+            cross_encoder=cross_encoder,
+        )
     else:
         # Validate Neo4j settings are present
         if not all([settings.neo4j_uri, settings.neo4j_user, settings.neo4j_password]):
@@ -100,18 +141,14 @@ def _create_graphiti_client(settings: ZepEnvDep) -> ZepGraphiti:
             uri=settings.neo4j_uri,
             user=settings.neo4j_user,
             password=settings.neo4j_password,
+            llm_client=llm_client,
+            embedder=embedder,
+            cross_encoder=cross_encoder,
         )
 
 
 async def get_graphiti(settings: ZepEnvDep):
     client = _create_graphiti_client(settings)
-    if settings.openai_base_url is not None:
-        client.llm_client.config.base_url = settings.openai_base_url
-    if settings.openai_api_key is not None:
-        client.llm_client.config.api_key = settings.openai_api_key
-    if settings.model_name is not None:
-        client.llm_client.model = settings.model_name
-
     try:
         yield client
     finally:

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     "pydantic-settings>=2.4.0",
     "uvicorn>=0.44.0",
     "httpx>=0.28.1",
+    # Imported directly by main.py, which maps openai's exceptions onto HTTP statuses. A
+    # transitive dependency of graphiti-core too, but declared here so that stays incidental.
+    "openai>=1.92.2",
 ]
 
 [project.optional-dependencies]

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -1,9 +1,9 @@
 """Auth tests for the graph endpoints.
 
 Need no OpenAI key and no database, so they run in the default `make test`. Nothing asserts a
-successful response: the app is built without its lifespan, so anything past auth reaches a
-handler with no Graphiti client and fails. Only whether require_api_key let the request through
-is asserted — see _assert_passed_auth.
+successful response: the app is built without its lifespan, so anything past auth reaches a handler
+with no Graphiti client and fails. These assert only whether require_api_key let the request
+through — see _assert_passed_auth.
 
 The real graph_service.main is reloaded per case rather than a stand-in assembled, because its
 wiring is what these guard: the likeliest regression is a router included without the auth
@@ -25,9 +25,9 @@ from graph_service.config import MIN_API_KEY_LENGTH
 SECRET = 'test-api-key-6Yp2Qk'
 assert len(SECRET) >= MIN_API_KEY_LENGTH, 'the fixture key must itself be a valid key'
 
-# The allowlist the app is held to; every other route must carry the auth dependency. An
-# allowlist, not protected prefixes, so an unpredicted route name fails by default. The docs are
-# deliberately public — see main.py.
+# The allowlist the app is held to; every other route must carry the auth dependency. An allowlist,
+# not protected prefixes, so an unpredicted route name fails by default. The docs are deliberately
+# public — see main.py.
 PUBLIC_PATHS = {'/healthcheck', '/docs', '/docs/oauth2-redirect', '/redoc', '/openapi.json'}
 DOCS_PATHS = ['/openapi.json', '/docs', '/redoc']
 
@@ -37,9 +37,8 @@ def _fresh_rejection_budget():
     """Empty the failed-auth budget around every case.
 
     Autouse, not optional: the budget lives in graph_service.auth, which build_app does not
-    reload, so rejections would accumulate module-wide. This file provokes more than
-    MAX_FAILED_AUTH of them, so cases asserting 401 would see 429 — order-dependently, which a
-    single -k run would hide.
+    reload, so rejections accumulate module-wide. This file provokes more than MAX_FAILED_AUTH of
+    them, so cases asserting 401 would see 429 — order-dependently, which a single -k run hides.
     """
     auth._recent_rejections.clear()
     yield
@@ -50,20 +49,18 @@ def _fresh_rejection_budget():
 def build_app(monkeypatch):
     """Return a factory that builds the real app with GRAPHITI_API_KEY set to a given value.
 
-    The process environment should be the only input, and two things otherwise get a say:
-    Settings reads env_file='.env' relative to the cwd (server/ under `make test`), and
-    graphiti_core calls load_dotenv() on import, which searches upward from server/.venv and
-    finds the same file whatever the cwd. Either hands a developer with a server/.env the very
-    key test_no_key_means_no_service asserts the absence of, failing the suite on their machine
-    only. So: no env file for Settings, and the environment is set after the import that may
-    inject one.
+    The process environment should be the only input, and two things otherwise get a say: Settings
+    reads env_file='.env' relative to the cwd, and graphiti_core calls load_dotenv() on import,
+    which finds the same file whatever the cwd. Either hands a developer with a server/.env the
+    very key test_no_key_means_no_service asserts the absence of, failing the suite on their
+    machine only. So: no env file for Settings, and the environment is set after the import.
     """
     monkeypatch.setitem(config.Settings.model_config, 'env_file', None)
 
     def _build(graphiti_api_key: str | None):
-        # Imported before the environment is arranged, because this is the import that
-        # triggers load_dotenv() — on the first call, which is the one that matters. Nothing
-        # reads settings yet: the app is assembled at import, get_settings() runs in lifespan.
+        # Imported before the environment is arranged, because this is the import that triggers
+        # load_dotenv(). Nothing reads settings yet: the app is assembled at import, and
+        # get_settings() runs in the lifespan.
         import graph_service.main as main
 
         monkeypatch.setenv('OPENAI_API_KEY', 'unused-by-these-tests')
@@ -90,7 +87,7 @@ def _assert_passed_auth(response):
     """Assert only that require_api_key let the request through.
 
     Not `== 500`: what the handler does next is not this file's business, and pinning it would
-    break the day the fixture gains a lifespan. 401 is the one status meaning auth rejected it.
+    break the day the fixture gains a lifespan.
     """
     assert response.status_code != 401, response.text
 
@@ -99,13 +96,9 @@ def _assert_passed_auth(response):
 def test_no_key_means_no_service(build_app, graphiti_api_key):
     """Auth is mandatory, so a missing key is a startup error and not an open API.
 
-    A service that boots without a key and one that 401s everything both look healthy to Render,
-    and only one is safe. Blank and whitespace count as missing: a stray `GRAPHITI_API_KEY=` must
-    not become a key of '' or ' ' that the deployment accepts.
-
-    Asserted against the lifespan rather than get_settings() alone, because that is what makes it
-    a startup failure — uvicorn runs it before serving, so the process exits. Entering it is
-    enough, since settings are read on the first line.
+    Blank and whitespace count as missing: a stray `GRAPHITI_API_KEY=` must not become a key of ''
+    that the deployment accepts. Asserted against the lifespan rather than get_settings() alone,
+    because that is what makes it a startup failure — uvicorn runs it before serving.
     """
     app = build_app(graphiti_api_key)
     with pytest.raises(ValidationError, match='graphiti_api_key'), TestClient(app):
@@ -115,10 +108,9 @@ def test_no_key_means_no_service(build_app, graphiti_api_key):
 def test_a_guessable_key_is_refused_at_startup(build_app):
     """A key too short to survive guessing fails the deploy, rather than serving traffic.
 
-    The budget stops a stranger working through the keyspace, not a key already at the front of
-    it. Rotation is a hand edit in the Dashboard, and nothing there would reject
-    `GRAPHITI_API_KEY=dev` — this is what does. One character under the floor, so the boundary is
-    pinned rather than a value that would pass a floor set lower by accident.
+    The budget stops a stranger working through the keyspace, not a key already at the front of it.
+    Rotation is a hand edit in the Dashboard, and nothing there rejects `GRAPHITI_API_KEY=dev` —
+    this is what does. One character under the floor, so the boundary itself is pinned.
     """
     app = build_app('k' * (MIN_API_KEY_LENGTH - 1))
     with pytest.raises(ValidationError, match='string_too_short'), TestClient(app):
@@ -149,9 +141,8 @@ def test_configured_key_accepts_the_right_bearer_token(build_app):
         # The right value one byte short: guards against compare_digest becoming a prefix
         # comparison.
         pytest.param({'Authorization': f'Bearer {SECRET[:-1]}'}, id='truncated-key'),
-        # Raw bytes, since httpx refuses a non-ASCII str header. Starlette decodes as
-        # latin-1, so this arrives as a non-ASCII str, which compare_digest refuses to
-        # compare. Must be a 401, not a 500 for anyone sending a stray high byte.
+        # Raw bytes, since httpx refuses a non-ASCII str header. Starlette decodes as latin-1,
+        # so this arrives as a str compare_digest refuses to compare — a 401, not a 500.
         pytest.param({b'Authorization': b'Bearer \xff'}, id='non-ascii-token'),
     ],
 )
@@ -161,14 +152,14 @@ def test_configured_key_rejects_everything_else(build_app, headers):
 
 
 # Every value is over MIN_API_KEY_LENGTH, and the match below pins the pattern error: a short
-# non-ASCII key would fail on length and pass without the ASCII rule existing at all.
+# non-ASCII key would fail on length even with no ASCII rule at all.
 @pytest.mark.parametrize(
     'graphiti_api_key',
     [
         pytest.param('clé-secrète-assez-longue', id='accent'),
         pytest.param('key-with-an-emoji-🔑', id='emoji'),
-        # A tab survives RequiredStr's strip only mid-value, and a control character in a
-        # header is malformed however it is encoded.
+        # A tab survives RequiredStr's strip mid-value, and a control character in a header
+        # is malformed however it is encoded.
         pytest.param('key\twith\ttabs\tin\tit', id='control-char'),
     ],
 )
@@ -176,9 +167,8 @@ def test_a_non_ascii_key_is_refused_at_startup(build_app, graphiti_api_key):
     """A key that can't survive an HTTP header fails the deploy, rather than every request.
 
     Nothing in the Dashboard rejects a passphrase on rotation. Such a key authenticates for a
-    client encoding the header as latin-1 and not for one using UTF-8, so it can't be relied on
-    either way — and the operator who set it sees the same 401 as someone who mistyped it.
-    Failing at startup names the actual problem.
+    client encoding the header as latin-1 but not for one using UTF-8, and the operator who set it
+    sees the same 401 as someone who mistyped it. Failing at startup names the actual problem.
     """
     app = build_app(graphiti_api_key)
     with pytest.raises(ValidationError, match='string_pattern_mismatch'), TestClient(app):
@@ -189,7 +179,7 @@ def test_a_burst_of_wrong_keys_is_rate_limited(build_app):
     """The key can't be brute-forced, and the endpoint isn't a free scanner target.
 
     Exactly MAX_FAILED_AUTH rejections are spent first, pinning the boundary both ways: the last
-    inside the budget still gets its 401, the first past it does not.
+    inside the budget still gets its 401, the first past it doesn't.
     """
     app = build_app(SECRET)
     wrong = {'Authorization': 'Bearer wrong-key-but-long-enough'}
@@ -205,8 +195,8 @@ def test_a_burst_of_wrong_keys_is_rate_limited(build_app):
 def test_the_right_key_is_never_rate_limited(build_app):
     """Why a global budget is safe: it can't lock a real client out.
 
-    Otherwise one stranger guessing keys takes the API down for whoever holds the real one — a
-    worse outcome than the brute-force the budget exists to stop.
+    Otherwise one stranger guessing keys takes the API down for whoever holds the real one — worse
+    than the brute-force the budget exists to stop.
     """
     app = build_app(SECRET)
     wrong = {'Authorization': 'Bearer wrong-key-but-long-enough'}
@@ -250,10 +240,10 @@ def test_healthcheck_stays_public(build_app):
 
 @pytest.mark.parametrize('path', DOCS_PATHS)
 def test_the_docs_are_browsable(build_app, path):
-    """Deliberately public, and worth a test because it is a judgement call, not a default.
+    """Deliberately public, and worth a test because it's a judgement call, not a default.
 
     A browser can't attach a bearer header to a navigation, so protecting these would make them
-    unreachable by clicking a link on any deployment with a key.
+    unreachable by clicking a link.
     """
     app = build_app(SECRET)
     assert TestClient(app).get(path).status_code == 200
@@ -262,8 +252,8 @@ def test_the_docs_are_browsable(build_app, path):
 def test_the_docs_offer_the_bearer_scheme(build_app):
     """Swagger's Authorize button, which keeps the docs usable against a deployment.
 
-    It comes from the routers' dependency, easy to lose by protecting the routes some other way,
-    and its absence would leave Try it out silently 401ing.
+    It comes from the routers' dependency — easy to lose by protecting the routes some other way,
+    which would leave Try it out silently 401ing.
     """
     schema = TestClient(build_app(SECRET)).get('/openapi.json').json()
     assert schema['components']['securitySchemes']['HTTPBearer']['scheme'] == 'bearer'
@@ -273,9 +263,9 @@ def test_the_docs_offer_the_bearer_scheme(build_app):
 def _is_protected(route) -> bool:
     """Whether require_api_key runs before this route's handler.
 
-    Identity, not a name comparison, so a same-named dependency elsewhere can't satisfy it.
-    Anything that is not an APIRoute has no dependant and counts as unprotected — a Mount or
-    WebSocketRoute is exactly what this must not wave through.
+    Identity, not a name comparison, so a same-named dependency elsewhere can't satisfy it. Anything
+    that isn't an APIRoute has no dependant and counts as unprotected — a Mount or WebSocketRoute is
+    exactly what this must not wave through.
     """
     if not isinstance(route, APIRoute):
         return False
@@ -285,8 +275,8 @@ def _is_protected(route) -> bool:
 def test_every_route_but_the_public_ones_is_protected(build_app):
     """The whole surface, not a list of prefixes someone has to remember to extend.
 
-    A router included without the dependency, or a public endpoint added by accident, fails
-    here; adding a route to PUBLIC_PATHS is then a deliberate edit.
+    A router included without the dependency, or a public endpoint added by accident, fails here;
+    adding a route to PUBLIC_PATHS is then a deliberate edit.
     """
     app = build_app(SECRET)
     unprotected = {

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -1,0 +1,297 @@
+"""Auth tests for the graph endpoints.
+
+Need no OpenAI key and no database, so they run in the default `make test`. Nothing asserts a
+successful response: the app is built without its lifespan, so anything past auth reaches a
+handler with no Graphiti client and fails. Only whether require_api_key let the request through
+is asserted — see _assert_passed_auth.
+
+The real graph_service.main is reloaded per case rather than a stand-in assembled, because its
+wiring is what these guard: the likeliest regression is a router included without the auth
+dependency, and only the real module can catch that.
+"""
+
+import importlib
+import time
+
+import pytest
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from graph_service import auth, config
+from graph_service.auth import MAX_FAILED_AUTH, require_api_key
+from graph_service.config import MIN_API_KEY_LENGTH
+
+SECRET = 'test-api-key-6Yp2Qk'
+assert len(SECRET) >= MIN_API_KEY_LENGTH, 'the fixture key must itself be a valid key'
+
+# The allowlist the app is held to; every other route must carry the auth dependency. An
+# allowlist, not protected prefixes, so an unpredicted route name fails by default. The docs are
+# deliberately public — see main.py.
+PUBLIC_PATHS = {'/healthcheck', '/docs', '/docs/oauth2-redirect', '/redoc', '/openapi.json'}
+DOCS_PATHS = ['/openapi.json', '/docs', '/redoc']
+
+
+@pytest.fixture(autouse=True)
+def _fresh_rejection_budget():
+    """Empty the failed-auth budget around every case.
+
+    Autouse, not optional: the budget lives in graph_service.auth, which build_app does not
+    reload, so rejections would accumulate module-wide. This file provokes more than
+    MAX_FAILED_AUTH of them, so cases asserting 401 would see 429 — order-dependently, which a
+    single -k run would hide.
+    """
+    auth._recent_rejections.clear()
+    yield
+    auth._recent_rejections.clear()
+
+
+@pytest.fixture
+def build_app(monkeypatch):
+    """Return a factory that builds the real app with GRAPHITI_API_KEY set to a given value.
+
+    The process environment should be the only input, and two things otherwise get a say:
+    Settings reads env_file='.env' relative to the cwd (server/ under `make test`), and
+    graphiti_core calls load_dotenv() on import, which searches upward from server/.venv and
+    finds the same file whatever the cwd. Either hands a developer with a server/.env the very
+    key test_no_key_means_no_service asserts the absence of, failing the suite on their machine
+    only. So: no env file for Settings, and the environment is set after the import that may
+    inject one.
+    """
+    monkeypatch.setitem(config.Settings.model_config, 'env_file', None)
+
+    def _build(graphiti_api_key: str | None):
+        # Imported before the environment is arranged, because this is the import that
+        # triggers load_dotenv() — on the first call, which is the one that matters. Nothing
+        # reads settings yet: the app is assembled at import, get_settings() runs in lifespan.
+        import graph_service.main as main
+
+        monkeypatch.setenv('OPENAI_API_KEY', 'unused-by-these-tests')
+        if graphiti_api_key is None:
+            monkeypatch.delenv('GRAPHITI_API_KEY', raising=False)
+        else:
+            monkeypatch.setenv('GRAPHITI_API_KEY', graphiti_api_key)
+        # Both cached at import time, so both must be discarded for a new key to take effect.
+        config.get_settings.cache_clear()
+        return importlib.reload(main).app
+
+    yield _build
+    config.get_settings.cache_clear()
+
+
+def _search(app, headers=None):
+    client = TestClient(app, raise_server_exceptions=False)
+    return client.post(
+        '/search', json={'query': 'anything', 'group_ids': ['g']}, headers=headers or {}
+    )
+
+
+def _assert_passed_auth(response):
+    """Assert only that require_api_key let the request through.
+
+    Not `== 500`: what the handler does next is not this file's business, and pinning it would
+    break the day the fixture gains a lifespan. 401 is the one status meaning auth rejected it.
+    """
+    assert response.status_code != 401, response.text
+
+
+@pytest.mark.parametrize('graphiti_api_key', [None, '', '   '], ids=['unset', 'blank', 'space'])
+def test_no_key_means_no_service(build_app, graphiti_api_key):
+    """Auth is mandatory, so a missing key is a startup error and not an open API.
+
+    A service that boots without a key and one that 401s everything both look healthy to Render,
+    and only one is safe. Blank and whitespace count as missing: a stray `GRAPHITI_API_KEY=` must
+    not become a key of '' or ' ' that the deployment accepts.
+
+    Asserted against the lifespan rather than get_settings() alone, because that is what makes it
+    a startup failure — uvicorn runs it before serving, so the process exits. Entering it is
+    enough, since settings are read on the first line.
+    """
+    app = build_app(graphiti_api_key)
+    with pytest.raises(ValidationError, match='graphiti_api_key'), TestClient(app):
+        pass  # never reached: entering the lifespan is what raises
+
+
+def test_a_guessable_key_is_refused_at_startup(build_app):
+    """A key too short to survive guessing fails the deploy, rather than serving traffic.
+
+    The budget stops a stranger working through the keyspace, not a key already at the front of
+    it. Rotation is a hand edit in the Dashboard, and nothing there would reject
+    `GRAPHITI_API_KEY=dev` — this is what does. One character under the floor, so the boundary is
+    pinned rather than a value that would pass a floor set lower by accident.
+    """
+    app = build_app('k' * (MIN_API_KEY_LENGTH - 1))
+    with pytest.raises(ValidationError, match='string_too_short'), TestClient(app):
+        pass  # never reached: entering the lifespan is what raises
+
+
+def test_a_key_at_the_length_floor_is_accepted(build_app):
+    """The other half of the boundary: the floor is inclusive, so it can't drift upward."""
+    key = 'k' * MIN_API_KEY_LENGTH
+    app = build_app(key)
+    _assert_passed_auth(_search(app, {'Authorization': f'Bearer {key}'}))
+
+
+def test_configured_key_accepts_the_right_bearer_token(build_app):
+    app = build_app(SECRET)
+    _assert_passed_auth(_search(app, {'Authorization': f'Bearer {SECRET}'}))
+
+
+@pytest.mark.parametrize(
+    'headers',
+    [
+        pytest.param({}, id='no-header'),
+        pytest.param({'Authorization': 'Bearer wrong-key'}, id='wrong-key'),
+        pytest.param({'Authorization': 'Bearer '}, id='empty-token'),
+        pytest.param({'Authorization': f'Basic {SECRET}'}, id='wrong-scheme'),
+        pytest.param({'Authorization': SECRET}, id='bare-token-no-scheme'),
+        pytest.param({'X-API-Key': SECRET}, id='wrong-header'),
+        # The right value one byte short: guards against compare_digest becoming a prefix
+        # comparison.
+        pytest.param({'Authorization': f'Bearer {SECRET[:-1]}'}, id='truncated-key'),
+        # Raw bytes, since httpx refuses a non-ASCII str header. Starlette decodes as
+        # latin-1, so this arrives as a non-ASCII str, which compare_digest refuses to
+        # compare. Must be a 401, not a 500 for anyone sending a stray high byte.
+        pytest.param({b'Authorization': b'Bearer \xff'}, id='non-ascii-token'),
+    ],
+)
+def test_configured_key_rejects_everything_else(build_app, headers):
+    app = build_app(SECRET)
+    assert _search(app, headers).status_code == 401
+
+
+# Every value is over MIN_API_KEY_LENGTH, and the match below pins the pattern error: a short
+# non-ASCII key would fail on length and pass without the ASCII rule existing at all.
+@pytest.mark.parametrize(
+    'graphiti_api_key',
+    [
+        pytest.param('clé-secrète-assez-longue', id='accent'),
+        pytest.param('key-with-an-emoji-🔑', id='emoji'),
+        # A tab survives RequiredStr's strip only mid-value, and a control character in a
+        # header is malformed however it is encoded.
+        pytest.param('key\twith\ttabs\tin\tit', id='control-char'),
+    ],
+)
+def test_a_non_ascii_key_is_refused_at_startup(build_app, graphiti_api_key):
+    """A key that can't survive an HTTP header fails the deploy, rather than every request.
+
+    Nothing in the Dashboard rejects a passphrase on rotation. Such a key authenticates for a
+    client encoding the header as latin-1 and not for one using UTF-8, so it can't be relied on
+    either way — and the operator who set it sees the same 401 as someone who mistyped it.
+    Failing at startup names the actual problem.
+    """
+    app = build_app(graphiti_api_key)
+    with pytest.raises(ValidationError, match='string_pattern_mismatch'), TestClient(app):
+        pass  # never reached: entering the lifespan is what raises
+
+
+def test_a_burst_of_wrong_keys_is_rate_limited(build_app):
+    """The key can't be brute-forced, and the endpoint isn't a free scanner target.
+
+    Exactly MAX_FAILED_AUTH rejections are spent first, pinning the boundary both ways: the last
+    inside the budget still gets its 401, the first past it does not.
+    """
+    app = build_app(SECRET)
+    wrong = {'Authorization': 'Bearer wrong-key-but-long-enough'}
+    for attempt in range(MAX_FAILED_AUTH):
+        assert _search(app, wrong).status_code == 401, f'budgeted attempt {attempt} was refused'
+
+    limited = _search(app, wrong)
+    assert limited.status_code == 429
+    # Conventional on a 429, and the client has no other way to know how long to wait.
+    assert 0 < int(limited.headers['Retry-After']) <= auth.FAILED_AUTH_WINDOW_SECONDS
+
+
+def test_the_right_key_is_never_rate_limited(build_app):
+    """Why a global budget is safe: it can't lock a real client out.
+
+    Otherwise one stranger guessing keys takes the API down for whoever holds the real one — a
+    worse outcome than the brute-force the budget exists to stop.
+    """
+    app = build_app(SECRET)
+    wrong = {'Authorization': 'Bearer wrong-key-but-long-enough'}
+    for _ in range(MAX_FAILED_AUTH + 5):
+        _search(app, wrong)
+    assert _search(app, wrong).status_code == 429, 'the budget should be spent by now'
+
+    _assert_passed_auth(_search(app, {'Authorization': f'Bearer {SECRET}'}))
+
+
+def test_the_budget_recovers_once_the_window_passes(build_app):
+    """A spent budget is a delay, not a latch — otherwise one burst closes the API for good.
+
+    The window is moved rather than waited out: back-dating the deque's monotonic timestamps is
+    the same thing to the code and keeps the suite fast.
+    """
+    app = build_app(SECRET)
+    wrong = {'Authorization': 'Bearer wrong-key-but-long-enough'}
+    for _ in range(MAX_FAILED_AUTH):
+        _search(app, wrong)
+    assert _search(app, wrong).status_code == 429
+
+    stale = time.monotonic() - auth.FAILED_AUTH_WINDOW_SECONDS - 1
+    auth._recent_rejections.extend([stale] * MAX_FAILED_AUTH)
+    assert _search(app, wrong).status_code == 401
+
+
+def test_rejection_names_the_scheme_to_retry_with(build_app):
+    """RFC 9110 requires WWW-Authenticate on a 401, and it tells clients what to send."""
+    app = build_app(SECRET)
+    assert _search(app).headers.get('WWW-Authenticate') == 'Bearer'
+
+
+def test_healthcheck_stays_public(build_app):
+    """If auth ever covers it, every deploy fails its health check and rolls back."""
+    app = build_app(SECRET)
+    response = TestClient(app).get('/healthcheck')
+    assert response.status_code == 200
+    assert response.json() == {'status': 'healthy'}
+
+
+@pytest.mark.parametrize('path', DOCS_PATHS)
+def test_the_docs_are_browsable(build_app, path):
+    """Deliberately public, and worth a test because it is a judgement call, not a default.
+
+    A browser can't attach a bearer header to a navigation, so protecting these would make them
+    unreachable by clicking a link on any deployment with a key.
+    """
+    app = build_app(SECRET)
+    assert TestClient(app).get(path).status_code == 200
+
+
+def test_the_docs_offer_the_bearer_scheme(build_app):
+    """Swagger's Authorize button, which keeps the docs usable against a deployment.
+
+    It comes from the routers' dependency, easy to lose by protecting the routes some other way,
+    and its absence would leave Try it out silently 401ing.
+    """
+    schema = TestClient(build_app(SECRET)).get('/openapi.json').json()
+    assert schema['components']['securitySchemes']['HTTPBearer']['scheme'] == 'bearer'
+    assert schema['paths']['/search']['post']['security'] == [{'HTTPBearer': []}]
+
+
+def _is_protected(route) -> bool:
+    """Whether require_api_key runs before this route's handler.
+
+    Identity, not a name comparison, so a same-named dependency elsewhere can't satisfy it.
+    Anything that is not an APIRoute has no dependant and counts as unprotected — a Mount or
+    WebSocketRoute is exactly what this must not wave through.
+    """
+    if not isinstance(route, APIRoute):
+        return False
+    return any(dependency.call is require_api_key for dependency in route.dependant.dependencies)
+
+
+def test_every_route_but_the_public_ones_is_protected(build_app):
+    """The whole surface, not a list of prefixes someone has to remember to extend.
+
+    A router included without the dependency, or a public endpoint added by accident, fails
+    here; adding a route to PUBLIC_PATHS is then a deliberate edit.
+    """
+    app = build_app(SECRET)
+    unprotected = {
+        route.path
+        for route in app.routes
+        if route.path not in PUBLIC_PATHS and not _is_protected(route)
+    }
+    assert not unprotected, f'routes missing auth: {sorted(unprotected)}'

--- a/server/tests/test_live_falkordb_int.py
+++ b/server/tests/test_live_falkordb_int.py
@@ -50,9 +50,8 @@ FALKORDB_PORT = int(os.environ.get('FALKORDB_PORT', '6379'))
 
 pytestmark = [pytest.mark.integration]
 
-# The key the live server is spawned with; auth is mandatory, so it needs one to boot. Pinned,
-# not inherited: a root-.env GRAPHITI_API_KEY would reach the subprocess via load_dotenv above
-# and 401 every request here.
+# The key the live server is spawned with; auth is mandatory, so it needs one to boot. Pinned, not
+# inherited: a root-.env key would reach the subprocess via load_dotenv and 401 every request here.
 API_KEY = 'srvtest-api-key-Rk4Wm2'
 AUTH_HEADERS = {'Authorization': f'Bearer {API_KEY}'}
 

--- a/server/tests/test_live_falkordb_int.py
+++ b/server/tests/test_live_falkordb_int.py
@@ -50,6 +50,12 @@ FALKORDB_PORT = int(os.environ.get('FALKORDB_PORT', '6379'))
 
 pytestmark = [pytest.mark.integration]
 
+# The key the live server is spawned with; auth is mandatory, so it needs one to boot. Pinned,
+# not inherited: a root-.env GRAPHITI_API_KEY would reach the subprocess via load_dotenv above
+# and 401 every request here.
+API_KEY = 'srvtest-api-key-Rk4Wm2'
+AUTH_HEADERS = {'Authorization': f'Bearer {API_KEY}'}
+
 
 def _falkordb_reachable(host: str, port: int) -> bool:
     """Best-effort TCP check that a FalkorDB (Redis) endpoint is reachable."""
@@ -116,6 +122,7 @@ def live_server() -> Iterator[tuple[str, str]]:
         # A fresh logical graph per run isolates the test and keeps a long-lived
         # local FalkorDB from accumulating data across runs.
         'FALKORDB_DATABASE': token,
+        'GRAPHITI_API_KEY': API_KEY,
     }
     # Not a context manager: the handle must outlive setup (the subprocess writes
     # to it across the yield) and is closed explicitly in the finally block.
@@ -198,6 +205,7 @@ def _search_until(
 
 
 def test_healthcheck(live_server: tuple[str, str]) -> None:
+    # No auth header: /healthcheck must stay public or Render's poll rolls the deploy back.
     base_url, _ = live_server
     with httpx.Client(base_url=base_url, timeout=10) as client:
         resp = client.get('/healthcheck')
@@ -207,7 +215,7 @@ def test_healthcheck(live_server: tuple[str, str]) -> None:
 
 def test_ingest_search_delete_e2e(live_server: tuple[str, str]) -> None:
     base_url, group_id = live_server
-    with httpx.Client(base_url=base_url, timeout=30) as client:
+    with httpx.Client(base_url=base_url, timeout=30, headers=AUTH_HEADERS) as client:
         try:
             # 1. Ingest a message with clearly-extractable entities and a relationship.
             add = client.post(

--- a/server/tests/test_upstream_failures.py
+++ b/server/tests/test_upstream_failures.py
@@ -23,21 +23,27 @@ API_KEY = 'test-api-key-6Yp2Qk'
 AUTH = {'Authorization': f'Bearer {API_KEY}'}
 
 
-def _openai_error(cls: type[openai.APIStatusError], status: int, message: str):
+def _openai_error(
+    cls: type[openai.APIStatusError], status: int, message: str
+) -> openai.APIStatusError:
     """Build a real openai error, since the handler dispatches on the exception type."""
     request = httpx.Request('POST', 'https://api.openai.com/v1/embeddings')
     response = httpx.Response(status, request=request)
     return cls(message, response=response, body={'error': {'message': message}})
 
 
-QUOTA_ERROR = _openai_error(
-    openai.RateLimitError,
-    429,
-    'You exceeded your current quota, please check your plan and billing details.',
-)
-BAD_KEY_ERROR = _openai_error(
-    openai.AuthenticationError, 401, 'Incorrect API key provided: sk-xxx.'
-)
+# Built per use, not shared as constants: raising one instance in several cases accumulates
+# __traceback__ and __context__ on it, which couples the cases through it.
+def quota_error() -> openai.APIStatusError:
+    return _openai_error(
+        openai.RateLimitError,
+        429,
+        'You exceeded your current quota, please check your plan and billing details.',
+    )
+
+
+def bad_key_error() -> openai.APIStatusError:
+    return _openai_error(openai.AuthenticationError, 401, 'Incorrect API key provided: sk-xxx.')
 
 
 class RaisingGraphiti:
@@ -51,7 +57,7 @@ class RaisingGraphiti:
 
 
 @pytest.fixture
-def client(monkeypatch):
+def build_client(monkeypatch):
     """A TestClient over the real app, with auth satisfied and no lifespan.
 
     No lifespan, so no Graphiti client is built and no index build runs; the dependency override
@@ -61,11 +67,11 @@ def client(monkeypatch):
     monkeypatch.setenv('OPENAI_API_KEY', 'sk-not-used')
     get_settings.cache_clear()
 
-    def _client(error: Exception):
+    def _build(error: Exception):
         app.dependency_overrides[get_graphiti] = lambda: RaisingGraphiti(error)
         return TestClient(app)
 
-    yield _client
+    yield _build
     app.dependency_overrides.clear()
     get_settings.cache_clear()
 
@@ -73,9 +79,9 @@ def client(monkeypatch):
 SEARCH_BODY = {'group_ids': ['demo'], 'query': 'who leads the payments team?', 'max_facts': 10}
 
 
-def test_exhausted_quota_is_not_an_internal_server_error(client):
+def test_exhausted_quota_is_not_an_internal_server_error(build_client):
     """A refused OpenAI call is upstream's fault, and the response should say which upstream."""
-    response = client(QUOTA_ERROR).post('/search', json=SEARCH_BODY, headers=AUTH)
+    response = build_client(quota_error()).post('/search', json=SEARCH_BODY, headers=AUTH)
 
     assert response.status_code == 429
     detail = response.json()['detail']
@@ -83,12 +89,38 @@ def test_exhausted_quota_is_not_an_internal_server_error(client):
     assert 'quota' in detail.lower()
 
 
-def test_rejected_openai_key_is_reported_as_a_bad_gateway(client):
+def test_rejected_openai_key_is_reported_as_a_bad_gateway(build_client):
     """The caller's key was fine; OPENAI_API_KEY is the one the operator has to go fix."""
-    response = client(BAD_KEY_ERROR).post('/search', json=SEARCH_BODY, headers=AUTH)
+    response = build_client(bad_key_error()).post('/search', json=SEARCH_BODY, headers=AUTH)
 
     assert response.status_code == 502
     assert 'OPENAI_API_KEY' in response.json()['detail']
+
+
+@pytest.mark.parametrize(
+    ('error', 'expected_status'),
+    [
+        pytest.param(
+            _openai_error(openai.InternalServerError, 500, 'The server had an error.'),
+            502,
+            id='openai-broke',
+        ),
+        pytest.param(
+            openai.APIConnectionError(request=httpx.Request('POST', 'https://api.openai.com')),
+            504,
+            id='never-reached-openai',
+        ),
+    ],
+)
+def test_other_openai_failures_are_gateway_errors(build_client, error, expected_status):
+    """The two fallback branches: an error OpenAI returned, and one where it never answered.
+
+    Neither is the caller's fault, so neither may come back as a 5xx pointing at this service.
+    """
+    response = build_client(error).post('/search', json=SEARCH_BODY, headers=AUTH)
+
+    assert response.status_code == expected_status
+    assert 'OpenAI' in response.json()['detail']
 
 
 async def _drain(worker: AsyncWorker):
@@ -118,7 +150,7 @@ async def test_worker_survives_a_failing_job():
 
     async def failing():
         ran.append('failing')
-        raise QUOTA_ERROR
+        raise quota_error()
 
     async def succeeding():
         ran.append('succeeding')
@@ -136,7 +168,7 @@ async def test_failing_job_is_logged(caplog):
     worker = AsyncWorker()
 
     async def failing():
-        raise QUOTA_ERROR
+        raise quota_error()
 
     await worker.queue.put(failing)
     with caplog.at_level('ERROR'):

--- a/server/tests/test_upstream_failures.py
+++ b/server/tests/test_upstream_failures.py
@@ -14,6 +14,7 @@ import openai
 import pytest
 from fastapi.testclient import TestClient
 
+from graph_service.config import get_settings
 from graph_service.main import app
 from graph_service.routers.ingest import AsyncWorker
 from graph_service.zep_graphiti import get_graphiti
@@ -58,8 +59,6 @@ def client(monkeypatch):
     """
     monkeypatch.setenv('GRAPHITI_API_KEY', API_KEY)
     monkeypatch.setenv('OPENAI_API_KEY', 'sk-not-used')
-    from graph_service.config import get_settings
-
     get_settings.cache_clear()
 
     def _client(error: Exception):
@@ -92,8 +91,12 @@ def test_rejected_openai_key_is_reported_as_a_bad_gateway(client):
     assert 'OPENAI_API_KEY' in response.json()['detail']
 
 
-async def _drain(worker: AsyncWorker, jobs: int):
-    """Run the worker until it has taken `jobs` jobs off the queue, or the worker dies."""
+async def _drain(worker: AsyncWorker):
+    """Run the worker until the queue is empty, then let the job it last took finish.
+
+    Polls rather than joins: the worker never calls queue.task_done(), so queue.join() would
+    block forever.
+    """
     await worker.start()
     for _ in range(200):
         if worker.queue.empty():
@@ -122,7 +125,7 @@ async def test_worker_survives_a_failing_job():
 
     await worker.queue.put(failing)
     await worker.queue.put(succeeding)
-    await _drain(worker, jobs=2)
+    await _drain(worker)
 
     assert ran == ['failing', 'succeeding'], 'the worker stopped after the failing job'
 
@@ -137,6 +140,6 @@ async def test_failing_job_is_logged(caplog):
 
     await worker.queue.put(failing)
     with caplog.at_level('ERROR'):
-        await _drain(worker, jobs=1)
+        await _drain(worker)
 
     assert any(r.exc_info for r in caplog.records), 'no traceback was logged'

--- a/server/tests/test_upstream_failures.py
+++ b/server/tests/test_upstream_failures.py
@@ -1,0 +1,142 @@
+"""What the service does when OpenAI refuses the request.
+
+The failure that motivated these: an exhausted OpenAI quota turned `POST /search` into a bare
+500 `Internal Server Error` and killed the ingestion worker silently, so `POST /messages` kept
+answering 202 into a queue nobody drained. Both looked like bugs in the graph query.
+
+Need no OpenAI key and no database: the Graphiti client is a stand-in that raises.
+"""
+
+import asyncio
+
+import httpx
+import openai
+import pytest
+from fastapi.testclient import TestClient
+
+from graph_service.main import app
+from graph_service.routers.ingest import AsyncWorker
+from graph_service.zep_graphiti import get_graphiti
+
+API_KEY = 'test-api-key-6Yp2Qk'
+AUTH = {'Authorization': f'Bearer {API_KEY}'}
+
+
+def _openai_error(cls: type[openai.APIStatusError], status: int, message: str):
+    """Build a real openai error, since the handler dispatches on the exception type."""
+    request = httpx.Request('POST', 'https://api.openai.com/v1/embeddings')
+    response = httpx.Response(status, request=request)
+    return cls(message, response=response, body={'error': {'message': message}})
+
+
+QUOTA_ERROR = _openai_error(
+    openai.RateLimitError,
+    429,
+    'You exceeded your current quota, please check your plan and billing details.',
+)
+BAD_KEY_ERROR = _openai_error(
+    openai.AuthenticationError, 401, 'Incorrect API key provided: sk-xxx.'
+)
+
+
+class RaisingGraphiti:
+    """Stands in for ZepGraphiti, failing the way an unusable OPENAI_API_KEY makes it fail."""
+
+    def __init__(self, error: Exception):
+        self.error = error
+
+    async def search(self, **_kwargs):
+        raise self.error
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """A TestClient over the real app, with auth satisfied and no lifespan.
+
+    No lifespan, so no Graphiti client is built and no index build runs; the dependency override
+    below is what the routers get instead.
+    """
+    monkeypatch.setenv('GRAPHITI_API_KEY', API_KEY)
+    monkeypatch.setenv('OPENAI_API_KEY', 'sk-not-used')
+    from graph_service.config import get_settings
+
+    get_settings.cache_clear()
+
+    def _client(error: Exception):
+        app.dependency_overrides[get_graphiti] = lambda: RaisingGraphiti(error)
+        return TestClient(app)
+
+    yield _client
+    app.dependency_overrides.clear()
+    get_settings.cache_clear()
+
+
+SEARCH_BODY = {'group_ids': ['demo'], 'query': 'who leads the payments team?', 'max_facts': 10}
+
+
+def test_exhausted_quota_is_not_an_internal_server_error(client):
+    """A refused OpenAI call is upstream's fault, and the response should say which upstream."""
+    response = client(QUOTA_ERROR).post('/search', json=SEARCH_BODY, headers=AUTH)
+
+    assert response.status_code == 429
+    detail = response.json()['detail']
+    assert 'OpenAI' in detail
+    assert 'quota' in detail.lower()
+
+
+def test_rejected_openai_key_is_reported_as_a_bad_gateway(client):
+    """The caller's key was fine; OPENAI_API_KEY is the one the operator has to go fix."""
+    response = client(BAD_KEY_ERROR).post('/search', json=SEARCH_BODY, headers=AUTH)
+
+    assert response.status_code == 502
+    assert 'OPENAI_API_KEY' in response.json()['detail']
+
+
+async def _drain(worker: AsyncWorker, jobs: int):
+    """Run the worker until it has taken `jobs` jobs off the queue, or the worker dies."""
+    await worker.start()
+    for _ in range(200):
+        if worker.queue.empty():
+            break
+        await asyncio.sleep(0.01)
+    await asyncio.sleep(0.05)
+    await worker.stop()
+
+
+@pytest.mark.asyncio
+async def test_worker_survives_a_failing_job():
+    """A job that raises must not take the worker down with it.
+
+    The worker outlives every request, so a job that kills it leaves /messages answering 202
+    for the rest of the process's life while nothing is ingested.
+    """
+    worker = AsyncWorker()
+    ran: list[str] = []
+
+    async def failing():
+        ran.append('failing')
+        raise QUOTA_ERROR
+
+    async def succeeding():
+        ran.append('succeeding')
+
+    await worker.queue.put(failing)
+    await worker.queue.put(succeeding)
+    await _drain(worker, jobs=2)
+
+    assert ran == ['failing', 'succeeding'], 'the worker stopped after the failing job'
+
+
+@pytest.mark.asyncio
+async def test_failing_job_is_logged(caplog):
+    """A dropped episode has to leave a trace, or ingestion fails where nobody can see it."""
+    worker = AsyncWorker()
+
+    async def failing():
+        raise QUOTA_ERROR
+
+    await worker.queue.put(failing)
+    with caplog.at_level('ERROR'):
+        await _drain(worker, jobs=1)
+
+    assert any(r.exc_info for r in caplog.records), 'no traceback was logged'

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -162,14 +162,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.2.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -262,6 +262,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "graphiti-core" },
     { name = "httpx" },
+    { name = "openai" },
     { name = "pydantic-settings" },
     { name = "uvicorn" },
 ]
@@ -286,6 +287,7 @@ requires-dist = [
     { name = "graphiti-core", specifier = ">=0.28.2" },
     { name = "graphiti-core", extras = ["falkordb"], marker = "extra == 'dev'", specifier = ">=0.28.2" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "openai", specifier = ">=1.92.2" },
     { name = "pydantic", marker = "extra == 'dev'", specifier = ">=2.8.2" },
     { name = "pydantic-settings", specifier = ">=2.4.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.380" },


### PR DESCRIPTION
An exhausted OpenAI quota made this service look broken: `POST /search` answered a bare
`500 Internal Server Error`, and the ingestion worker died on the first failing job — silently,
since nothing awaits its task — so `POST /messages` kept answering 202 into a queue with no
reader. Both read as bugs in the graph query; the real cause was only in the logs, as a traceback.

## Changes

- `graph_service/openai_errors.py` maps an `openai.APIError` to a status and a message naming
  what to go and fix: 429 for a rate limit or exhausted quota, 502 when OpenAI rejected this
  service's credentials (not 401/403 — the caller's `GRAPHITI_API_KEY` was fine), 504 when OpenAI
  was never reached. Registered in `main.py` on the base class, so a subclass the SDK adds later
  is still mapped.
- `AsyncWorker.worker` drops a failing episode and keeps going instead of ending ingestion for the
  life of the process. No retry: `add_episode` isn't idempotent and a dead key would retry forever.
- `openai` is declared as a direct dependency, since `main.py` imports it.
- README: `"success": true` means queued, not ingested; and which endpoint fails first when
  `OPENAI_API_KEY` is unusable.

## Testing

`tests/test_upstream_failures.py` — needs no OpenAI key and no database, so it runs in the default
`make test`. Covers each mapped status, plus that the worker survives a failing job and logs it.

`make lint` clean, 33 tests passing.

## Flagged for a reviewer, not changed

- Responses append OpenAI's own error text (`Upstream said: ...`). Deliberate — the caller here is
  the operator who set the key, and the message is the only place the rate-limit/quota distinction
  survives — but it does pass upstream account state to any bearer-token holder.
- `openai.OpenAIError` siblings that aren't `APIError` (`LengthFinishReasonError`,
  `ContentFilterFinishReasonError`) still surface as 500s. They describe a response that arrived
  rather than an upstream that refused us, so neither gateway status fits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)