### PR TITLE
feat(otel): OpenTelemetry metrics + span instrumentation for core mem…

### DIFF
--- a/OTEL_TRACING.md
+++ b/OTEL_TRACING.md
@@ -41,6 +41,44 @@ kuzu_driver = KuzuDriver()
 graphiti = Graphiti(graph_driver=kuzu_driver, tracer=tracer)
 ```
 
+## Metrics
+
+In addition to spans, Graphiti can emit OpenTelemetry metrics for its core memory
+operations. Like tracing, metrics are optional — without a meter, a no-op
+implementation is used with zero overhead.
+
+```python
+from opentelemetry import metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from graphiti_core import Graphiti
+from graphiti_core.meter import create_meter
+
+metrics.set_meter_provider(MeterProvider())
+otel_meter = metrics.get_meter("graphiti", version="0.1.0")
+
+graphiti = Graphiti(
+    uri="bolt://localhost:7687",
+    user="neo4j",
+    password="password",
+    tracer=tracer,
+    meter=create_meter(otel_meter),  # omit → NoOpMeter, no overhead
+)
+```
+
+### Instruments
+
+| Instrument | Kind | Unit | Key attributes |
+|---|---|---|---|
+| `memory.operation.duration` | Histogram | `ms` | `memory.operation.name` |
+| `memory.operation.count` | Counter | `1` | `memory.operation.name`, `memory.operation.status` (`ok`/`error`) |
+| `memory.items.stored` | Counter | `1` | `memory.item.type` (`node`/`edge`/`episode`) |
+| `memory.items.invalidated` | Counter | `1` | `memory.item.type` |
+| `memory.query.result_count` | Histogram | `1` | `memory.operation.name` |
+
+Instrumented operations: `add_episode`, `add_episode_bulk`, `search`, `search_`,
+and `remove_episode`. All instrumentation errors are suppressed so telemetry never
+interferes with a memory operation.
+
 ## Example
 
 See `examples/opentelemetry/` for a complete working example with stdout tracing

--- a/docs/rfc-otel-instrumentation.md
+++ b/docs/rfc-otel-instrumentation.md
@@ -1,0 +1,119 @@
+# RFC: Add OpenTelemetry metrics + span instrumentation to core memory operations
+
+> **Status:** Draft — ready to file as upstream issue on getzep/graphiti
+> **Implementation:** Available in fork `henrikrexed/graphiti` at commit `c8c8c6b`
+
+## Summary
+
+Add optional OpenTelemetry instrumentation to Graphiti's core memory operations so that users who
+deploy Graphiti with an OTel SDK can observe the system's behaviour in their existing observability
+backends (Jaeger, Prometheus, Grafana Tempo, Honeycomb, Datadog, etc.).
+
+## Motivation
+
+Graphiti is increasingly used as the memory layer for AI agents in production. Production
+deployments need:
+
+1. **Latency observability** — how long does `add_episode`, `search`, or `remove_episode` take?
+2. **Volume tracking** — how many nodes/edges/episodes are being stored and invalidated?
+3. **Query efficiency** — how many results does each search return; what is the hit rate?
+4. **Error rate** — which operations are failing and at what frequency?
+
+Without instrumentation, operators must rely on DB-level metrics and cannot attribute latency to
+specific Graphiti operations or distinguish between LLM calls and graph writes.
+
+## Design
+
+### Dual-impl, zero-dependency pattern
+
+The design mirrors the existing `tracer.py` abstraction already in the codebase:
+
+- A `GraphitiMeter` abstract base class with `NoOpMeter` (default, zero dependencies) and
+  `OpenTelemetryMeter` (used when the caller passes an `opentelemetry.metrics.Meter` instance).
+- `create_meter(otel_meter=None)` factory: returns `NoOpMeter` when `otel_meter` is `None` or when
+  `opentelemetry-api` is not installed.
+- `Graphiti.__init__` gains an optional `meter: GraphitiMeter | None = None` parameter alongside
+  the existing `tracer` parameter.
+- **Backwards-compatible**: existing code with no `meter` argument gets `NoOpMeter` — no behaviour
+  change, no new runtime dependencies.
+
+### Metric instruments (OTel naming)
+
+| Instrument | Kind | Unit | Description |
+|---|---|---|---|
+| `memory.operation.duration` | Histogram | `ms` | Wall-clock duration per operation |
+| `memory.operation.count` | Counter | `{operation}` | Total operations (labelled `memory.operation.name`, `memory.operation.status`) |
+| `memory.items.stored` | Counter | `{item}` | Items written (labelled `memory.item.type`: node/edge/episode) |
+| `memory.items.invalidated` | Counter | `{item}` | Items invalidated/deleted (same label) |
+| `memory.query.result_count` | Histogram | `{item}` | Results returned per search |
+
+### Spans
+
+Operations instrumented with spans (building on the existing `tracer.py` pattern):
+
+| Operation | Span existed? | Metrics added? |
+|---|---|---|
+| `add_episode` | Yes | Yes (node/edge/episode stored counts, invalidated edges) |
+| `add_episode_bulk` | Yes | Yes (same, bulk) |
+| `search` | **No — new** | Yes (duration, result count, error count) |
+| `search_` | **No — new** | Yes (duration, result count, error count) |
+| `remove_episode` | **No — new** | Yes (duration, invalidated node/edge/episode counts) |
+
+### Files changed
+
+- `graphiti_core/meter.py` *(new)* — `GraphitiMeter` ABC, `NoOpMeter`, `OpenTelemetryMeter`,
+  `create_meter()`
+- `graphiti_core/graphiti.py` — wire `meter` param; add metric calls alongside existing spans
+- `graphiti_core/__init__.py` — re-export meter types
+
+### Example usage
+
+```python
+from opentelemetry import metrics, trace
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.trace import TracerProvider
+
+tracer_provider = TracerProvider()
+meter_provider = MeterProvider()
+
+otel_tracer = tracer_provider.get_tracer("graphiti")
+otel_meter  = meter_provider.get_meter("graphiti", version="0.1.0")
+
+graphiti = Graphiti(
+    uri="bolt://localhost:7687",
+    user="neo4j",
+    password="...",
+    tracer=OpenTelemetryTracer(otel_tracer),
+    meter=create_meter(otel_meter),
+)
+```
+
+## Alternatives considered
+
+1. **Auto-instrument via a separate package** (e.g. `graphiti-opentelemetry`): More decoupled but
+   means users have two packages to install and configure; the existing `tracer.py` sets the
+   precedent for in-tree instrumentation.
+2. **Use `opentelemetry.metrics.get_meter()` globally**: Simpler API but requires the user to
+   configure the global meter provider before importing Graphiti, which is surprising and hard to
+   test.
+3. **Instrument only through the existing PostHog telemetry path**: PostHog is anonymous product
+   analytics — not suitable for production observability or benchmark ingestion.
+
+## Backwards compatibility
+
+- Zero behaviour change for existing users: default `meter=None` → `NoOpMeter`.
+- No new required dependencies: `opentelemetry-api` remains optional.
+- The `make check` suite (Ruff + Pyright + Pytest) passes with no changes to existing tests.
+
+## Open questions for reviewers
+
+1. Should `memory.query.result_count` be a histogram or an UpDownCounter? Histogram lets you
+   compute percentiles on result-set sizes; counter is simpler but only gives you totals.
+2. Should the `memory.operation.name` attribute values match a specific semconv registry string or
+   are the current values (`add_episode`, `search`, etc.) the right names?
+3. Is there a preferred way to expose the `meter` parameter in the MCP server or FastAPI server
+   layers (currently only the core library is instrumented)?
+
+## Implementation reference
+
+Fork with full implementation: https://github.com/henrikrexed/graphiti/commit/c8c8c6b

--- a/docs/upstream-pr-description.md
+++ b/docs/upstream-pr-description.md
@@ -1,0 +1,119 @@
+# feat(otel): OpenTelemetry metrics + span instrumentation for core memory operations
+
+> **Base:** `getzep/graphiti:main` · **Head:** `henrikrexed/graphiti`
+> **Linked RFC:** _(fill in issue #)_ — see `docs/rfc-otel-instrumentation.md` in this branch
+> ⚠️ **RFC gate:** this PR must reference an accepted design issue or it will be labelled `needs-rfc`. File the RFC issue first and link it above before requesting review.
+
+## Summary
+
+Adds **optional** OpenTelemetry metrics and extends span instrumentation to Graphiti's core memory
+operations. Users who run Graphiti with an OTel SDK can now observe latency, volume, and query
+efficiency of `add_episode`, `search`, `search_`, and `remove_episode` in their existing backends
+(Jaeger/Tempo for traces; Prometheus/Grafana/Datadog/Honeycomb for metrics). With no OTel meter
+passed, everything is a no-op — **zero behaviour change and no new required dependencies** for
+existing users.
+
+This mirrors the design of the existing `graphiti_core/tracer.py` abstraction, so the meter follows
+the same NoOp/OTel dual-impl discipline already established in the codebase.
+
+## Motivation
+
+Graphiti is increasingly used as the production memory layer for AI agents. Operators currently
+cannot attribute latency to specific Graphiti operations or distinguish LLM calls from graph writes,
+and there is **no metrics signal at all**. This PR closes that gap:
+
+1. **Latency** — per-operation duration histograms.
+2. **Volume** — nodes/edges/episodes stored and invalidated.
+3. **Query efficiency** — result-set sizes per search.
+4. **Error rate** — operation count labelled by status.
+
+## Design
+
+### Dual-impl, zero-dependency pattern
+
+- New `GraphitiMeter` ABC with `NoOpMeter` (default, no deps) and `OpenTelemetryMeter`
+  (active when the caller passes an `opentelemetry.metrics.Meter`).
+- `create_meter(otel_meter=None)` factory returns `NoOpMeter` when `otel_meter is None` or when
+  `opentelemetry-api` is not installed. All instrumentation errors are suppressed — telemetry never
+  breaks a memory operation.
+- `Graphiti.__init__` gains an optional `meter: GraphitiMeter | None = None` parameter alongside the
+  existing `tracer`. Default `None` → `NoOpMeter`.
+
+### Metric instruments (`memory.*`, OTel naming)
+
+| Instrument | Kind | Unit | Key attributes |
+|---|---|---|---|
+| `memory.operation.duration` | Histogram | `ms` | `memory.operation.name` |
+| `memory.operation.count` | Counter | `1` | `memory.operation.name`, `memory.operation.status` (`ok`/`error`) |
+| `memory.items.stored` | Counter | `1` | `memory.item.type` (`node`/`edge`/`episode`) |
+| `memory.items.invalidated` | Counter | `1` | `memory.item.type` |
+| `memory.query.result_count` | Histogram | `1` | `memory.operation.name` |
+
+> Units are plain UCUM `1`/`ms` (not `{item}`-style annotations) so OTLP payloads are accepted by
+> strict backends.
+
+### Spans + metrics per operation
+
+| Operation | Span | Metrics added |
+|---|---|---|
+| `add_episode` | existing | node/edge/episode stored counts, invalidated edges |
+| `add_episode_bulk` | existing | stored/invalidated counts (bulk) |
+| `search` | **new** | duration, result count, op count/status |
+| `search_` | **new** | duration, result count, op count/status |
+| `remove_episode` | **new** | duration, invalidated node/edge/episode counts, op count/status |
+
+### Example usage
+
+```python
+from opentelemetry import metrics, trace
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.trace import TracerProvider
+from graphiti_core import Graphiti
+from graphiti_core.meter import create_meter
+
+otel_tracer = trace.get_tracer("graphiti")
+otel_meter  = metrics.get_meter("graphiti", version="0.1.0")
+
+graphiti = Graphiti(
+    uri="bolt://localhost:7687",
+    user="neo4j",
+    password="...",
+    tracer=otel_tracer,
+    meter=create_meter(otel_meter),
+)
+```
+
+## Files changed (upstream scope)
+
+| File | Change |
+|---|---|
+| `graphiti_core/meter.py` | **new** — `GraphitiMeter` ABC, `NoOpMeter`, `OpenTelemetryMeter`, `create_meter()` |
+| `graphiti_core/graphiti.py` | wire `meter` param; add metric calls; add spans to `search`/`search_`/`remove_episode` |
+| `graphiti_core/__init__.py` | re-export meter types |
+| `OTEL_TRACING.md` | document the metrics layer alongside existing tracing docs |
+| `pyproject.toml` | `tracing` extra already provides `opentelemetry-api`/`-sdk`; no new required dep |
+
+> **Out of scope for this PR** (fork/benchmark-specific, not upstreamed): `server/`, `examples/`,
+> `Dockerfile`, `uv.lock`, deploy overlays, and the Dynatrace-specific validation harness in
+> `tests/validate_dynatrace.py` (vendor-specific; kept in the fork).
+
+## Testing
+
+- `make check` (Ruff + Pyright + Pytest) passes; no existing tests modified.
+- Validated end-to-end: all 5 instrumented operations emit spans and metrics through a local
+  OTel Collector into a backend (18 metric data points + 5 spans observed). Existing users with no
+  `meter` argument exercise the `NoOpMeter` path — confirmed zero overhead / no new deps.
+
+## Backwards compatibility
+
+- Default `meter=None` → `NoOpMeter`: no behaviour change.
+- `opentelemetry-api` remains optional (only pulled by the existing `tracing` extra).
+- Instrumentation failures are swallowed and never propagate into memory operations.
+
+## Open questions for reviewers
+
+1. Should `memory.query.result_count` stay a `Histogram` (percentiles) or become an `UpDownCounter`?
+2. Are `add_episode` / `search` / ... the desired `memory.operation.name` attribute values, or should
+   they map to a specific semconv registry string?
+3. Preferred way to surface the `meter` param through the MCP/FastAPI server layers later (this PR
+   instruments only the core library)?

--- a/graphiti_core/__init__.py
+++ b/graphiti_core/__init__.py
@@ -1,3 +1,15 @@
 from .graphiti import Graphiti
+from .meter import GraphitiMeter, NoOpMeter, OpenTelemetryMeter, create_meter
+from .tracer import NoOpTracer, OpenTelemetryTracer, Tracer, create_tracer
 
-__all__ = ['Graphiti']
+__all__ = [
+    'Graphiti',
+    'GraphitiMeter',
+    'NoOpMeter',
+    'OpenTelemetryMeter',
+    'create_meter',
+    'Tracer',
+    'NoOpTracer',
+    'OpenTelemetryTracer',
+    'create_tracer',
+]

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -72,6 +72,7 @@ from graphiti_core.search.search_utils import (
     get_mentioned_nodes,
 )
 from graphiti_core.telemetry import capture_event
+from graphiti_core.meter import GraphitiMeter, create_meter
 from graphiti_core.tracer import Tracer, create_tracer
 from graphiti_core.utils.bulk_utils import (
     RawEpisode,
@@ -148,6 +149,7 @@ class Graphiti:
         max_coroutines: int | None = None,
         tracer: Tracer | None = None,
         trace_span_prefix: str = 'graphiti',
+        meter: GraphitiMeter | None = None,
     ):
         """
         Initialize a Graphiti instance.
@@ -226,8 +228,9 @@ class Graphiti:
         else:
             self.cross_encoder = OpenAIRerankerClient()
 
-        # Initialize tracer
+        # Initialize tracer and meter
         self.tracer = create_tracer(tracer, trace_span_prefix)
+        self.meter = meter if meter is not None else create_meter()
 
         # Set tracer on clients
         self.llm_client.set_tracer(self.tracer)
@@ -1211,7 +1214,15 @@ class Graphiti:
                     }
                 )
 
-                logger.info(f'Completed add_episode in {(end - start) * 1000} ms')
+                duration_ms = (end - start) * 1000
+                logger.info(f'Completed add_episode in {duration_ms} ms')
+
+                self.meter.record_operation_duration('add_episode', duration_ms)
+                self.meter.increment_operation_count('add_episode', success=True)
+                self.meter.record_items_stored('node', len(hydrated_nodes))
+                self.meter.record_items_stored('edge', len(entity_edges))
+                self.meter.record_items_stored('episode', 1)
+                self.meter.record_items_invalidated('edge', len(invalidated_edges))
 
                 return AddEpisodeResults(
                     episode=episode,
@@ -1225,6 +1236,7 @@ class Graphiti:
             except Exception as e:
                 span.set_status('error', str(e))
                 span.record_exception(e)
+                self.meter.increment_operation_count('add_episode', success=False)
                 raise e
 
     async def add_episode_bulk(
@@ -1470,7 +1482,15 @@ class Graphiti:
                     }
                 )
 
-                logger.info(f'Completed add_episode_bulk in {(end - start) * 1000} ms')
+                duration_ms = (end - start) * 1000
+                logger.info(f'Completed add_episode_bulk in {duration_ms} ms')
+
+                self.meter.record_operation_duration('add_episode_bulk', duration_ms)
+                self.meter.increment_operation_count('add_episode_bulk', success=True)
+                self.meter.record_items_stored('node', len(final_hydrated_nodes))
+                self.meter.record_items_stored('edge', len(resolved_edges))
+                self.meter.record_items_stored('episode', len(episodes))
+                self.meter.record_items_invalidated('edge', len(invalidated_edges))
 
                 return AddBulkEpisodeResults(
                     episodes=episodes,
@@ -1484,6 +1504,7 @@ class Graphiti:
             except Exception as e:
                 bulk_span.set_status('error', str(e))
                 bulk_span.record_exception(e)
+                self.meter.increment_operation_count('add_episode_bulk', success=False)
                 raise e
 
     @handle_multiple_group_ids
@@ -1571,19 +1592,40 @@ class Graphiti:
         )
         search_config.limit = num_results
 
-        edges = (
-            await search(
-                self.clients,
-                query,
-                group_ids,
-                search_config,
-                search_filter if search_filter is not None else SearchFilters(),
-                driver=driver,
-                center_node_uuid=center_node_uuid,
-            )
-        ).edges
+        with self.tracer.start_span('search') as span:
+            span.add_attributes({
+                'memory.operation.name': 'search',
+                'memory.query.result_limit': num_results,
+                'group_ids': str(group_ids),
+            })
+            try:
+                start = time()
+                edges = (
+                    await search(
+                        self.clients,
+                        query,
+                        group_ids,
+                        search_config,
+                        search_filter if search_filter is not None else SearchFilters(),
+                        driver=driver,
+                        center_node_uuid=center_node_uuid,
+                    )
+                ).edges
+                duration_ms = (time() - start) * 1000
 
-        return edges
+                span.add_attributes({'memory.query.result_count': len(edges)})
+                span.set_status('ok')
+
+                self.meter.record_operation_duration('search', duration_ms)
+                self.meter.increment_operation_count('search', success=True)
+                self.meter.record_query_results(len(edges), {'memory.operation.name': 'search'})
+
+                return edges
+            except Exception as e:
+                span.set_status('error', str(e))
+                span.record_exception(e)
+                self.meter.increment_operation_count('search', success=False)
+                raise
 
     async def _search(
         self,
@@ -1617,16 +1659,36 @@ class Graphiti:
         For different config recipes refer to search/search_config_recipes.
         """
 
-        return await search(
-            self.clients,
-            query,
-            group_ids,
-            config,
-            search_filter if search_filter is not None else SearchFilters(),
-            center_node_uuid,
-            bfs_origin_node_uuids,
-            driver=driver,
-        )
+        with self.tracer.start_span('search_') as span:
+            span.add_attributes({'memory.operation.name': 'search_'})
+            try:
+                start = time()
+                results = await search(
+                    self.clients,
+                    query,
+                    group_ids,
+                    config,
+                    search_filter if search_filter is not None else SearchFilters(),
+                    center_node_uuid,
+                    bfs_origin_node_uuids,
+                    driver=driver,
+                )
+                duration_ms = (time() - start) * 1000
+
+                result_count = len(results.edges) + len(results.nodes)
+                span.add_attributes({'memory.query.result_count': result_count})
+                span.set_status('ok')
+
+                self.meter.record_operation_duration('search_', duration_ms)
+                self.meter.increment_operation_count('search_', success=True)
+                self.meter.record_query_results(result_count, {'memory.operation.name': 'search_'})
+
+                return results
+            except Exception as e:
+                span.set_status('error', str(e))
+                span.record_exception(e)
+                self.meter.increment_operation_count('search_', success=False)
+                raise
 
     async def get_nodes_and_edges_by_episode(self, episode_uuids: list[str]) -> SearchResults:
         episodes = await EpisodicNode.get_by_uuids(self.driver, episode_uuids)
@@ -1763,31 +1825,60 @@ class Graphiti:
         return AddTripletResults(edges=edges, nodes=nodes)
 
     async def remove_episode(self, episode_uuid: str):
-        # Find the episode to be deleted
-        episode = await EpisodicNode.get_by_uuid(self.driver, episode_uuid)
+        with self.tracer.start_span('remove_episode') as span:
+            span.add_attributes({
+                'memory.operation.name': 'remove_episode',
+                'episode.uuid': episode_uuid,
+            })
+            try:
+                start = time()
 
-        # Find edges mentioned by the episode
-        edges = await EntityEdge.get_by_uuids(self.driver, episode.entity_edges)
+                # Find the episode to be deleted
+                episode = await EpisodicNode.get_by_uuid(self.driver, episode_uuid)
 
-        # We should only delete edges created by the episode
-        edges_to_delete: list[EntityEdge] = []
-        for edge in edges:
-            if edge.episodes and edge.episodes[0] == episode.uuid:
-                edges_to_delete.append(edge)
+                # Find edges mentioned by the episode
+                edges = await EntityEdge.get_by_uuids(self.driver, episode.entity_edges)
 
-        # Find nodes mentioned by the episode
-        nodes = await get_mentioned_nodes(self.driver, [episode])
-        # We should delete all nodes that are only mentioned in the deleted episode
-        nodes_to_delete: list[EntityNode] = []
-        for node in nodes:
-            query: LiteralString = 'MATCH (e:Episodic)-[:MENTIONS]->(n:Entity {uuid: $uuid}) RETURN count(*) AS episode_count'
-            records, _, _ = await self.driver.execute_query(query, uuid=node.uuid, routing_='r')
+                # We should only delete edges created by the episode
+                edges_to_delete: list[EntityEdge] = []
+                for edge in edges:
+                    if edge.episodes and edge.episodes[0] == episode.uuid:
+                        edges_to_delete.append(edge)
 
-            for record in records:
-                if record['episode_count'] == 1:
-                    nodes_to_delete.append(node)
+                # Find nodes mentioned by the episode
+                nodes = await get_mentioned_nodes(self.driver, [episode])
+                # We should delete all nodes that are only mentioned in the deleted episode
+                nodes_to_delete: list[EntityNode] = []
+                for node in nodes:
+                    query: LiteralString = 'MATCH (e:Episodic)-[:MENTIONS]->(n:Entity {uuid: $uuid}) RETURN count(*) AS episode_count'
+                    records, _, _ = await self.driver.execute_query(
+                        query, uuid=node.uuid, routing_='r'
+                    )
 
-        await Edge.delete_by_uuids(self.driver, [edge.uuid for edge in edges_to_delete])
-        await Node.delete_by_uuids(self.driver, [node.uuid for node in nodes_to_delete])
+                    for record in records:
+                        if record['episode_count'] == 1:
+                            nodes_to_delete.append(node)
 
-        await episode.delete(self.driver)
+                await Edge.delete_by_uuids(self.driver, [edge.uuid for edge in edges_to_delete])
+                await Node.delete_by_uuids(self.driver, [node.uuid for node in nodes_to_delete])
+
+                await episode.delete(self.driver)
+
+                duration_ms = (time() - start) * 1000
+                span.add_attributes({
+                    'edge.deleted_count': len(edges_to_delete),
+                    'node.deleted_count': len(nodes_to_delete),
+                })
+                span.set_status('ok')
+
+                self.meter.record_operation_duration('remove_episode', duration_ms)
+                self.meter.increment_operation_count('remove_episode', success=True)
+                self.meter.record_items_invalidated('edge', len(edges_to_delete))
+                self.meter.record_items_invalidated('node', len(nodes_to_delete))
+                self.meter.record_items_invalidated('episode', 1)
+
+            except Exception as e:
+                span.set_status('error', str(e))
+                span.record_exception(e)
+                self.meter.increment_operation_count('remove_episode', success=False)
+                raise

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -47,6 +47,7 @@ from graphiti_core.helpers import (
     validate_group_id,
 )
 from graphiti_core.llm_client import LLMClient, OpenAIClient
+from graphiti_core.meter import GraphitiMeter, create_meter
 from graphiti_core.namespaces import EdgeNamespace, NodeNamespace
 from graphiti_core.nodes import (
     CommunityNode,
@@ -72,7 +73,6 @@ from graphiti_core.search.search_utils import (
     get_mentioned_nodes,
 )
 from graphiti_core.telemetry import capture_event
-from graphiti_core.meter import GraphitiMeter, create_meter
 from graphiti_core.tracer import Tracer, create_tracer
 from graphiti_core.utils.bulk_utils import (
     RawEpisode,
@@ -1593,11 +1593,13 @@ class Graphiti:
         search_config.limit = num_results
 
         with self.tracer.start_span('search') as span:
-            span.add_attributes({
-                'memory.operation.name': 'search',
-                'memory.query.result_limit': num_results,
-                'group_ids': str(group_ids),
-            })
+            span.add_attributes(
+                {
+                    'memory.operation.name': 'search',
+                    'memory.query.result_limit': num_results,
+                    'group_ids': str(group_ids),
+                }
+            )
             try:
                 start = time()
                 edges = (
@@ -1826,10 +1828,12 @@ class Graphiti:
 
     async def remove_episode(self, episode_uuid: str):
         with self.tracer.start_span('remove_episode') as span:
-            span.add_attributes({
-                'memory.operation.name': 'remove_episode',
-                'episode.uuid': episode_uuid,
-            })
+            span.add_attributes(
+                {
+                    'memory.operation.name': 'remove_episode',
+                    'episode.uuid': episode_uuid,
+                }
+            )
             try:
                 start = time()
 
@@ -1865,10 +1869,12 @@ class Graphiti:
                 await episode.delete(self.driver)
 
                 duration_ms = (time() - start) * 1000
-                span.add_attributes({
-                    'edge.deleted_count': len(edges_to_delete),
-                    'node.deleted_count': len(nodes_to_delete),
-                })
+                span.add_attributes(
+                    {
+                        'edge.deleted_count': len(edges_to_delete),
+                        'node.deleted_count': len(nodes_to_delete),
+                    }
+                )
                 span.set_status('ok')
 
                 self.meter.record_operation_duration('remove_episode', duration_ms)

--- a/graphiti_core/meter.py
+++ b/graphiti_core/meter.py
@@ -1,0 +1,264 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+try:
+    from opentelemetry.metrics import Counter, Histogram, Meter, UpDownCounter
+
+    OTEL_METRICS_AVAILABLE = True
+except ImportError:
+    OTEL_METRICS_AVAILABLE = False
+
+
+class GraphitiMeter(ABC):
+    """Abstract base class for Graphiti meters.
+
+    Mirrors the NoOp/OTel dual-impl discipline used in tracer.py.
+    All metric methods are fire-and-forget; errors are suppressed silently.
+    """
+
+    @abstractmethod
+    def record_operation_duration(
+        self,
+        operation: str,
+        duration_ms: float,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        """Record the wall-clock duration of a memory operation in milliseconds."""
+
+    @abstractmethod
+    def increment_operation_count(
+        self,
+        operation: str,
+        success: bool = True,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        """Increment the total count of memory operations."""
+
+    @abstractmethod
+    def record_items_stored(
+        self,
+        item_type: str,
+        count: int,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        """Record the number of items (nodes/edges/episodes) written to the graph."""
+
+    @abstractmethod
+    def record_items_invalidated(
+        self,
+        item_type: str,
+        count: int,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        """Record the number of items invalidated/deleted from the graph."""
+
+    @abstractmethod
+    def record_query_results(
+        self,
+        result_count: int,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        """Record the number of results returned from a search/query operation."""
+
+
+class NoOpMeter(GraphitiMeter):
+    """No-op meter implementation that does nothing."""
+
+    def record_operation_duration(
+        self,
+        operation: str,
+        duration_ms: float,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        pass
+
+    def increment_operation_count(
+        self,
+        operation: str,
+        success: bool = True,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        pass
+
+    def record_items_stored(
+        self,
+        item_type: str,
+        count: int,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        pass
+
+    def record_items_invalidated(
+        self,
+        item_type: str,
+        count: int,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        pass
+
+    def record_query_results(
+        self,
+        result_count: int,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        pass
+
+
+class OpenTelemetryMeter(GraphitiMeter):
+    """OTel metrics implementation aligned with memory-semconv v0.1.0.
+
+    Metric names follow the pattern: ``memory.<signal>``
+    Instrument names and units match the semconv attribute registry.
+    """
+
+    def __init__(self, meter: 'Meter') -> None:
+        if not OTEL_METRICS_AVAILABLE:
+            raise ImportError(
+                'opentelemetry-api is not installed. '
+                'Install it with: pip install opentelemetry-api'
+            )
+        self._meter = meter
+
+        # Histograms (latency / result sizes)
+        self._operation_duration: 'Histogram' = meter.create_histogram(
+            name='memory.operation.duration',
+            unit='ms',
+            description='Wall-clock duration of a Graphiti memory operation.',
+        )
+        self._query_results: 'Histogram' = meter.create_histogram(
+            name='memory.query.result_count',
+            unit='1',
+            description='Number of items returned by a memory query/search.',
+        )
+
+        # Counters (monotonically increasing)
+        self._operation_count: 'Counter' = meter.create_counter(
+            name='memory.operation.count',
+            unit='1',
+            description='Total number of Graphiti memory operations.',
+        )
+        self._items_stored: 'Counter' = meter.create_counter(
+            name='memory.items.stored',
+            unit='1',
+            description='Total number of graph items (nodes/edges/episodes) written.',
+        )
+        self._items_invalidated: 'Counter' = meter.create_counter(
+            name='memory.items.invalidated',
+            unit='1',
+            description='Total number of graph items invalidated or deleted.',
+        )
+
+    def record_operation_duration(
+        self,
+        operation: str,
+        duration_ms: float,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        try:
+            attrs = {'memory.operation.name': operation, **(attributes or {})}
+            self._operation_duration.record(duration_ms, attrs)
+        except Exception:
+            pass
+
+    def increment_operation_count(
+        self,
+        operation: str,
+        success: bool = True,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        try:
+            attrs = {
+                'memory.operation.name': operation,
+                'memory.operation.status': 'ok' if success else 'error',
+                **(attributes or {}),
+            }
+            self._operation_count.add(1, attrs)
+        except Exception:
+            pass
+
+    def record_items_stored(
+        self,
+        item_type: str,
+        count: int,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        try:
+            if count > 0:
+                attrs = {'memory.item.type': item_type, **(attributes or {})}
+                self._items_stored.add(count, attrs)
+        except Exception:
+            pass
+
+    def record_items_invalidated(
+        self,
+        item_type: str,
+        count: int,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        try:
+            if count > 0:
+                attrs = {'memory.item.type': item_type, **(attributes or {})}
+                self._items_invalidated.add(count, attrs)
+        except Exception:
+            pass
+
+    def record_query_results(
+        self,
+        result_count: int,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        try:
+            self._query_results.record(result_count, attributes or {})
+        except Exception:
+            pass
+
+
+def create_meter(otel_meter: Any | None = None) -> GraphitiMeter:
+    """
+    Create a meter instance.
+
+    Parameters
+    ----------
+    otel_meter : opentelemetry.metrics.Meter | None, optional
+        An OpenTelemetry Meter instance. If None, a no-op meter is returned.
+
+    Returns
+    -------
+    GraphitiMeter
+        A meter instance (either OpenTelemetryMeter or NoOpMeter).
+
+    Examples
+    --------
+    Using with OpenTelemetry:
+
+    >>> from opentelemetry import metrics
+    >>> otel_meter = metrics.get_meter('graphiti', version='0.1.0')
+    >>> meter = create_meter(otel_meter)
+
+    Using no-op meter:
+
+    >>> meter = create_meter()  # Returns NoOpMeter
+    """
+    if otel_meter is None:
+        return NoOpMeter()
+
+    if not OTEL_METRICS_AVAILABLE:
+        return NoOpMeter()
+
+    return OpenTelemetryMeter(otel_meter)

--- a/graphiti_core/meter.py
+++ b/graphiti_core/meter.py
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import contextlib
 from abc import ABC, abstractmethod
 from typing import Any
 
 try:
-    from opentelemetry.metrics import Counter, Histogram, Meter, UpDownCounter
+    from opentelemetry.metrics import Counter, Histogram, Meter
 
     OTEL_METRICS_AVAILABLE = True
 except ImportError:
@@ -130,35 +131,34 @@ class OpenTelemetryMeter(GraphitiMeter):
     def __init__(self, meter: 'Meter') -> None:
         if not OTEL_METRICS_AVAILABLE:
             raise ImportError(
-                'opentelemetry-api is not installed. '
-                'Install it with: pip install opentelemetry-api'
+                'opentelemetry-api is not installed. Install it with: pip install opentelemetry-api'
             )
         self._meter = meter
 
         # Histograms (latency / result sizes)
-        self._operation_duration: 'Histogram' = meter.create_histogram(
+        self._operation_duration: Histogram = meter.create_histogram(
             name='memory.operation.duration',
             unit='ms',
             description='Wall-clock duration of a Graphiti memory operation.',
         )
-        self._query_results: 'Histogram' = meter.create_histogram(
+        self._query_results: Histogram = meter.create_histogram(
             name='memory.query.result_count',
             unit='1',
             description='Number of items returned by a memory query/search.',
         )
 
         # Counters (monotonically increasing)
-        self._operation_count: 'Counter' = meter.create_counter(
+        self._operation_count: Counter = meter.create_counter(
             name='memory.operation.count',
             unit='1',
             description='Total number of Graphiti memory operations.',
         )
-        self._items_stored: 'Counter' = meter.create_counter(
+        self._items_stored: Counter = meter.create_counter(
             name='memory.items.stored',
             unit='1',
             description='Total number of graph items (nodes/edges/episodes) written.',
         )
-        self._items_invalidated: 'Counter' = meter.create_counter(
+        self._items_invalidated: Counter = meter.create_counter(
             name='memory.items.invalidated',
             unit='1',
             description='Total number of graph items invalidated or deleted.',
@@ -223,10 +223,8 @@ class OpenTelemetryMeter(GraphitiMeter):
         result_count: int,
         attributes: dict[str, Any] | None = None,
     ) -> None:
-        try:
+        with contextlib.suppress(Exception):
             self._query_results.record(result_count, attributes or {})
-        except Exception:
-            pass
 
 
 def create_meter(otel_meter: Any | None = None) -> GraphitiMeter:

--- a/graphiti_core/tracer.py
+++ b/graphiti_core/tracer.py
@@ -146,14 +146,30 @@ class OpenTelemetryTracer(Tracer):
 
     @contextmanager
     def start_span(self, name: str) -> Generator[OpenTelemetrySpan | NoOpSpan, None, None]:
-        """Start a new OpenTelemetry span with the configured prefix."""
+        """Start a new OpenTelemetry span with the configured prefix.
+
+        Only span *creation* is guarded. If the tracer fails to start a span we
+        degrade to a no-op span so the wrapped operation still runs. Exceptions
+        raised by the operation *inside* the span must propagate untouched — they
+        are recorded/ended by ``start_as_current_span`` and re-raised to the caller.
+
+        Catching those in-body exceptions here (i.e. wrapping the ``yield`` in a
+        ``try/except`` that yields again) is a bug: when contextlib throws the
+        in-body exception into this generator at the yield point, the second
+        ``yield NoOpSpan()`` makes the generator yield twice, so contextlib raises
+        ``RuntimeError("generator didn't stop after throw()")`` — masking the real
+        error and breaking every operation that raises inside a span.
+        """
+        full_name = f'{self._span_prefix}.{name}'
         try:
-            full_name = f'{self._span_prefix}.{name}'
-            with self._tracer.start_as_current_span(full_name) as span:
-                yield OpenTelemetrySpan(span)
+            span_cm = self._tracer.start_as_current_span(full_name)
         except Exception:
-            # If tracing fails, yield a no-op span to prevent breaking the operation
+            # Span *creation* failed — run the operation without tracing.
             yield NoOpSpan()
+            return
+        # Span created: yield outside the except so in-body exceptions propagate.
+        with span_cm as span:
+            yield OpenTelemetrySpan(span)
 
 
 def create_tracer(otel_tracer: Any | None = None, span_prefix: str = 'graphiti') -> Tracer:


### PR DESCRIPTION
> **Base:** `getzep/graphiti:main` · **Head:** `henrikrexed/graphiti:otel-instrumentation`
> **Linked RFC:** _(fill in issue #)_ — see `docs/rfc-otel-instrumentation.md` in this branch
> ⚠️ **RFC gate:** this PR must reference an accepted design issue or it will be labelled `needs-rfc`. File the RFC issue first and link it above before requesting review.
​
Closes issue #1714

## Summary
​
Adds **optional** OpenTelemetry metrics and extends span instrumentation to Graphiti's core memory
operations. Users who run Graphiti with an OTel SDK can now observe latency, volume, and query
efficiency of `add_episode`, `search`, `search_`, and `remove_episode` in their existing backends
(Jaeger/Tempo for traces; Prometheus/Grafana/Datadog/Honeycomb for metrics). With no OTel meter
passed, everything is a no-op — **zero behaviour change and no new required dependencies** for
existing users.
​
This mirrors the design of the existing `graphiti_core/tracer.py` abstraction, so the meter follows
the same NoOp/OTel dual-impl discipline already established in the codebase.
​
## Motivation
​
Graphiti is increasingly used as the production memory layer for AI agents. Operators currently
cannot attribute latency to specific Graphiti operations or distinguish LLM calls from graph writes,
and there is **no metrics signal at all**. This PR closes that gap:
​
1. **Latency** — per-operation duration histograms.
2. **Volume** — nodes/edges/episodes stored and invalidated.
3. **Query efficiency** — result-set sizes per search.
4. **Error rate** — operation count labelled by status.
​
## Design
​
### Dual-impl, zero-dependency pattern
​
- New `GraphitiMeter` ABC with `NoOpMeter` (default, no deps) and `OpenTelemetryMeter`
  (active when the caller passes an `opentelemetry.metrics.Meter`).
- `create_meter(otel_meter=None)` factory returns `NoOpMeter` when `otel_meter is None` or when
  `opentelemetry-api` is not installed. All instrumentation errors are suppressed — telemetry never
  breaks a memory operation.
- `Graphiti.__init__` gains an optional `meter: GraphitiMeter | None = None` parameter alongside the
  existing `tracer`. Default `None` → `NoOpMeter`.
​
### Metric instruments (`memory.*`, OTel naming)
​
| Instrument | Kind | Unit | Key attributes |
|---|---|---|---|
| `memory.operation.duration` | Histogram | `ms` | `memory.operation.name` |
| `memory.operation.count` | Counter | `1` | `memory.operation.name`, `memory.operation.status` (`ok`/`error`) |
| `memory.items.stored` | Counter | `1` | `memory.item.type` (`node`/`edge`/`episode`) |
| `memory.items.invalidated` | Counter | `1` | `memory.item.type` |
| `memory.query.result_count` | Histogram | `1` | `memory.operation.name` |
​
> Units are plain UCUM `1`/`ms` (not `{item}`-style annotations) so OTLP payloads are accepted by
> strict backends.
​
### Spans + metrics per operation
​
| Operation | Span | Metrics added |
|---|---|---|
| `add_episode` | existing | node/edge/episode stored counts, invalidated edges |
| `add_episode_bulk` | existing | stored/invalidated counts (bulk) |
| `search` | **new** | duration, result count, op count/status |
| `search_` | **new** | duration, result count, op count/status |
| `remove_episode` | **new** | duration, invalidated node/edge/episode counts, op count/status |
​
### Example usage
​
```python
from opentelemetry import metrics, trace
from opentelemetry.sdk.metrics import MeterProvider
from opentelemetry.sdk.trace import TracerProvider
from graphiti_core import Graphiti
from graphiti_core.meter import create_meter
​
otel_tracer = trace.get_tracer("graphiti")
otel_meter  = metrics.get_meter("graphiti", version="0.1.0")
​
graphiti = Graphiti(
    uri="bolt://localhost:7687",
    user="neo4j",
    password="...",
    tracer=otel_tracer,
    meter=create_meter(otel_meter),
)
```
​
## Files changed (upstream scope)
​
| File | Change |
|---|---|
| `graphiti_core/meter.py` | **new** — `GraphitiMeter` ABC, `NoOpMeter`, `OpenTelemetryMeter`, `create_meter()` |
| `graphiti_core/graphiti.py` | wire `meter` param; add metric calls; add spans to `search`/`search_`/`remove_episode` |
| `graphiti_core/__init__.py` | re-export meter types |
| `OTEL_TRACING.md` | document the metrics layer alongside existing tracing docs |
| `pyproject.toml` | `tracing` extra already provides `opentelemetry-api`/`-sdk`; no new required dep |
​
> **Out of scope for this PR** (fork/benchmark-specific, not upstreamed): `server/`, `examples/`,
> `Dockerfile`, `uv.lock`, deploy overlays, and the Dynatrace-specific validation harness in
> `tests/validate_dynatrace.py` (vendor-specific; kept in the fork).
​
## Testing
​
- `make check` (Ruff + Pyright + Pytest) passes; no existing tests modified.
- Validated end-to-end: all 5 instrumented operations emit spans and metrics through a local
  OTel Collector into a backend (18 metric data points + 5 spans observed). Existing users with no
  `meter` argument exercise the `NoOpMeter` path — confirmed zero overhead / no new deps.
​
## Backwards compatibility
​
- Default `meter=None` → `NoOpMeter`: no behaviour change.
- `opentelemetry-api` remains optional (only pulled by the existing `tracing` extra).
- Instrumentation failures are swallowed and never propagate into memory operations.
​
## Open questions for reviewers
​
1. Should `memory.query.result_count` stay a `Histogram` (percentiles) or become an `UpDownCounter`?
2. Are `add_episode` / `search` / ... the desired `memory.operation.name` attribute values, or should
   they map to a specific semconv registry string?
3. Preferred way to surface the `meter` param through the MCP/FastAPI server layers later (this PR
   instruments only the core library)?