### PR TITLE
Fix infinite loop in label_propagation on disconnected graphs

### DIFF
--- a/graphiti_core/driver/operations/graph_utils.py
+++ b/graphiti_core/driver/operations/graph_utils.py
@@ -24,12 +24,21 @@ class Neighbor(BaseModel):
     edge_count: int
 
 
+MAX_LABEL_PROPAGATION_ITERATIONS = 100
+
+
 def label_propagation(projection: dict[str, list[Neighbor]]) -> list[list[str]]:
+    # Updates are applied in place (asynchronous propagation) rather than via a
+    # separate snapshot swapped in at the end of each pass. Batching all updates
+    # together lets two nodes trade labels back and forth in lockstep on some
+    # graph shapes (e.g. several small components with degree-1 nodes),
+    # oscillating forever instead of converging; applying updates as they're
+    # computed breaks that symmetry. The iteration cap is a backstop in case a
+    # graph shape still oscillates despite that.
     community_map = {uuid: i for i, uuid in enumerate(projection.keys())}
 
-    while True:
+    for _ in range(MAX_LABEL_PROPAGATION_ITERATIONS):
         no_change = True
-        new_community_map: dict[str, int] = {}
 
         for uuid, neighbors in projection.items():
             curr_community = community_map[uuid]
@@ -48,15 +57,12 @@ def label_propagation(projection: dict[str, list[Neighbor]]) -> list[list[str]]:
             else:
                 new_community = max(community_candidate, curr_community)
 
-            new_community_map[uuid] = new_community
-
             if new_community != curr_community:
+                community_map[uuid] = new_community
                 no_change = False
 
         if no_change:
             break
-
-        community_map = new_community_map
 
     community_cluster_map: dict[int, list[str]] = defaultdict(list)
     for uuid, community in community_map.items():

--- a/graphiti_core/utils/maintenance/community_operations.py
+++ b/graphiti_core/utils/maintenance/community_operations.py
@@ -90,18 +90,29 @@ async def get_community_clusters(
     return community_clusters
 
 
+MAX_LABEL_PROPAGATION_ITERATIONS = 100
+
+
 def label_propagation(projection: dict[str, list[Neighbor]]) -> list[list[str]]:
     # Implement the label propagation community detection algorithm.
     # 1. Start with each node being assigned its own community
     # 2. Each node will take on the community of the plurality of its neighbors
     # 3. Ties are broken by going to the largest community
-    # 4. Continue until no communities change during propagation
+    # 4. Continue until no communities change during propagation, or a max
+    #    iteration count is reached.
+    #
+    # Updates are applied in place (asynchronous propagation) rather than via a
+    # separate snapshot swapped in at the end of each pass. Batching all updates
+    # together lets two nodes trade labels back and forth in lockstep on some
+    # graph shapes (e.g. several small components with degree-1 nodes),
+    # oscillating forever instead of converging; applying updates as they're
+    # computed breaks that symmetry. The iteration cap is a backstop in case a
+    # graph shape still oscillates despite that.
 
     community_map = {uuid: i for i, uuid in enumerate(projection.keys())}
 
-    while True:
+    for _ in range(MAX_LABEL_PROPAGATION_ITERATIONS):
         no_change = True
-        new_community_map: dict[str, int] = {}
 
         for uuid, neighbors in projection.items():
             curr_community = community_map[uuid]
@@ -120,15 +131,12 @@ def label_propagation(projection: dict[str, list[Neighbor]]) -> list[list[str]]:
             else:
                 new_community = max(community_candidate, curr_community)
 
-            new_community_map[uuid] = new_community
-
             if new_community != curr_community:
+                community_map[uuid] = new_community
                 no_change = False
 
         if no_change:
             break
-
-        community_map = new_community_map
 
     community_cluster_map = defaultdict(list)
     for uuid, community in community_map.items():


### PR DESCRIPTION
## Summary

`label_propagation` (the community-detection clustering algorithm used by `build_communities`) can loop forever on graphs with several small disconnected components containing degree-1 nodes. Its convergence loop built a snapshot of updated labels and swapped it in at the end of each pass; on the right graph shape, two nodes can end up trading community labels back and forth in lockstep every pass, so the `no_change` check never becomes `True`.

Since the loop is synchronous with no `await` inside it, this doesn't just hang the one request — it blocks the entire asyncio event loop, so a single unlucky `build_communities` call freezes the whole server for every other in-flight and incoming request too.

There are two copies of this same algorithm in the codebase (`graphiti_core/utils/maintenance/community_operations.py` and the shared `graphiti_core/driver/operations/graph_utils.py` used by the Neo4j/FalkorDB/Kuzu/Neptune drivers) — both had the identical bug and both are fixed here.

## Fix

- Apply label updates in place as they're computed (asynchronous propagation) instead of via a separate snapshot swapped in afterward. This breaks the lockstep symmetry that causes the oscillation.
- Add a hard iteration cap (`MAX_LABEL_PROPAGATION_ITERATIONS = 100`) as a backstop in case some other graph shape still doesn't converge, so the loop is now guaranteed to terminate regardless.

## How this was found / verified

Reproduced by building a small knowledge graph (via `add_memory`) that ended up with four disconnected clusters, then calling `build_communities` — it hung indefinitely at high CPU with no progress. Isolated the repro by pulling the exact neighbor projection from Neo4j and running the algorithm standalone: the original implementation did not converge after 1000 iterations. The fixed version converges immediately (~0.3s end-to-end through `get_community_clusters`) and produces the expected 4 clusters. Confirmed the fix through the actual `build_communities` MCP tool end-to-end afterward (4 communities built with real LLM summaries, no hang).

## Test plan
- [x] Existing community-building tests still pass
- [x] Manual repro: a group with several small disconnected clusters (e.g. multiple unrelated 2-3 node components) no longer hangs `build_communities`
