### PR TITLE
fix(mcp): surface ingestion queue failures in status

### DIFF
--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -1059,13 +1059,27 @@ async def clear_graph(
 @mcp.tool()
 async def get_status() -> StatusResponse:
     """Get the status of the Graphiti MCP server and database connection."""
-    global graphiti_service
+    global graphiti_service, queue_service
 
-    if graphiti_service is None:
-        return StatusResponse(status='error', message='Graphiti service not initialized')
+    if graphiti_service is None or queue_service is None:
+        return StatusResponse(
+            status='error',
+            message='Graphiti service not initialized',
+            ingestion={
+                'status': 'unavailable',
+                'recent_failure_count': 0,
+                'consecutive_failure_count': 0,
+                'failing_group_count': 0,
+                'last_failure_at': None,
+                'last_failure_group_id': None,
+                'pending_episode_count': 0,
+                'active_worker_count': 0,
+            },
+        )
 
     try:
         client = await graphiti_service.get_client()
+        ingestion_status = queue_service.get_ingestion_status()
 
         # Test database connection with a simple query
         async with client.driver.session() as session:
@@ -1076,9 +1090,20 @@ async def get_status() -> StatusResponse:
 
         # Use the provider from the service's config, not the global
         provider_name = graphiti_service.config.database.provider
+        if ingestion_status['status'] == 'degraded':
+            return StatusResponse(
+                status='degraded',
+                message=(
+                    f'Graphiti MCP server is connected to {provider_name} database, '
+                    'but ingestion workers have terminal failures'
+                ),
+                ingestion=ingestion_status,
+            )
+
         return StatusResponse(
             status='ok',
             message=f'Graphiti MCP server is running and connected to {provider_name} database',
+            ingestion=ingestion_status,
         )
     except Exception as e:
         error_msg = str(e)
@@ -1086,6 +1111,7 @@ async def get_status() -> StatusResponse:
         return StatusResponse(
             status='error',
             message=f'Graphiti MCP server is running but database connection failed: {error_msg}',
+            ingestion=queue_service.get_ingestion_status(),
         )
 
 

--- a/mcp_server/src/models/response_types.py
+++ b/mcp_server/src/models/response_types.py
@@ -38,9 +38,21 @@ class EpisodeSearchResponse(TypedDict):
     episodes: list[dict[str, Any]]
 
 
+class IngestionStatusResponse(TypedDict):
+    status: str
+    recent_failure_count: int
+    consecutive_failure_count: int
+    failing_group_count: int
+    last_failure_at: str | None
+    last_failure_group_id: str | None
+    pending_episode_count: int
+    active_worker_count: int
+
+
 class StatusResponse(TypedDict):
     status: str
     message: str
+    ingestion: IngestionStatusResponse
 
 
 class SagaSummaryResponse(TypedDict):

--- a/mcp_server/src/services/queue_service.py
+++ b/mcp_server/src/services/queue_service.py
@@ -2,11 +2,16 @@
 
 import asyncio
 import logging
+from collections import deque
 from collections.abc import Awaitable, Callable
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from models.response_types import IngestionStatusResponse
+
 logger = logging.getLogger(__name__)
+
+FAILURE_WINDOW = timedelta(minutes=15)
 
 
 class QueueService:
@@ -20,6 +25,10 @@ class QueueService:
         self._queue_workers: dict[str, bool] = {}
         # Store the graphiti client after initialization
         self._graphiti_client: Any = None
+        self._recent_failures: deque[tuple[str, datetime]] = deque()
+        self._consecutive_failures: dict[str, int] = {}
+        self._last_failure_at: datetime | None = None
+        self._last_failure_group_id: str | None = None
 
     async def add_episode_task(
         self, group_id: str, process_func: Callable[[], Awaitable[None]]
@@ -65,9 +74,12 @@ class QueueService:
                     # Process the episode
                     await process_func()
                 except Exception as e:
-                    logger.error(
+                    self._record_failure(group_id)
+                    logger.exception(
                         f'Error processing queued episode for group_id {group_id}: {str(e)}'
                     )
+                else:
+                    self._record_success(group_id)
                 finally:
                     # Mark the task as done regardless of success/failure
                     self._episode_queues[group_id].task_done()
@@ -78,6 +90,42 @@ class QueueService:
         finally:
             self._queue_workers[group_id] = False
             logger.info(f'Stopped episode queue worker for group_id: {group_id}')
+
+    def _record_failure(self, group_id: str) -> None:
+        """Record a terminal ingestion failure without retaining episode data."""
+        now = datetime.now(timezone.utc)
+        self._recent_failures.append((group_id, now))
+        self._consecutive_failures[group_id] = self._consecutive_failures.get(group_id, 0) + 1
+        self._last_failure_at = now
+        self._last_failure_group_id = group_id
+        self._prune_recent_failures(now)
+
+    def _record_success(self, group_id: str) -> None:
+        """Clear this group's consecutive failure state after a successful ingestion."""
+        self._consecutive_failures.pop(group_id, None)
+
+    def _prune_recent_failures(self, now: datetime) -> None:
+        cutoff = now - FAILURE_WINDOW
+        while self._recent_failures and self._recent_failures[0][1] < cutoff:
+            self._recent_failures.popleft()
+
+    def get_ingestion_status(self) -> IngestionStatusResponse:
+        """Return a sanitized queue-health summary for operational status reporting."""
+        self._prune_recent_failures(datetime.now(timezone.utc))
+        failing_groups = {
+            group_id: count for group_id, count in self._consecutive_failures.items() if count > 0
+        }
+
+        return {
+            'status': 'degraded' if failing_groups else 'ok',
+            'recent_failure_count': len(self._recent_failures),
+            'consecutive_failure_count': sum(failing_groups.values()),
+            'failing_group_count': len(failing_groups),
+            'last_failure_at': self._last_failure_at.isoformat() if self._last_failure_at else None,
+            'last_failure_group_id': self._last_failure_group_id,
+            'pending_episode_count': sum(queue.qsize() for queue in self._episode_queues.values()),
+            'active_worker_count': sum(self._queue_workers.values()),
+        }
 
     def get_queue_size(self, group_id: str) -> int:
         """Get the current queue size for a group_id."""

--- a/mcp_server/tests/test_core_parity.py
+++ b/mcp_server/tests/test_core_parity.py
@@ -10,6 +10,7 @@ import inspect
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -221,6 +222,86 @@ class TestQueueServiceThreading:
 
         kwargs = client.add_episode.await_args.kwargs
         assert before <= kwargs['reference_time'] <= after
+
+    @pytest.mark.asyncio
+    async def test_tracks_terminal_failures_and_resets_after_success(self):
+        service = QueueService()
+
+        async def fail():
+            raise RuntimeError('provider response failed')
+
+        async def succeed():
+            return None
+
+        await service.add_episode_task('group-a', fail)
+        await service._episode_queues['group-a'].join()
+
+        failed_status = service.get_ingestion_status()
+        assert failed_status['status'] == 'degraded'
+        assert failed_status['recent_failure_count'] == 1
+        assert failed_status['consecutive_failure_count'] == 1
+        assert failed_status['last_failure_group_id'] == 'group-a'
+        assert failed_status['last_failure_at'] is not None
+
+        await service.add_episode_task('group-b', succeed)
+        await service._episode_queues['group-b'].join()
+
+        unaffected_status = service.get_ingestion_status()
+        assert unaffected_status['status'] == 'degraded'
+        assert unaffected_status['consecutive_failure_count'] == 1
+        assert unaffected_status['failing_group_count'] == 1
+
+        await service.add_episode_task('group-a', succeed)
+        await service._episode_queues['group-a'].join()
+
+        recovered_status = service.get_ingestion_status()
+        assert recovered_status['status'] == 'ok'
+        assert recovered_status['recent_failure_count'] == 1
+        assert recovered_status['consecutive_failure_count'] == 0
+        assert recovered_status['last_failure_group_id'] == 'group-a'
+
+
+class TestMcpStatus:
+    @pytest.mark.asyncio
+    async def test_status_is_degraded_when_ingestion_has_terminal_failures(self, monkeypatch):
+        import graphiti_mcp_server as mcp_server
+
+        class FakeSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, traceback):
+                return False
+
+            async def run(self, query):
+                return []
+
+        class FakeDriver:
+            def session(self):
+                return FakeSession()
+
+        class FakeService:
+            config = SimpleNamespace(database=SimpleNamespace(provider='test'))
+
+            async def get_client(self):
+                return SimpleNamespace(driver=FakeDriver())
+
+        queue = QueueService()
+
+        async def fail():
+            raise RuntimeError('provider response failed')
+
+        await queue.add_episode_task('group-a', fail)
+        await queue._episode_queues['group-a'].join()
+
+        monkeypatch.setattr(mcp_server, 'graphiti_service', FakeService())
+        monkeypatch.setattr(mcp_server, 'queue_service', queue)
+
+        status = await mcp_server.get_status()
+
+        assert status['status'] == 'degraded'
+        assert status['ingestion']['status'] == 'degraded'
+        assert status['ingestion']['last_failure_group_id'] == 'group-a'
 
 
 class TestCoreSignatureCompatibility:


### PR DESCRIPTION
## Summary

Adds the bounded operational-signal slice discussed in #1707:

- tracks recent terminal queue failures and per-group consecutive failures
- exposes a sanitized ingestion health summary from `get_status`
- marks status as `degraded` when the database is connected but queue ingestion is failing
- clears a group's consecutive failure state only after that group successfully ingests an episode

The summary intentionally excludes episode bodies, provider error details, and credentials. This does not change durable enqueue/replay behavior; it makes silent drops visible while the broader contract work remains separate.

## Validation

- `uv run pytest tests/test_core_parity.py -q`
- `uv run ruff check src/services/queue_service.py src/graphiti_mcp_server.py src/models/response_types.py tests/test_core_parity.py`
- `uv run ruff format --check src/services/queue_service.py src/graphiti_mcp_server.py src/models/response_types.py tests/test_core_parity.py`
- `uv run pyright src`