### PR TITLE
feat(embedder): support native OpenAI embedding dimensions instead of truncating (#1087)

### DIFF
--- a/graphiti_core/embedder/openai.py
+++ b/graphiti_core/embedder/openai.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from collections.abc import Iterable
+from typing import Any
 
 from openai import AsyncAzureOpenAI, AsyncOpenAI
 from openai.types import EmbeddingModel
@@ -28,6 +29,16 @@ class OpenAIEmbedderConfig(EmbedderConfig):
     embedding_model: EmbeddingModel | str = DEFAULT_EMBEDDING_MODEL
     api_key: str | None = None
     base_url: str | None = None
+    dimensions: int | None = None
+    """Requested output dimensionality.
+
+    When set, it is forwarded to the OpenAI ``dimensions`` parameter (supported by
+    ``text-embedding-3-*`` models) so the API returns a natively reduced, renormalized
+    vector instead of one that is naively truncated. Leave as ``None`` (the default) for
+    backwards-compatible behavior and for models/endpoints that do not support the
+    parameter (e.g. ``text-embedding-ada-002`` or custom ``base_url`` deployments). When
+    set, prefer matching :attr:`embedding_dim` so downstream storage stays consistent.
+    """
 
 
 class OpenAIEmbedder(EmbedderClient):
@@ -51,16 +62,28 @@ class OpenAIEmbedder(EmbedderClient):
         else:
             self.client = AsyncOpenAI(api_key=config.api_key, base_url=config.base_url)
 
+    def _create_kwargs(self, input_data: Any) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
+            'input': input_data,
+            'model': self.config.embedding_model,
+        }
+        if self.config.dimensions is not None:
+            kwargs['dimensions'] = self.config.dimensions
+        return kwargs
+
+    def _postprocess(self, embedding: list[float]) -> list[float]:
+        # A natively requested ``dimensions`` value already yields a correctly sized,
+        # renormalized vector, so only fall back to truncation when it is not used.
+        if self.config.dimensions is not None:
+            return embedding
+        return embedding[: self.config.embedding_dim]
+
     async def create(
         self, input_data: str | list[str] | Iterable[int] | Iterable[Iterable[int]]
     ) -> list[float]:
-        result = await self.client.embeddings.create(
-            input=input_data, model=self.config.embedding_model
-        )
-        return result.data[0].embedding[: self.config.embedding_dim]
+        result = await self.client.embeddings.create(**self._create_kwargs(input_data))
+        return self._postprocess(result.data[0].embedding)
 
     async def create_batch(self, input_data_list: list[str]) -> list[list[float]]:
-        result = await self.client.embeddings.create(
-            input=input_data_list, model=self.config.embedding_model
-        )
-        return [embedding.embedding[: self.config.embedding_dim] for embedding in result.data]
+        result = await self.client.embeddings.create(**self._create_kwargs(input_data_list))
+        return [self._postprocess(embedding.embedding) for embedding in result.data]

--- a/tests/embedder/test_openai.py
+++ b/tests/embedder/test_openai.py
@@ -90,6 +90,8 @@ async def test_create_calls_api_correctly(
     _, kwargs = mock_openai_client.embeddings.create.call_args
     assert kwargs['model'] == DEFAULT_EMBEDDING_MODEL
     assert kwargs['input'] == 'Test input'
+    # dimensions is not forwarded unless explicitly configured
+    assert 'dimensions' not in kwargs
 
     # Verify result is processed correctly
     assert result == mock_openai_response.data[0].embedding[: openai_embedder.config.embedding_dim]
@@ -120,6 +122,49 @@ async def test_create_batch_processes_multiple_inputs(
         mock_openai_batch_response.data[1].embedding[: openai_embedder.config.embedding_dim],
         mock_openai_batch_response.data[2].embedding[: openai_embedder.config.embedding_dim],
     ]
+
+
+@pytest.mark.asyncio
+async def test_create_forwards_dimensions_and_skips_truncation(
+    mock_openai_client: Any, mock_openai_response: MagicMock
+) -> None:
+    """When ``dimensions`` is configured it is forwarded to the API and the natively
+    sized vector is returned without the lossy truncation step."""
+    # Setup: request a native dimensionality larger than the default embedding_dim
+    native_vector = mock_openai_response.data[0].embedding
+    config = OpenAIEmbedderConfig(api_key='test_api_key', dimensions=len(native_vector))
+    embedder = OpenAIEmbedder(config=config)
+    embedder.client = mock_openai_client
+    mock_openai_client.embeddings.create.return_value = mock_openai_response
+
+    # Call method
+    result = await embedder.create('Test input')
+
+    # Verify dimensions is forwarded to the API
+    _, kwargs = mock_openai_client.embeddings.create.call_args
+    assert kwargs['dimensions'] == len(native_vector)
+
+    # Verify the full native vector is returned, not truncated to embedding_dim
+    assert result == native_vector
+    assert len(result) > embedder.config.embedding_dim
+
+
+@pytest.mark.asyncio
+async def test_create_batch_forwards_dimensions(
+    mock_openai_client: Any, mock_openai_batch_response: MagicMock
+) -> None:
+    """create_batch forwards ``dimensions`` and returns untruncated native vectors."""
+    native_len = len(mock_openai_batch_response.data[0].embedding)
+    config = OpenAIEmbedderConfig(api_key='test_api_key', dimensions=native_len)
+    embedder = OpenAIEmbedder(config=config)
+    embedder.client = mock_openai_client
+    mock_openai_client.embeddings.create.return_value = mock_openai_batch_response
+
+    result = await embedder.create_batch(['Input 1', 'Input 2', 'Input 3'])
+
+    _, kwargs = mock_openai_client.embeddings.create.call_args
+    assert kwargs['dimensions'] == native_len
+    assert result == [data.embedding for data in mock_openai_batch_response.data]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What

Adds an opt-in `dimensions` field to `OpenAIEmbedderConfig` so `OpenAIEmbedder` can request natively reduced embeddings via the OpenAI [`dimensions`](https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-dimensions) parameter, instead of naively slicing the full vector.

Related to #1087.

## Why

Today `create`/`create_batch` return `result.data[0].embedding[: self.config.embedding_dim]`. Slicing a `text-embedding-3-*` vector drops the trailing components **without renormalizing**, so the resulting vector is no longer unit-length and cosine similarity degrades — the exact retrieval-quality issue raised in #1087 (most severe for `text-embedding-3-large`, 3072 → 1024 = 66% dropped).

The OpenAI models support generating the embedding at a target dimensionality server-side, which returns a properly normalized reduced vector. As @danielchalef noted on the issue, truncation is intentional for storage cost, so this is added as an **opt-in** rather than a behavior change.

## Behavior

- `dimensions=None` (default): **unchanged** — full vector requested and truncated to `embedding_dim`. Safe for models/endpoints that don't accept the parameter (e.g. `text-embedding-ada-002`, custom `base_url` deployments).
- `dimensions=N`: `N` is forwarded to the API and the natively sized, renormalized vector is returned without truncation. Users setting this should match `embedding_dim` for downstream storage consistency (documented on the field).

## Tests

Extends `tests/embedder/test_openai.py`:
- existing tests assert `dimensions` is **not** sent when unconfigured;
- new tests assert it is forwarded and that the full native vector is returned (no truncation) for both `create` and `create_batch`.

All four pass; the two new tests fail against the pre-change implementation, confirming they exercise the new path. `ruff check` and `ruff format --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
