### PR TITLE
fix: Neo4j similarity search crashes on null/invalid embeddings

### DIFF
--- a/graphiti_core/driver/neo4j/operations/search_ops.py
+++ b/graphiti_core/driver/neo4j/operations/search_ops.py
@@ -142,6 +142,13 @@ class Neo4jSearchOperations(SearchOperations):
             filter_queries.append('n.group_id IN $group_ids')
             filter_params['group_ids'] = group_ids
 
+        # Exclude nodes with a missing/invalid embedding before computing cosine
+        # similarity - vector.similarity.cosine() raises
+        # Neo.ClientError.Statement.ArgumentError on a null vector, which
+        # otherwise fails the entire search once any node lacks (or has a
+        # stale-dimension) name_embedding (#1328).
+        filter_queries.append('n.name_embedding IS NOT NULL')
+
         filter_query = ''
         if filter_queries:
             filter_query = ' WHERE ' + (' AND '.join(filter_queries))
@@ -295,6 +302,13 @@ class Neo4jSearchOperations(SearchOperations):
         filter_queries, filter_params = edge_search_filter_query_constructor(
             search_filter, GraphProvider.NEO4J
         )
+
+        # Exclude edges with a missing/invalid embedding before computing cosine
+        # similarity - vector.similarity.cosine() raises
+        # Neo.ClientError.Statement.ArgumentError on a null vector, which
+        # otherwise fails the entire search once any edge lacks (or has a
+        # stale-dimension) fact_embedding (#1328).
+        filter_queries.append('e.fact_embedding IS NOT NULL')
 
         if group_ids is not None:
             filter_queries.append('e.group_id IN $group_ids')
@@ -490,9 +504,14 @@ class Neo4jSearchOperations(SearchOperations):
     ) -> list[CommunityNode]:
         query_params: dict[str, Any] = {}
 
-        group_filter_query = ''
+        # Exclude communities with a missing/invalid embedding before computing
+        # cosine similarity - vector.similarity.cosine() raises
+        # Neo.ClientError.Statement.ArgumentError on a null vector, which
+        # otherwise fails the entire search once any community lacks (or has a
+        # stale-dimension) name_embedding (#1328).
+        group_filter_query = ' WHERE c.name_embedding IS NOT NULL'
         if group_ids is not None:
-            group_filter_query += ' WHERE c.group_id IN $group_ids'
+            group_filter_query += ' AND c.group_id IN $group_ids'
             query_params['group_ids'] = group_ids
 
         cypher = (

--- a/graphiti_core/driver/neo4j/operations/search_ops.py
+++ b/graphiti_core/driver/neo4j/operations/search_ops.py
@@ -142,12 +142,13 @@ class Neo4jSearchOperations(SearchOperations):
             filter_queries.append('n.group_id IN $group_ids')
             filter_params['group_ids'] = group_ids
 
-        # Exclude nodes with a missing/invalid embedding before computing cosine
-        # similarity - vector.similarity.cosine() raises
-        # Neo.ClientError.Statement.ArgumentError on a null vector, which
-        # otherwise fails the entire search once any node lacks (or has a
-        # stale-dimension) name_embedding (#1328).
+        # Exclude nodes with a missing or dimension-mismatched embedding before
+        # computing cosine similarity - vector.similarity.cosine() raises
+        # Neo.ClientError.Statement.ArgumentError on a null vector, and errors
+        # on a dimension mismatch too, which otherwise fails the entire search
+        # once any node lacks (or has a stale-dimension) name_embedding (#1328).
         filter_queries.append('n.name_embedding IS NOT NULL')
+        filter_queries.append('size(n.name_embedding) = size($search_vector)')
 
         filter_query = ''
         if filter_queries:
@@ -303,12 +304,13 @@ class Neo4jSearchOperations(SearchOperations):
             search_filter, GraphProvider.NEO4J
         )
 
-        # Exclude edges with a missing/invalid embedding before computing cosine
-        # similarity - vector.similarity.cosine() raises
-        # Neo.ClientError.Statement.ArgumentError on a null vector, which
-        # otherwise fails the entire search once any edge lacks (or has a
-        # stale-dimension) fact_embedding (#1328).
+        # Exclude edges with a missing or dimension-mismatched embedding before
+        # computing cosine similarity - vector.similarity.cosine() raises
+        # Neo.ClientError.Statement.ArgumentError on a null vector, and errors
+        # on a dimension mismatch too, which otherwise fails the entire search
+        # once any edge lacks (or has a stale-dimension) fact_embedding (#1328).
         filter_queries.append('e.fact_embedding IS NOT NULL')
