### PR TITLE
fix(ci): accept CLA signature comment variants

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,7 +28,10 @@ jobs:
           private-key: ${{ secrets.CLA_APP_PRIVATE_KEY }}
 
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        if: >
+          github.event_name == 'pull_request_target' ||
+          github.event.comment.body == 'recheck' ||
+          startsWith(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')
         # Maintained node24 fork of the (archived) contributor-assistant/github-action.
         # Pinned to a commit SHA because the fork publishes no semver tags.
         uses: SiliconLabsSoftware/action-cla-assistant@89980ac6cfe974ea7703b4ccfbaeb1b2cc6065d2 # silabs_flavour_v2 (node24)

--- a/tests/test_cla_workflow.py
+++ b/tests/test_cla_workflow.py
@@ -1,0 +1,101 @@
+import re
+from pathlib import Path
+
+CANONICAL_SIGNATURE = 'I have read the CLA Document and I hereby sign the CLA'
+WORKFLOW_PATH = Path(__file__).parents[1] / '.github' / 'workflows' / 'cla.yml'
+
+
+def _indent(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
+def _cla_assistant_condition() -> str:
+    lines = WORKFLOW_PATH.read_text().splitlines()
+    step_index = next(
+        index for index, line in enumerate(lines) if line.strip() == '- name: "CLA Assistant"'
+    )
+    step_indent = _indent(lines[step_index])
+
+    for index in range(step_index + 1, len(lines)):
+        line = lines[index]
+        stripped = line.strip()
+        if stripped and _indent(line) <= step_indent:
+            break
+        if not stripped.startswith('if:'):
+            continue
+
+        if_indent = _indent(line)
+        value = stripped.removeprefix('if:').strip()
+        if value not in {'>', '>-', '|', '|-'}:
+            return value
+
+        folded_lines: list[str] = []
+        for continuation in lines[index + 1 :]:
+            if continuation.strip() and _indent(continuation) <= if_indent:
+                break
+            if continuation.strip():
+                folded_lines.append(continuation.strip())
+        return ' '.join(folded_lines)
+
+    raise AssertionError('CLA Assistant step has no if condition')
+
+
+def _condition_runs(condition: str, event_name: str, comment_body: str | None) -> bool:
+    clauses = [clause.strip().lstrip('(').strip() for clause in condition.split('||')]
+    results: list[bool] = []
+
+    for clause in clauses:
+        event_match = re.fullmatch(
+            r"github\.event_name\s*==\s*(['\"])pull_request_target\1\)*",
+            clause,
+        )
+        if event_match:
+            results.append(event_name == 'pull_request_target')
+            continue
+
+        exact_match = re.fullmatch(
+            r"github\.event\.comment\.body\s*==\s*(['\"])(.*?)\1\)*",
+            clause,
+        )
+        if exact_match:
+            expected_body = exact_match.group(2)
+            assert expected_body in {'recheck', CANONICAL_SIGNATURE}, (
+                f'unsupported exact comment clause: {clause}'
+            )
+            results.append(comment_body == expected_body)
+            continue
+
+        starts_with_match = re.fullmatch(
+            r"startsWith\(github\.event\.comment\.body,\s*(['\"])(.*?)\1\)\)*",
+            clause,
+        )
+        if starts_with_match:
+            prefix = starts_with_match.group(2)
+            assert prefix == CANONICAL_SIGNATURE, f'unsupported signature prefix: {prefix}'
+            results.append(comment_body is not None and comment_body.startswith(prefix))
+            continue
+
+        raise AssertionError(f'unsupported CLA condition clause: {clause}')
+
+    return any(results)
+
+
+def test_cla_assistant_trigger_contract() -> None:
+    condition = _cla_assistant_condition()
+    cases = (
+        ('issue_comment', CANONICAL_SIGNATURE, True),
+        ('issue_comment', f'{CANONICAL_SIGNATURE}, e-mail: user@example.com', True),
+        (
+            'issue_comment',
+            f'{CANONICAL_SIGNATURE} behalf of my company, e-mail: user@example.com',
+            True,
+        ),
+        ('issue_comment', 'recheck', True),
+        ('issue_comment', 'unrelated body', False),
+        ('pull_request_target', None, True),
+        ('pull_request_target', 'arbitrary body', True),
+    )
+
+    for event_name, comment_body, expected in cases:
+        observed = _condition_runs(condition, event_name, comment_body)
+        assert observed is expected, f'{event_name=}, {comment_body=}, {expected=}'


### PR DESCRIPTION
## Summary

- allow the CLA workflow's `issue_comment` gate to accept the canonical signing sentence when CLA Assistant Lite appends its documented e-mail or company suffix
- preserve the existing exact `recheck` path and every `pull_request_target` run
- add an offline regression test that reads `.github/workflows/cla.yml` and exercises accepted and rejected event/body combinations

The implementation deliberately does not set `custom-pr-sign-comment`: at the pinned action revision, any nonempty custom signing comment switches the action's own matching to exact equality and would reject the existing suffix-bearing signatures once the workflow starts.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation/Tests

## Objective

This is the bounded trigger fix discussed in issue #1727. It changes only the workflow gate and adds its regression fence; it does not change the CLA document, signature ledger, action pin, permissions, tokens, or branch protection.

## Issue checkpoint

Issue #1727 remains open. The pre-implementation checkpoint is https://github.com/getzep/graphiti/issues/1727#issuecomment-5175092880. At publication time, the live default branch was `main` at `aab852df94413fd0d55cbea2b7886173020281d5`, and no existing PR used head `xiaoyaner0201:fix/1727-cla-signature-trigger`.

This Draft intentionally references #1727 without an automatic-closing keyword. It must remain Draft and must not merge until maintainers review the contributor-governance behavior and required checks complete.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

Focused verification on the exact published candidate:

- `GRAPHITI_TELEMETRY_ENABLED=false uv run pytest tests/test_cla_workflow.py -q` — 1 passed; one unrelated Pydantic deprecation warning
- `uv run ruff check tests/test_cla_workflow.py` — passed
- `git diff --check aab852df94413fd0d55cbea2b7886173020281d5..HEAD` — passed
- `actionlint` — unavailable/not installed locally, so no actionlint result is claimed

Published candidate identity:

- HEAD: `5b995104dc9823573c178e6a53de5b032ba61cfd`
- tree: `1ad7ceecdfdd0504203c36bbedc11a10af684837`
- changed files: `.github/workflows/cla.yml`, `tests/test_cla_workflow.py`

## Governance and review limitation

This publication does not establish independent one-to-one governance review. The operational GitHub identity involved in the contribution/publication path may overlap with a repository governor or reviewer identity. Nothing in this Draft or its pre-publication technical verification is a public approval claim. A separate maintainer/CODEOWNER review and the repository's required approval/check rules remain necessary.

## Breaking Changes

- [ ] This PR contains breaking changes

## Checklist

- [x] Code follows project style guidelines for the focused changed test (`ruff check` passes)
- [x] Exact-tree technical self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues

Related to #1727 (non-closing while Draft).
