### PR TITLE
feat(mcp): allow deployments to override the server instructions

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -254,6 +254,8 @@ The `config.yaml` file supports environment variable expansion using `${VAR_NAME
 - `AZURE_OPENAI_API_VERSION`: Optional Azure OpenAI API version
 - `USE_AZURE_AD`: Optional use Azure Managed Identities for authentication
 - `SEMAPHORE_LIMIT`: Episode processing concurrency. See [Concurrency and LLM Provider 429 Rate Limit Errors](#concurrency-and-llm-provider-429-rate-limit-errors)
+- `GRAPHITI_MCP_INSTRUCTIONS`: Optional replacement for the instructions sent to MCP clients on connect
+- `GRAPHITI_MCP_INSTRUCTIONS_FILE`: Optional path to read those instructions from, which is usually easier than a multi-paragraph environment variable. Ignored if `GRAPHITI_MCP_INSTRUCTIONS` is set; if the file cannot be read the built-in instructions are used and a warning is logged
 
 You can set these variables in a `.env` file in the project directory.
 

--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -172,6 +172,7 @@ When searching, use specific queries and consider filtering by group_id, type, o
 server requires a configured database and valid API keys for language-model operations.
 """
 
+
 def resolve_server_instructions() -> str:
     """Return the instructions advertised to MCP clients on connect.
 

--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -172,10 +172,50 @@ When searching, use specific queries and consider filtering by group_id, type, o
 server requires a configured database and valid API keys for language-model operations.
 """
 
+def resolve_server_instructions() -> str:
+    """Return the instructions advertised to MCP clients on connect.
+
+    Deployments often need to describe their own conventions here — which
+    group_ids exist, how to route facts between them, when to search before
+    answering. The built-in text cannot know any of that, so without an
+    override the only way to supply it is to edit this module, which means
+    maintaining a patched image.
+
+    Resolution order (first match wins):
+
+    1. ``GRAPHITI_MCP_INSTRUCTIONS`` — the instructions themselves.
+    2. ``GRAPHITI_MCP_INSTRUCTIONS_FILE`` — a path to read them from, which is
+       easier for the multi-paragraph text this field usually holds.
+    3. The built-in default below.
+
+    Environment rather than ``config.yaml`` because the FastMCP instance is
+    constructed at import time, before the configuration file is loaded.
+    """
+    inline = os.environ.get('GRAPHITI_MCP_INSTRUCTIONS')
+    if inline:
+        return inline
+
+    path = os.environ.get('GRAPHITI_MCP_INSTRUCTIONS_FILE')
+    if path:
+        try:
+            return Path(path).read_text(encoding='utf-8')
+        except OSError as e:
+            # Fall back rather than refusing to start: bad instructions are a
+            # much smaller problem than an unreachable memory server.
+            logger.warning(
+                'Could not read GRAPHITI_MCP_INSTRUCTIONS_FILE %s (%s); '
+                'using the built-in instructions',
+                path,
+                e,
+            )
+
+    return GRAPHITI_MCP_INSTRUCTIONS
+
+
 # MCP server instance
 mcp = FastMCP(
     'Graphiti Agent Memory',
-    instructions=GRAPHITI_MCP_INSTRUCTIONS,
+    instructions=resolve_server_instructions(),
 )
 
 # Global services

--- a/mcp_server/tests/test_server_instructions.py
+++ b/mcp_server/tests/test_server_instructions.py
@@ -1,0 +1,55 @@
+"""Tests for configurable MCP server instructions."""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv('GRAPHITI_MCP_INSTRUCTIONS', raising=False)
+    monkeypatch.delenv('GRAPHITI_MCP_INSTRUCTIONS_FILE', raising=False)
+
+
+def _resolve():
+    from graphiti_mcp_server import resolve_server_instructions
+
+    return resolve_server_instructions()
+
+
+def test_defaults_to_builtin_instructions():
+    from graphiti_mcp_server import GRAPHITI_MCP_INSTRUCTIONS
+
+    assert _resolve() == GRAPHITI_MCP_INSTRUCTIONS
+
+
+def test_inline_env_var_overrides_default(monkeypatch):
+    monkeypatch.setenv('GRAPHITI_MCP_INSTRUCTIONS', 'route facts to their own group')
+    assert _resolve() == 'route facts to their own group'
+
+
+def test_file_env_var_is_read(monkeypatch, tmp_path):
+    f = tmp_path / 'instructions.md'
+    f.write_text('line one\nline two\n', encoding='utf-8')
+    monkeypatch.setenv('GRAPHITI_MCP_INSTRUCTIONS_FILE', str(f))
+    assert _resolve() == 'line one\nline two\n'
+
+
+def test_inline_takes_precedence_over_file(monkeypatch, tmp_path):
+    f = tmp_path / 'instructions.md'
+    f.write_text('from file', encoding='utf-8')
+    monkeypatch.setenv('GRAPHITI_MCP_INSTRUCTIONS_FILE', str(f))
+    monkeypatch.setenv('GRAPHITI_MCP_INSTRUCTIONS', 'from env')
+    assert _resolve() == 'from env'
+
+
+def test_unreadable_file_falls_back_instead_of_raising(monkeypatch, tmp_path):
+    """A bad path must not stop the server from starting."""
+    from graphiti_mcp_server import GRAPHITI_MCP_INSTRUCTIONS
+
+    monkeypatch.setenv('GRAPHITI_MCP_INSTRUCTIONS_FILE', str(tmp_path / 'does-not-exist.md'))
+    assert _resolve() == GRAPHITI_MCP_INSTRUCTIONS

--- a/mcp_server/tests/test_server_instructions.py
+++ b/mcp_server/tests/test_server_instructions.py
@@ -1,6 +1,5 @@
 """Tests for configurable MCP server instructions."""
 
-import os
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
## Summary

`GRAPHITI_MCP_INSTRUCTIONS` is a module-level constant passed straight into `FastMCP(...)`, so the only way to change what MCP clients are told on connect is to edit `graphiti_mcp_server.py`. For anyone running the server as a container that means maintaining a patched image purely to carry a few paragraphs of text.

That text is exactly where a deployment's own conventions belong — which `group_id`s exist, how to route facts between them, when to search before answering. The built-in default cannot know any of that, and it is the first thing every connecting client reads.

## Change

A small `resolve_server_instructions()` helper, checked in order:

1. `GRAPHITI_MCP_INSTRUCTIONS` — the instructions themselves
2. `GRAPHITI_MCP_INSTRUCTIONS_FILE` — a path to read them from
3. the built-in default (unchanged)

```python
mcp = FastMCP(
    'Graphiti Agent Memory',
    instructions=resolve_server_instructions(),
)
```

**Why environment and not `config.yaml`:** the `FastMCP` instance is constructed at import time, before the configuration file is loaded. `FastMCP.instructions` is a read-only property over `self._mcp_server.instructions`, so setting it later in `initialize_server()` would mean writing to a private attribute. Resolving before construction keeps this to public API only.

**Why a file path as well as an inline variable:** this field is normally multi-paragraph, which is awkward to carry in an environment variable and unpleasant to quote in compose files.

**Unreadable file falls back rather than raising** — it logs a warning and uses the default. Wrong instructions are a much smaller problem than a memory server that will not start.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] Documentation/Tests

## Objective

Let deployments describe their own memory conventions without forking the image. This came out of running the MCP server against FalkorDB with several active `group_id`s, where the routing rules an agent needs are entirely site-specific.

## Testing

- [x] Unit tests added — `mcp_server/tests/test_server_instructions.py`, five cases: default, inline override, file override, inline-beats-file precedence, and unreadable-file fallback.
- [ ] Integration tests added/updated
- [x] Existing tests unaffected — the change is additive and the default path is byte-identical to before.

> Note: I verified the resolution order by exercising the function's logic directly (all five cases pass) but could not run the repository's `pytest` suite in my environment. Worth a CI run.

## Breaking Changes

- [ ] This PR contains breaking changes

With neither variable set, behaviour is exactly as before.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated where necessary — both variables added to the environment table in `mcp_server/README.md`
- [x] No secrets or sensitive information committed
