### PR TITLE
fix(search): rank all edge candidates with the cross-encoder, not just the first `limit` (#1642)

### DIFF
--- a/graphiti_core/search/search.py
+++ b/graphiti_core/search/search.py
@@ -393,9 +393,7 @@ async def edge_search(
                         reranker_min_score,
                     )
             elif config.reranker == EdgeReranker.cross_encoder:
-                fact_to_uuid_map = {
-                    edge.fact: edge.uuid for edge in list(edge_uuid_map.values())[:limit]
-                }
+                fact_to_uuid_map = {edge.fact: edge.uuid for edge in list(edge_uuid_map.values())}
                 with _trace_phase(
                     search_tracer,
                     'search.edge_search.cross_encoder_rank',


### PR DESCRIPTION
## Description

Fixes #1642.

In `edge_search`, the `cross_encoder` reranker truncates the merged candidate pool to `[:limit]` **before** scoring:

```python
fact_to_uuid_map = {
    edge.fact: edge.uuid for edge in list(edge_uuid_map.values())[:limit]
}
```

Since `edge_uuid_map` preserves the insertion order of `search_results`, candidates retrieved by later search methods (vector similarity, BFS) can be dropped before the cross-encoder ever scores them. As a result, hybrid-search recall is reduced and cross-encoder ranking quality becomes dependent on retrieval-method ordering.

## Fix

Rank the full merged candidate set with the cross-encoder and let the existing tail slice cap the output.

This makes `edge_search` consistent with the rest of the codebase:

- The other edge rerankers (`rrf`, `mmr`, `node_distance`) all operate on the full `edge_uuid_map`, and the result is truncated to `limit` only at the end via `return reranked_edges[:limit], edge_scores[:limit]`.
- The sibling `node_search` and `community_search` cross-encoder paths already pass their full candidate maps to `cross_encoder.rank(...)` with no pre-truncation.

The change is a single line — removing the `[:limit]` slice — so no candidate is discarded before reranking, while the final output is still limited exactly as before.

## Notes

I deliberately kept this minimal and did **not** add a separate `candidate_limit` config or a round-robin merge (both mentioned in the issue as possible enhancements): correctness here only requires that the cross-encoder see the same candidate set the other rerankers already do. A balanced/round-robin merge across search methods would be a reasonable follow-up but is a broader design change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