+        filter_queries.append('size(e.fact_embedding) = size($search_vector)')
 
         if group_ids is not None:
             filter_queries.append('e.group_id IN $group_ids')
@@ -504,12 +506,15 @@ class Neo4jSearchOperations(SearchOperations):
     ) -> list[CommunityNode]:
         query_params: dict[str, Any] = {}
 
-        # Exclude communities with a missing/invalid embedding before computing
-        # cosine similarity - vector.similarity.cosine() raises
-        # Neo.ClientError.Statement.ArgumentError on a null vector, which
-        # otherwise fails the entire search once any community lacks (or has a
-        # stale-dimension) name_embedding (#1328).
-        group_filter_query = ' WHERE c.name_embedding IS NOT NULL'
+        # Exclude communities with a missing or dimension-mismatched embedding
+        # before computing cosine similarity - vector.similarity.cosine() raises
+        # Neo.ClientError.Statement.ArgumentError on a null vector, and errors
+        # on a dimension mismatch too, which otherwise fails the entire search
+        # once any community lacks (or has a stale-dimension) name_embedding
+        # (#1328).
+        group_filter_query = (
+            ' WHERE c.name_embedding IS NOT NULL AND size(c.name_embedding) = size($search_vector)'
+        )
         if group_ids is not None:
             group_filter_query += ' AND c.group_id IN $group_ids'
             query_params['group_ids'] = group_ids

--- a/tests/driver/test_neo4j_search_ops.py
+++ b/tests/driver/test_neo4j_search_ops.py
@@ -2,12 +2,12 @@
 
 Regression coverage for #1328: edge_similarity_search / node_similarity_search
 / community_similarity_search computed vector.similarity.cosine() over every
