### PR TITLE
fix(embedder): pair batch embeddings by response index, not position

### DIFF
--- a/graphiti_core/embedder/azure_openai.py
+++ b/graphiti_core/embedder/azure_openai.py
@@ -65,7 +65,10 @@ class AzureOpenAIEmbedderClient(EmbedderClient):
                 model=self.model, input=input_data_list
             )
 
-            return [embedding.embedding for embedding in response.data]
+            # Pair by `index`, not position: the API does not guarantee that
+            # `data` arrives in input order (see OpenAIEmbedder.create_batch).
+            ordered = sorted(response.data, key=lambda embedding: embedding.index)
+            return [embedding.embedding for embedding in ordered]
         except Exception as e:
             logger.error(f'Error in Azure OpenAI batch embedding: {e}')
             raise

--- a/graphiti_core/embedder/openai.py
+++ b/graphiti_core/embedder/openai.py
@@ -63,4 +63,8 @@ class OpenAIEmbedder(EmbedderClient):
         result = await self.client.embeddings.create(
             input=input_data_list, model=self.config.embedding_model
         )
-        return [embedding.embedding[: self.config.embedding_dim] for embedding in result.data]
+        # The API documents `data` as index-addressed and does not guarantee it
+        # arrives in input order, so pair by `index` rather than by position:
+        # reading positionally attaches embeddings to the wrong inputs silently.
+        ordered = sorted(result.data, key=lambda embedding: embedding.index)
+        return [embedding.embedding[: self.config.embedding_dim] for embedding in ordered]

