### PR TITLE
docs(mcp): correct the tool names in the Cursor rules (#1656)

### DIFF
--- a/mcp_server/docs/cursor_rules.md
+++ b/mcp_server/docs/cursor_rules.md
@@ -3,8 +3,8 @@
 ### Before Starting Any Task
 
 - **Always search first:** Use the `search_nodes` tool to look for relevant preferences and procedures before beginning work.
-- **Search for facts too:** Use the `search_facts` tool to discover relationships and factual information that may be relevant to your task.
-- **Filter by entity type:** Specify `Preference`, `Procedure`, or `Requirement` in your node search to get targeted results.
+- **Search for facts too:** Use the `search_memory_facts` tool to discover relationships and factual information that may be relevant to your task.
+- **Filter by entity type:** Pass the entity types you care about (for example `Preference`, `Procedure`, or `Requirement`) in `entity_types` to get targeted results. The server only knows the entity types registered in its configuration, so leave the filter off if none are configured.
 - **Review all matches:** Carefully examine any preferences, procedures, or facts that match your current task.
 
 ### Always Save New or Updated Information
@@ -27,7 +27,7 @@
 
 - **Search before suggesting:** Always check if there's established knowledge before making recommendations.
 - **Combine node and fact searches:** For complex tasks, search both nodes and facts to build a complete picture.
-- **Use `center_node_uuid`:** When exploring related information, center your search around a specific node.
+- **Use `center_node_uuid`:** When exploring related information, center your search around a specific node. Both `search_nodes` and `search_memory_facts` accept it.
 - **Prioritize specific matches:** More specific information takes precedence over general information.
 - **Be proactive:** If you notice patterns in user behavior, consider storing them as preferences or procedures.
 


### PR DESCRIPTION
Related to #1656.

That issue reports an instruction/tool-name mismatch on the prebuilt `zepai/knowledge-graph-mcp:latest` image. The image-vs-tag drift is a release-process question I can't fix from here, but the same mismatch is live in `main` in the file the README tells users to hand to their agent — that part is fixable, and this PR is scoped to exactly that.

### The drift

`mcp_server/docs/cursor_rules.md` instructs agents to call `search_facts`. That tool does not exist:

```
$ rg -n 'search_facts' --glob '!tests'      → mcp_server/docs/cursor_rules.md only
$ rg -n 'async def search' mcp_server/src/graphiti_mcp_server.py
491:async def search_nodes(
568:async def search_memory_facts(
```

`mcp_server/README.md` (`search_memory_facts`, L564) and `GRAPHITI_MCP_INSTRUCTIONS` (L157) both already use the registered name — only this doc lagged. And README step 3 of the Cursor setup says *"Add the Graphiti rules to Cursor's User Rules. See cursor_rules.md"*, so the stale name lands directly in an agent's system rules and turns into a tool-not-found on its first fact search.

### Changes

- `search_facts` → `search_memory_facts`.
- The entity-type bullet named `Preference` / `Procedure` / `Requirement` as if they were built in. They appear nowhere under `mcp_server/` — entity types come from `build_entity_types(config.graphiti.entity_types)`, so with no such configuration the filter matches nothing. Reworded to name the `entity_types` argument and say the types must be registered first.
- Noted that `center_node_uuid` works on both search tools, since the surrounding bullet recommends combining node and fact searches.

Docs only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
