### PR TITLE
fix(mcp): serialize driver temporal types in node/edge attributes

### DIFF
--- a/mcp_server/src/utils/formatting.py
+++ b/mcp_server/src/utils/formatting.py
@@ -1,11 +1,62 @@
 """Formatting utilities for Graphiti MCP Server."""
 
+import json
+from datetime import date, datetime, time, timedelta
 from typing import Any
 
 from graphiti_core.edges import EntityEdge
 from graphiti_core.nodes import EntityNode
 
 from models.response_types import EdgeResult, NodeResult
+
+
+def _json_safe(value: Any) -> Any:
+    """Recursively convert driver-specific values into JSON-serializable ones.
+
+    Graph drivers return temporal properties as their own types rather than
+    Python's built-ins -- ``neo4j.time.DateTime``, for instance, is not a
+    ``datetime`` subclass. Those values reach us inside ``attributes``, an
+    untyped ``dict[str, Any]`` that Pydantic's JSON mode passes through
+    unconverted, so serializing the response later raises.
+
+    Detection is duck-typed rather than isinstance-based on purpose: this
+    package depends on ``graphiti-core[falkordb]`` and does not require the
+    neo4j driver, so this module must not import any driver package.
+    """
+    if isinstance(value, dict):
+        return {key: _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, datetime | date | time):
+        return value.isoformat()
+    if isinstance(value, timedelta):
+        return str(value)
+
+    # Driver temporal types (neo4j.time.Date/Time/DateTime and equivalents)
+    # expose to_native(); Duration-like types do not and fall through to str().
+    to_native = getattr(value, 'to_native', None)
+    if callable(to_native):
+        try:
+            native = to_native()
+        except Exception:
+            return str(value)
+        native_isoformat = getattr(native, 'isoformat', None)
+        return native_isoformat() if callable(native_isoformat) else str(native)
+
+    isoformat = getattr(value, 'isoformat', None)
+    if callable(isoformat):
+        try:
+            return isoformat()
+        except Exception:
+            return str(value)
+
+    # Anything still unencodable (driver Duration types, for example) degrades
+    # to its string form rather than breaking the whole response.
+    try:
+        json.dumps(value)
+    except (TypeError, ValueError):
+        return str(value)
+    return value
 
 
 def to_node_result(node: EntityNode) -> NodeResult:
@@ -19,7 +70,7 @@ def to_node_result(node: EntityNode) -> NodeResult:
         created_at=node.created_at.isoformat() if node.created_at else None,
         summary=node.summary,
         group_id=node.group_id,
-        attributes=attrs,
+        attributes=_json_safe(attrs),
     )
 
 
@@ -41,8 +92,9 @@ def to_edge_result(edge: EntityEdge) -> EdgeResult:
 def format_node_result(node: EntityNode) -> dict[str, Any]:
     """Format an entity node into a readable result.
 
-    Since EntityNode is a Pydantic BaseModel, we can use its built-in serialization capabilities.
-    Excludes embedding vectors to reduce payload size and avoid exposing internal representations.
+    Typed fields are serialized by Pydantic's JSON mode. ``attributes`` is
+    excluded from that pass and sanitized separately, because it is an untyped
+    bag that can hold driver temporal types Pydantic cannot serialize.
 
     Args:
         node: The EntityNode to format
@@ -54,17 +106,24 @@ def format_node_result(node: EntityNode) -> dict[str, Any]:
         mode='json',
         exclude={
             'name_embedding',
+            'attributes',
         },
     )
-    # Remove any embedding that might be in attributes
-    result.get('attributes', {}).pop('name_embedding', None)
+    attributes = _json_safe(node.attributes or {})
+    attributes.pop('name_embedding', None)
+    result['attributes'] = attributes
     return result
 
 
 def format_fact_result(edge: EntityEdge) -> dict[str, Any]:
     """Format an entity edge into a readable result.
 
-    Since EntityEdge is a Pydantic BaseModel, we can use its built-in serialization capabilities.
+    Typed fields are serialized by Pydantic's JSON mode. ``attributes`` is
+    excluded from that pass and sanitized separately, because it is an untyped
+    bag that can hold driver temporal types Pydantic cannot serialize. This
+    shows up in practice when the installed ``graphiti-core`` predates a field
+    the driver returns: the value stays in ``attributes`` as a raw driver type
+    instead of being parsed onto the model.
 
     Args:
         edge: The EntityEdge to format
@@ -76,7 +135,10 @@ def format_fact_result(edge: EntityEdge) -> dict[str, Any]:
         mode='json',
         exclude={
             'fact_embedding',
+            'attributes',
         },
     )
