### PR TITLE
fix(graph-service): require API key authentication

### DIFF
--- a/server/graph_service/auth.py
+++ b/server/graph_service/auth.py
@@ -1,0 +1,31 @@
+import secrets
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from graph_service.config import ZepEnvDep
+
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+async def require_api_key(
+    settings: ZepEnvDep,
+    credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(bearer_scheme)],
+) -> None:
+    """Fail-closed bearer-token guard for all ingest/retrieve endpoints.
+
+    A request is only authorized when an ``api_key`` is configured and the caller
+    presents a matching ``Authorization: Bearer <api_key>`` credential. If no key
+    is configured the service fails closed and rejects every request.
+    """
+    if (
+        settings.api_key is None
+        or credentials is None
+        or not secrets.compare_digest(credentials.credentials, settings.api_key)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail='Missing or invalid API key',
+            headers={'WWW-Authenticate': 'Bearer'},
+        )

--- a/server/graph_service/config.py
+++ b/server/graph_service/config.py
@@ -19,6 +19,8 @@ class Settings(BaseSettings):
     falkordb_database: str | None = Field(None)
     db_backend: str = Field('neo4j')
 
+    api_key: str | None = Field(None)
+
     model_config = SettingsConfigDict(env_file='.env', extra='ignore')
 
 

--- a/server/graph_service/routers/ingest.py
+++ b/server/graph_service/routers/ingest.py
@@ -2,10 +2,11 @@ import asyncio
 from contextlib import asynccontextmanager
 from functools import partial
 
-from fastapi import APIRouter, FastAPI, status
+from fastapi import APIRouter, Depends, FastAPI, status
 from graphiti_core.nodes import EpisodeType  # type: ignore
 from graphiti_core.utils.maintenance.graph_data_operations import clear_data  # type: ignore
 
+from graph_service.auth import require_api_key
 from graph_service.dto import AddEntityNodeRequest, AddMessagesRequest, Message, Result
 from graph_service.zep_graphiti import ZepGraphitiDep
 
@@ -45,7 +46,7 @@ async def lifespan(_: FastAPI):
     await async_worker.stop()
 
 
-router = APIRouter(lifespan=lifespan)
+router = APIRouter(dependencies=[Depends(require_api_key)], lifespan=lifespan)
 
 
 @router.post('/messages', status_code=status.HTTP_202_ACCEPTED)

--- a/server/graph_service/routers/retrieve.py
+++ b/server/graph_service/routers/retrieve.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, Depends, status
 
+from graph_service.auth import require_api_key
 from graph_service.dto import (
     GetMemoryRequest,
     GetMemoryResponse,
@@ -11,7 +12,7 @@ from graph_service.dto import (
 )
 from graph_service.zep_graphiti import ZepGraphitiDep, get_fact_result_from_edge
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_api_key)])
 
 
 @router.post('/search', status_code=status.HTTP_200_OK)

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -1,0 +1,85 @@
+import pytest
+from fastapi import FastAPI, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+from fastapi.testclient import TestClient
+
+from graph_service.auth import require_api_key
+from graph_service.config import Settings, get_settings
+from graph_service.routers import ingest, retrieve
+from graph_service.zep_graphiti import get_graphiti
+
+
+class _FakeGraphiti:
+    async def retrieve_episodes(self, group_ids, last_n, reference_time):
+        return []
+
+
+def _settings(api_key: str | None) -> Settings:
+    return Settings(openai_api_key='test-openai-key', api_key=api_key)
+
+
+def _client(api_key: str | None) -> TestClient:
+    settings = _settings(api_key)
+    app = FastAPI()
+    app.dependency_overrides[get_settings] = lambda: settings
+    app.dependency_overrides[get_graphiti] = lambda: _FakeGraphiti()
+    app.include_router(retrieve.router)
+    app.include_router(ingest.router)
+    return TestClient(app)
+
+
+@pytest.mark.asyncio
+async def test_missing_credentials_rejected():
+    with pytest.raises(HTTPException) as exc_info:
+        await require_api_key(_settings('secret'), None)
+    assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_wrong_key_rejected():
+    credentials = HTTPAuthorizationCredentials(scheme='Bearer', credentials='wrong')
+    with pytest.raises(HTTPException) as exc_info:
+        await require_api_key(_settings('secret'), credentials)
+    assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_matching_key_accepted():
+    credentials = HTTPAuthorizationCredentials(scheme='Bearer', credentials='secret')
+    await require_api_key(_settings('secret'), credentials)
+
+
+@pytest.mark.asyncio
+async def test_fail_closed_when_no_key_configured():
+    credentials = HTTPAuthorizationCredentials(scheme='Bearer', credentials='anything')
+    with pytest.raises(HTTPException) as exc_info:
+        await require_api_key(_settings(None), credentials)
+    assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_clear_requires_authentication():
+    response = _client('secret').post('/clear')
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_cross_group_delete_requires_authentication():
+    response = _client('secret').delete('/group/some-other-tenant')
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_authorized_request_succeeds():
+    response = _client('secret').get(
+        '/episodes/tenant-a',
+        params={'last_n': 1},
+        headers={'Authorization': 'Bearer secret'},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_authorized_request_fails_closed_without_configured_key():
+    response = _client(None).get(
+        '/episodes/tenant-a',
+        params={'last_n': 1},
+        headers={'Authorization': 'Bearer secret'},
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
## Summary

- require a configured bearer API key for every graph-service ingest and retrieve endpoint
- fail closed when the API key is missing or invalid
- add focused authentication regression tests

Closes #1716.

## Verification

- `git apply --check --recount` passed
- `git diff --check` passed
- local verification not run; relying on upstream CI
- The focused pytest collection was unavailable in this fresh worktree because FastAPI is not installed.