-matched row with no guard against a null or invalid embedding. Neo4j's
-vector.similarity.cosine() raises Neo.ClientError.Statement.ArgumentError on a
-null vector, so a single row with a missing/invalid embedding failed the
-entire search. These tests assert the generated Cypher excludes such rows
-before the cosine call, using a mocked executor so no live Neo4j instance is
-required (mirrors the existing _build_neo4j_fulltext_query query-shape tests).
+matched row with no guard against a null or dimension-mismatched embedding.
+Neo4j's vector.similarity.cosine() raises Neo.ClientError.Statement.ArgumentError
+on a null vector, and errors on a dimension mismatch too, so a single such row
+failed the entire search. These tests assert the generated Cypher excludes such
+rows before the cosine call, using a mocked executor so no live Neo4j instance
+is required (mirrors the existing _build_neo4j_fulltext_query query-shape tests).
 """
 
 from unittest.mock import AsyncMock
@@ -33,9 +33,11 @@ async def test_node_similarity_search_excludes_null_embeddings():
 
     cypher = executor.execute_query.call_args.args[0]
     assert 'n.name_embedding IS NOT NULL' in cypher
-    # The null-check must gate the MATCH before the cosine call, not just
+    assert 'size(n.name_embedding) = size($search_vector)' in cypher
+    # Both guards must gate the MATCH before the cosine call, not just
     # appear anywhere in the query string.
-    assert cypher.index('n.name_embedding IS NOT NULL') < cypher.index(
+    assert cypher.index('n.name_embedding IS NOT NULL') < cypher.index('vector.similarity.cosine')
+    assert cypher.index('size(n.name_embedding) = size($search_vector)') < cypher.index(
         'vector.similarity.cosine'
     )
 
@@ -51,6 +53,7 @@ async def test_node_similarity_search_combines_null_check_with_group_ids():
 
     cypher = executor.execute_query.call_args.args[0]
     assert 'n.name_embedding IS NOT NULL' in cypher
+    assert 'size(n.name_embedding) = size($search_vector)' in cypher
     assert 'n.group_id IN $group_ids' in cypher
 
 
@@ -59,13 +62,13 @@ async def test_edge_similarity_search_excludes_null_embeddings():
     executor = _mock_executor()
     ops = Neo4jSearchOperations()
 
-    await ops.edge_similarity_search(
-        executor, [0.1, 0.2, 0.3], None, None, SearchFilters()
-    )
+    await ops.edge_similarity_search(executor, [0.1, 0.2, 0.3], None, None, SearchFilters())
 
     cypher = executor.execute_query.call_args.args[0]
     assert 'e.fact_embedding IS NOT NULL' in cypher
-    assert cypher.index('e.fact_embedding IS NOT NULL') < cypher.index(
+    assert 'size(e.fact_embedding) = size($search_vector)' in cypher
+    assert cypher.index('e.fact_embedding IS NOT NULL') < cypher.index('vector.similarity.cosine')
+    assert cypher.index('size(e.fact_embedding) = size($search_vector)') < cypher.index(
         'vector.similarity.cosine'
     )
 
@@ -86,6 +89,7 @@ async def test_edge_similarity_search_combines_null_check_with_group_ids():
 
     cypher = executor.execute_query.call_args.args[0]
     assert 'e.fact_embedding IS NOT NULL' in cypher
+    assert 'size(e.fact_embedding) = size($search_vector)' in cypher
     assert 'e.group_id IN $group_ids' in cypher
     assert 'n.uuid = $source_uuid' in cypher
     assert 'm.uuid = $target_uuid' in cypher
@@ -100,7 +104,9 @@ async def test_community_similarity_search_excludes_null_embeddings():
 
     cypher = executor.execute_query.call_args.args[0]
     assert 'c.name_embedding IS NOT NULL' in cypher
-    assert cypher.index('c.name_embedding IS NOT NULL') < cypher.index(
+    assert 'size(c.name_embedding) = size($search_vector)' in cypher
+    assert cypher.index('c.name_embedding IS NOT NULL') < cypher.index('vector.similarity.cosine')
+    assert cypher.index('size(c.name_embedding) = size($search_vector)') < cypher.index(
         'vector.similarity.cosine'
     )
 
@@ -114,4 +120,5 @@ async def test_community_similarity_search_combines_null_check_with_group_ids():
 
     cypher = executor.execute_query.call_args.args[0]
     assert 'c.name_embedding IS NOT NULL' in cypher
+    assert 'size(c.name_embedding) = size($search_vector)' in cypher
     assert 'c.group_id IN $group_ids' in cypher

--- a/tests/driver/test_neo4j_search_ops.py
+++ b/tests/driver/test_neo4j_search_ops.py
@@ -1,0 +1,117 @@
+"""Unit tests for Neo4jSearchOperations similarity search query construction.
+
+Regression coverage for #1328: edge_similarity_search / node_similarity_search
+/ community_similarity_search computed vector.similarity.cosine() over every
+matched row with no guard against a null or invalid embedding. Neo4j's
+vector.similarity.cosine() raises Neo.ClientError.Statement.ArgumentError on a
+null vector, so a single row with a missing/invalid embedding failed the
+entire search. These tests assert the generated Cypher excludes such rows
+before the cosine call, using a mocked executor so no live Neo4j instance is
+required (mirrors the existing _build_neo4j_fulltext_query query-shape tests).
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from graphiti_core.driver.neo4j.operations.search_ops import Neo4jSearchOperations
+from graphiti_core.search.search_filters import SearchFilters
+
+
+def _mock_executor():
+    executor = AsyncMock()
+    executor.execute_query = AsyncMock(return_value=([], None, None))
+    return executor
+
+
+@pytest.mark.asyncio
+async def test_node_similarity_search_excludes_null_embeddings():
+    executor = _mock_executor()
+    ops = Neo4jSearchOperations()
+
+    await ops.node_similarity_search(executor, [0.1, 0.2, 0.3], SearchFilters())
+
+    cypher = executor.execute_query.call_args.args[0]
+    assert 'n.name_embedding IS NOT NULL' in cypher
+    # The null-check must gate the MATCH before the cosine call, not just
+    # appear anywhere in the query string.
+    assert cypher.index('n.name_embedding IS NOT NULL') < cypher.index(
+        'vector.similarity.cosine'
+    )
+
+
+@pytest.mark.asyncio
+async def test_node_similarity_search_combines_null_check_with_group_ids():
+    executor = _mock_executor()
+    ops = Neo4jSearchOperations()
+
+    await ops.node_similarity_search(
+        executor, [0.1, 0.2, 0.3], SearchFilters(), group_ids=['group-1']
+    )
+
+    cypher = executor.execute_query.call_args.args[0]
+    assert 'n.name_embedding IS NOT NULL' in cypher
+    assert 'n.group_id IN $group_ids' in cypher
+
+
+@pytest.mark.asyncio
+async def test_edge_similarity_search_excludes_null_embeddings():
+    executor = _mock_executor()
+    ops = Neo4jSearchOperations()
+
+    await ops.edge_similarity_search(
+        executor, [0.1, 0.2, 0.3], None, None, SearchFilters()
+    )
+
+    cypher = executor.execute_query.call_args.args[0]
+    assert 'e.fact_embedding IS NOT NULL' in cypher
+    assert cypher.index('e.fact_embedding IS NOT NULL') < cypher.index(
+        'vector.similarity.cosine'
+    )
+
+
+@pytest.mark.asyncio
+async def test_edge_similarity_search_combines_null_check_with_group_ids():
+    executor = _mock_executor()
+    ops = Neo4jSearchOperations()
+
+    await ops.edge_similarity_search(
+        executor,
+        [0.1, 0.2, 0.3],
+        'source-uuid',
+        'target-uuid',
+        SearchFilters(),
+        group_ids=['group-1'],
+    )
+
+    cypher = executor.execute_query.call_args.args[0]
+    assert 'e.fact_embedding IS NOT NULL' in cypher
+    assert 'e.group_id IN $group_ids' in cypher
+    assert 'n.uuid = $source_uuid' in cypher
+    assert 'm.uuid = $target_uuid' in cypher
+
+
+@pytest.mark.asyncio
+async def test_community_similarity_search_excludes_null_embeddings():
+    executor = _mock_executor()
+    ops = Neo4jSearchOperations()
+
+    await ops.community_similarity_search(executor, [0.1, 0.2, 0.3])
+
+    cypher = executor.execute_query.call_args.args[0]
+    assert 'c.name_embedding IS NOT NULL' in cypher
+    assert cypher.index('c.name_embedding IS NOT NULL') < cypher.index(
+        'vector.similarity.cosine'
+    )
+
+
+@pytest.mark.asyncio
+async def test_community_similarity_search_combines_null_check_with_group_ids():
+    executor = _mock_executor()
+    ops = Neo4jSearchOperations()
+
+    await ops.community_similarity_search(executor, [0.1, 0.2, 0.3], group_ids=['group-1'])
+
+    cypher = executor.execute_query.call_args.args[0]
+    assert 'c.name_embedding IS NOT NULL' in cypher
+    assert 'c.group_id IN $group_ids' in cypher