-    result.get('attributes', {}).pop('fact_embedding', None)
+    attributes = _json_safe(edge.attributes or {})
+    attributes.pop('fact_embedding', None)
+    result['attributes'] = attributes
     return result

--- a/mcp_server/tests/test_formatting.py
+++ b/mcp_server/tests/test_formatting.py
@@ -1,0 +1,155 @@
+"""Unit tests for response formatting helpers.
+
+These cover the case where a graph driver returns temporal values as its own
+types rather than Python built-ins. Such values arrive inside ``attributes``,
+an untyped dict Pydantic's JSON mode does not convert, so without sanitizing
+them the formatted response cannot be JSON-encoded.
+
+The fake driver types below stand in for ``neo4j.time`` so these tests run
+without the neo4j driver installed -- this package only requires
+``graphiti-core[falkordb]``.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from graphiti_core.edges import EntityEdge
+from graphiti_core.nodes import EntityNode
+
+from utils.formatting import format_fact_result, format_node_result, to_node_result
+
+NOW = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+
+class FakeDriverDateTime:
+    """Stands in for neo4j.time.DateTime: not a datetime, but has to_native()."""
+
+    def __init__(self, native: datetime):
+        self._native = native
+
+    def to_native(self) -> datetime:
+        return self._native
+
+
+class FakeDriverDuration:
+    """Stands in for neo4j.time.Duration: no to_native(), no isoformat()."""
+
+    def __str__(self) -> str:
+        return 'P1DT2H'
+
+
+class FakeUnconvertible:
+    """A driver type whose to_native() raises; must degrade to str(), not blow up."""
+
+    def to_native(self):
+        raise ValueError('cannot convert')
+
+    def __str__(self) -> str:
+        return 'unconvertible'
+
+
+def _edge(attributes: dict) -> EntityEdge:
+    return EntityEdge(
+        uuid='edge-uuid',
+        group_id='group',
+        source_node_uuid='src-uuid',
+        target_node_uuid='tgt-uuid',
+        name='RELATES_TO',
+        fact='a relates to b',
+        created_at=NOW,
+        attributes=attributes,
+    )
+
+
+def _node(attributes: dict) -> EntityNode:
+    return EntityNode(
+        uuid='node-uuid',
+        name='Entity',
+        group_id='group',
+        labels=['Entity'],
+        created_at=NOW,
+        summary='a summary',
+        attributes=attributes,
+    )
+
+
+def test_format_fact_result_serializes_driver_datetime():
+    result = format_fact_result(_edge({'reference_time': FakeDriverDateTime(NOW)}))
+
+    assert result['attributes']['reference_time'] == NOW.isoformat()
+    json.dumps(result)
+
+
+def test_format_node_result_serializes_driver_datetime():
+    result = format_node_result(_node({'observed_at': FakeDriverDateTime(NOW)}))
+
+    assert result['attributes']['observed_at'] == NOW.isoformat()
+    json.dumps(result)
+
+
+def test_to_node_result_serializes_driver_datetime():
+    result = to_node_result(_node({'observed_at': FakeDriverDateTime(NOW)}))
+
+    assert result['attributes']['observed_at'] == NOW.isoformat()
+    json.dumps(result)
+
+
+def test_nested_containers_are_sanitized():
+    attributes = {
+        'history': [{'at': FakeDriverDateTime(NOW)}],
+        'nested': {'inner': {'at': FakeDriverDateTime(NOW)}},
+    }
+
+    result = format_fact_result(_edge(attributes))
+
+    assert result['attributes']['history'][0]['at'] == NOW.isoformat()
+    assert result['attributes']['nested']['inner']['at'] == NOW.isoformat()
+    json.dumps(result)
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        (FakeDriverDuration(), 'P1DT2H'),
+        (FakeUnconvertible(), 'unconvertible'),
+        (timedelta(days=1), str(timedelta(days=1))),
+        (NOW, NOW.isoformat()),
+    ],
+)
+def test_non_native_values_degrade_to_strings(value, expected):
+    result = format_fact_result(_edge({'value': value}))
+
+    assert result['attributes']['value'] == expected
+    json.dumps(result)
+
+
+def test_plain_values_pass_through_unchanged():
+    attributes = {'count': 3, 'label': 'x', 'ok': True, 'missing': None}
+
+    result = format_fact_result(_edge(attributes))
+
+    assert result['attributes'] == attributes
+    json.dumps(result)
+
+
+def test_embeddings_are_still_stripped():
+    edge_result = format_fact_result(_edge({'fact_embedding': [0.1, 0.2]}))
+    node_result = format_node_result(_node({'name_embedding': [0.1, 0.2]}))
+    typed_node_result = to_node_result(_node({'name_embedding': [0.1, 0.2]}))
+
+    assert 'fact_embedding' not in edge_result['attributes']
+    assert 'fact_embedding' not in edge_result
+    assert 'name_embedding' not in node_result['attributes']
+    assert 'name_embedding' not in node_result
+    assert 'name_embedding' not in typed_node_result['attributes']
+
+
+def test_typed_fields_are_still_serialized():
+    result = format_fact_result(_edge({}))
+
+    assert result['uuid'] == 'edge-uuid'
+    assert result['fact'] == 'a relates to b'
+    # Pydantic's JSON mode renders UTC as a trailing 'Z'; compare instants.
+    assert datetime.fromisoformat(result['created_at'].replace('Z', '+00:00')) == NOW
+    assert result['attributes'] == {}


### PR DESCRIPTION
## Summary

Graph drivers return temporal properties as their own types rather than Python built-ins — `neo4j.time.DateTime` is not a `datetime` subclass. When such a value ends up in `attributes` (an untyped `dict[str, Any]`), Pydantic's JSON mode cannot serialize it: `model_dump(mode='json')` raises `PydanticSerializationError`, so the MCP response fails.

## How driver temporals reach `attributes`

`get_entity_edge_from_record` (`graphiti_core/edges.py`) hydrates `attributes` by taking **all** stored edge properties and popping a hardcoded list of declared field names; whatever remains stays in the bag **exactly as the driver returned it**. Two ways a raw `neo4j.time.DateTime` survives that filter:

1. **Custom entity/edge types** — user-defined typed fields are stored as Neo4j temporal properties, aren't in the pop list, and come back in `attributes` as raw driver types.
2. **Version skew** — an installed `graphiti-core` whose pop list predates a field the database stores (e.g. `reference_time`, visibly a recent addition to that list) leaves the value in `attributes` instead of parsing it onto the model.

`attributes` is exposed in three response paths, all affected:

- `format_fact_result` — `search_memory_facts`, `get_entity_edge`
- `format_node_result`
- `to_node_result` — `search_memory_nodes` and the node lists in saga/episode responses

Each now sanitizes the attribute bag and excludes it from the Pydantic pass, so typed fields serialize exactly as before.

## Live verification (Neo4j 5.26, driver 5.28.1)

Against a production graph (46,942 `RELATES_TO` edges), `properties(e)` returns `neo4j.time.DateTime` for every stored temporal (`created_at`, `valid_at`, `invalid_at`, `expired_at`), and `json.dumps` on those raw properties raises `TypeError: Object of type DateTime is not JSON serializable`.

Placing one of those real driver values into `attributes` (as either trigger above produces):

```
upstream main:  PydanticSerializationError: Unable to serialize unknown type:
                <class 'neo4j.time.DateTime'>
this PR:        json.dumps succeeds; value round-trips exactly
                neo4j.time.DateTime(2026, 4, 16, 20, 1, 7, 386872000, tzinfo=<UTC>)
                -> '2026-04-16T20:01:07.386872+00:00'
```

## Why duck-typed instead of `isinstance`

`mcp_server` depends on `graphiti-core[falkordb]` and does not require the neo4j driver, so this module must not import a driver package — a top-level `from neo4j.time import ...` would break the default install. Conversion goes through `to_native()` / `isoformat()` when present (verified against driver 5.28.1: `DateTime` is not a `datetime` subclass and does expose `to_native()`), and anything still unencodable (driver `Duration` types, for instance) degrades to its string form rather than failing the whole response. This also keeps the fix provider-agnostic for FalkorDB and future drivers.

## Testing

New `mcp_server/tests/test_formatting.py`, 11 cases. Fake driver types stand in for `neo4j.time`, so the suite runs without the neo4j driver installed:

- driver datetimes serialized in all three call sites
- nested dicts and lists sanitized recursively
- `Duration`-like values, values whose `to_native()` raises, `timedelta` and plain `datetime` all degrade sensibly
- JSON primitives pass through byte-identical
- embeddings still stripped from both the payload and the attribute bag
- typed fields still serialized

```
71 passed   # test_formatting, test_configuration, test_core_parity, test_factories, test_falkordb_config
ruff check / ruff format --check   clean
pyright src/utils/formatting.py    0 errors, 0 warnings
```

`test_async_operations`, `test_cross_encoder_factory` and `test_stress_load` fail to collect on a pristine checkout too (`ModuleNotFoundError: test_fixtures`) — pre-existing, unrelated to this change.
