### PR TITLE
fix(mcp): honor CONFIG_PATH env var instead of clobbering it with the --config default (#1736)

### DIFF
--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -1109,7 +1109,7 @@ async def initialize_server() -> ServerConfig:
     parser.add_argument(
         '--config',
         type=Path,
-        default=default_config,
+        default=None,
         help='Path to YAML configuration file (default: config/config.yaml)',
     )
 
@@ -1173,9 +1173,16 @@ async def initialize_server() -> ServerConfig:
 
     args = parser.parse_args()
 
-    # Set config path in environment for the settings to pick up
-    if args.config:
+    # Set config path in environment for the settings to pick up.
+    # Precedence: explicit --config flag > CONFIG_PATH env var > bundled default.
+    # Only fall back to the bundled default when neither is provided, so a
+    # deployment's CONFIG_PATH env var is honored. Previously --config carried an
+    # always-truthy Path default that unconditionally overwrote CONFIG_PATH on
+    # every boot, silently ignoring the documented env-var pattern.
+    if args.config is not None:
         os.environ['CONFIG_PATH'] = str(args.config)
+    elif 'CONFIG_PATH' not in os.environ:
+        os.environ['CONFIG_PATH'] = str(default_config)
 
     # Load configuration with environment variables and YAML
     config = GraphitiConfig()


### PR DESCRIPTION
## Summary

Fixes #1736. The documented `CONFIG_PATH` env-var pattern for pointing the MCP server at a custom `config.yaml` in container deployments was silently ignored on every boot.

## Root cause

The `--config` CLI argument carried a non-empty `Path` default:

```python
default_config = Path(__file__).parent.parent / 'config' / 'config.yaml'
parser.add_argument('--config', type=Path, default=default_config, ...)
```

Since that default is always truthy, `args.config` is populated even when `--config` is never passed. The startup code then ran unconditionally:

```python
if args.config:
    os.environ['CONFIG_PATH'] = str(args.config)
```

so the bundled demo config path always overwrote whatever `CONFIG_PATH` the deployment environment had set, *before* `GraphitiConfig()` (and its `YamlSettingsSource`, which reads `os.environ.get('CONFIG_PATH', 'config/config.yaml')`) ever ran. Net effect: the env-var path never took effect, with no error or warning.

## Fix

- Change the `--config` default to `None` so an explicitly-passed flag can be distinguished from the default.
- Only write `CONFIG_PATH` when `--config` was actually passed; otherwise fall back to the bundled default **only if** `CONFIG_PATH` is not already set in the environment.

Precedence is now: **explicit `--config` > `CONFIG_PATH` env var > bundled default**. This restores the documented env-var behavior while preserving the previous no-argument default (the bundled absolute path), so nothing regresses for users who rely on neither.

## Testing

- `python -m ast` parse check on the modified module.
- Traced the three precedence paths against `config/schema.py:303` (`os.environ.get('CONFIG_PATH', 'config/config.yaml')`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