### PR DESCRIPTION
## Summary
`edge_similarity_search`, `node_similarity_search`, and `community_similarity_search` in `graphiti_core/driver/neo4j/operations/search_ops.py` compute `vector.similarity.cosine()` over every matched row with no guard against a missing or dimension-mismatched embedding. As a graph grows over time, some `RELATES_TO` edges (or `Entity`/`Community` nodes) can end up with a `null`, empty, or dimension-mismatched embedding - e.g. after an embedder change, a partial write, or a migration. Neo4j's `vector.similarity.cosine()` raises `Neo.ClientError.Statement.ArgumentError` on either case, so a single bad row fails the **entire** search instead of just being excluded.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
N/A (bug fix to existing functionality, not a new feature).

**Fix:** add both an `IS NOT NULL` guard and a `size(...) = size($search_vector)` dimension-match guard on the relevant embedding property (`e.fact_embedding` / `n.name_embedding` / `c.name_embedding`) before the cosine call, in all three functions. This reuses the existing `filter_queries` list construction so it composes correctly with `group_id` and source/target filters.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

Added `tests/driver/test_neo4j_search_ops.py` with 6 unit tests that mock the query executor and assert on the constructed Cypher text (mirroring the existing `_build_neo4j_fulltext_query` query-shape test convention) - no live Neo4j instance required. Covers all three functions, both alone and combined with `group_id`/source/target filters, and asserts both guards gate the `MATCH` before the cosine call.

**Before the fix:** all 6 tests failed (no guards present in the generated query) in 3.31s.
**After the fix:** 6/6 pass in 0.28s (including the dimension-check addition requested in review).

```
tests/driver/test_neo4j_search_ops.py::test_node_similarity_search_excludes_null_embeddings PASSED
tests/driver/test_neo4j_search_ops.py::test_node_similarity_search_combines_null_check_with_group_ids PASSED
tests/driver/test_neo4j_search_ops.py::test_edge_similarity_search_excludes_null_embeddings PASSED
tests/driver/test_neo4j_search_ops.py::test_edge_similarity_search_combines_null_check_with_group_ids PASSED
tests/driver/test_neo4j_search_ops.py::test_community_similarity_search_excludes_null_embeddings PASSED
tests/driver/test_neo4j_search_ops.py::test_community_similarity_search_combines_null_check_with_group_ids PASSED
6 passed in 0.28s
```

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [ ] Documentation updated where necessary (N/A - no user-facing docs affected)
- [x] No secrets or sensitive information committed

## Related Issues
Closes #1328