--- a/tests/embedder/test_azure_openai.py
+++ b/tests/embedder/test_azure_openai.py
@@ -1,0 +1,116 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graphiti_core.embedder.azure_openai import AzureOpenAIEmbedderClient
+from tests.embedder.embedder_fixtures import create_embedding_values
+
+
+def create_azure_embedding(multiplier: float = 0.1, index: int = 0) -> MagicMock:
+    """Create a mock Azure OpenAI embedding with a value multiplier and index."""
+    mock_embedding = MagicMock()
+    mock_embedding.embedding = create_embedding_values(multiplier)
+    mock_embedding.index = index
+    return mock_embedding
+
+
+@pytest.fixture
+def mock_azure_client() -> Generator[Any, Any, None]:
+    """Create a mocked Azure OpenAI client."""
+    with patch('openai.AsyncAzureOpenAI') as mock_client:
+        mock_instance = mock_client.return_value
+        mock_instance.embeddings = MagicMock()
+        mock_instance.embeddings.create = AsyncMock()
+        yield mock_instance
+
+
+@pytest.fixture
+def azure_embedder(mock_azure_client: Any) -> AzureOpenAIEmbedderClient:
+    """Create an Azure OpenAI embedder with a mocked client."""
+    return AzureOpenAIEmbedderClient(azure_client=mock_azure_client, model='text-embedding-3-small')
+
+
+@pytest.mark.asyncio
+async def test_create_returns_the_first_embedding(
+    azure_embedder: AzureOpenAIEmbedderClient, mock_azure_client: Any
+) -> None:
+    """A single-input create returns that input's embedding."""
+    mock_result = MagicMock()
+    mock_result.data = [create_azure_embedding(0.1, index=0)]
+    mock_azure_client.embeddings.create.return_value = mock_result
+
+    result = await azure_embedder.create('Input text')
+
+    assert result == create_embedding_values(0.1)
+
+
+@pytest.mark.asyncio
+async def test_create_batch_processes_multiple_inputs(
+    azure_embedder: AzureOpenAIEmbedderClient, mock_azure_client: Any
+) -> None:
+    """A batch returns one embedding per input, in input order."""
+    mock_result = MagicMock()
+    mock_result.data = [
+        create_azure_embedding(0.1, index=0),
+        create_azure_embedding(0.2, index=1),
+        create_azure_embedding(0.3, index=2),
+    ]
+    mock_azure_client.embeddings.create.return_value = mock_result
+
+    result = await azure_embedder.create_batch(['Input 1', 'Input 2', 'Input 3'])
+
+    assert len(result) == 3
+    assert result == [
+        create_embedding_values(0.1),
+        create_embedding_values(0.2),
+        create_embedding_values(0.3),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_batch_pairs_embeddings_by_index(
+    azure_embedder: AzureOpenAIEmbedderClient, mock_azure_client: Any
+) -> None:
+    """Embeddings must be returned in INPUT order, keyed by each item's index.
+
+    Reading `data` positionally silently attaches each embedding to the wrong
+    input, which is invisible downstream: every vector looks well-formed and
+    the wrong node is retrieved for the wrong text.
+    """
+    mock_result = MagicMock()
+    mock_result.data = [
+        create_azure_embedding(0.3, index=2),
+        create_azure_embedding(0.1, index=0),
+        create_azure_embedding(0.2, index=1),
+    ]
+    mock_azure_client.embeddings.create.return_value = mock_result
+
+    result = await azure_embedder.create_batch(['Input 1', 'Input 2', 'Input 3'])
+
+    assert result == [
+        create_embedding_values(0.1),  # Input 1 -> index 0
+        create_embedding_values(0.2),  # Input 2 -> index 1
+        create_embedding_values(0.3),  # Input 3 -> index 2
+    ]
+
+
+if __name__ == '__main__':
+    pytest.main(['-xvs', __file__])

--- a/tests/embedder/test_openai.py
+++ b/tests/embedder/test_openai.py
@@ -28,10 +28,11 @@ from graphiti_core.embedder.openai import (
 from tests.embedder.embedder_fixtures import create_embedding_values
 
 
-def create_openai_embedding(multiplier: float = 0.1) -> MagicMock:
-    """Create a mock OpenAI embedding with specified value multiplier."""
+def create_openai_embedding(multiplier: float = 0.1, index: int = 0) -> MagicMock:
+    """Create a mock OpenAI embedding with specified value multiplier and index."""
     mock_embedding = MagicMock()
     mock_embedding.embedding = create_embedding_values(multiplier)
+    mock_embedding.index = index
     return mock_embedding
 
 
@@ -48,9 +49,9 @@ def mock_openai_batch_response() -> MagicMock:
     """Create a mock OpenAI batch embeddings response."""
     mock_result = MagicMock()
     mock_result.data = [
-        create_openai_embedding(0.1),
-        create_openai_embedding(0.2),
-        create_openai_embedding(0.3),
+        create_openai_embedding(0.1, index=0),
+        create_openai_embedding(0.2, index=1),
+        create_openai_embedding(0.3, index=2),
     ]
     return mock_result
 
@@ -120,6 +121,50 @@ async def test_create_batch_processes_multiple_inputs(
         mock_openai_batch_response.data[1].embedding[: openai_embedder.config.embedding_dim],
         mock_openai_batch_response.data[2].embedding[: openai_embedder.config.embedding_dim],
     ]
+
+
+@pytest.fixture
+def mock_openai_batch_response_out_of_order() -> MagicMock:
+    """A valid batch response whose data list is not in input order.
+
+    The OpenAI embeddings API documents `data` as index-addressed, and the
+    order of the list is not guaranteed to match the input order.
+    """
+    mock_result = MagicMock()
+    mock_result.data = [
+        create_openai_embedding(0.3, index=2),
+        create_openai_embedding(0.1, index=0),
+        create_openai_embedding(0.2, index=1),
+    ]
+    return mock_result
+
+
+@pytest.mark.asyncio
+async def test_create_batch_pairs_embeddings_by_index(
+    openai_embedder: OpenAIEmbedder,
+    mock_openai_client: Any,
+    mock_openai_batch_response_out_of_order: MagicMock,
+) -> None:
+    """Embeddings must be returned in INPUT order, keyed by each item's index.
+
+    Reading `data` positionally silently attaches each embedding to the wrong
+    input, which is invisible downstream: every vector looks well-formed and
+    the wrong memory is retrieved for the wrong text.
+    """
+    mock_openai_client.embeddings.create.return_value = mock_openai_batch_response_out_of_order
+    input_batch = ['Input 1', 'Input 2', 'Input 3']
+
+    result = await openai_embedder.create_batch(input_batch)
+
+    dim = openai_embedder.config.embedding_dim
+    assert (
+        result
+        == [
+            create_embedding_values(0.1)[:dim],  # Input 1 -> index 0
+            create_embedding_values(0.2)[:dim],  # Input 2 -> index 1
+            create_embedding_values(0.3)[:dim],  # Input 3 -> index 2
+        ]
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

`create_batch` in both `OpenAIEmbedder` and `AzureOpenAIEmbedderClient` reads `response.data` **positionally**, but the OpenAI embeddings API documents that list as *index-addressed* and does not guarantee it arrives in input order. When a response comes back out of order, each embedding is attached to the wrong input.

```python
# graphiti_core/embedder/openai.py, before
return [embedding.embedding[: self.config.embedding_dim] for embedding in result.data]
```

This PR sorts by `index` before extracting, in both clients, and adds tests that fail without the fix.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation/Tests

## Objective

**The failure is silent.** Every vector is well-formed and the batch size is correct, so nothing errors and nothing looks wrong — the embeddings simply describe different text than the nodes they are stored on. Downstream, a search returns the wrong node for a query, with no signal anywhere that it happened.

It is also invisible to the current tests. `test_create_batch_processes_multiple_inputs` asserts:

```python
assert result == [
    mock_openai_batch_response.data[0].embedding[:dim],
    mock_openai_batch_response.data[1].embedding[:dim],
    mock_openai_batch_response.data[2].embedding[:dim],
]
```

That is positional on both sides, so it encodes the same assumption the code makes — and the mock embeddings carry no `index` field at all, so the fixture cannot express an out-of-order response.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

- `create_openai_embedding()` now accepts an `index` (default `0`) so fixtures can express real responses. Existing fixtures pass `index=0,1,2`; their assertions are unchanged.
- **`test_create_batch_pairs_embeddings_by_index`** (new, one per client): a valid response whose `data` is shuffled while carrying correct `.index` values must still return embeddings in **input** order.
- **`tests/embedder/test_azure_openai.py`** (new file): the Azure client had no tests, and this PR changes it — covers single create, batch, and index pairing.

Verified the new tests are not vacuous: with the source change reverted, exactly the two `test_create_batch_pairs_embeddings_by_index` tests fail and the rest pass; with it applied, all 6 pass.

```
tests/embedder/test_openai.py tests/embedder/test_azure_openai.py -> 6 passed
ruff format: clean · ruff check: All checks passed
```

## Breaking Changes
- [ ] This PR contains breaking changes

Behaviour only changes when a provider returns `data` out of order, where the previous result was incorrect.

## Checklist
- [x] Code follows project style guidelines (`ruff format` / `ruff check` pass)
- [x] Self-review completed
- [ ] Documentation updated where necessary — no user-facing docs affected
- [x] No secrets or sensitive information committed

## Related Issues

None found — I searched open issues and PRs for this before filing.

## Deliberately not in this PR

Two adjacent observations left alone to keep this reviewable. Happy to open issues or a follow-up PR if you'd like them:

1. `OpenAIEmbedder` truncates to `config.embedding_dim` while `AzureOpenAIEmbedderClient` does not, so the two clients can return different widths for the same configured model.
2. That truncation is silent — a model returning an unexpected dimension is reshaped rather than reported.
