### PR TITLE
fix: return recent episodes from MCP get_episodes

### DIFF
--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -419,6 +419,54 @@ class EpisodicNode(Node):
         return episodes
 
     @classmethod
+    async def get_most_recent_by_group_ids(
+        cls,
+        driver: GraphDriver,
+        group_ids: list[str],
+        limit: int | None = None,
+    ):
+        """Return the most recent episodes for the given groups, ordered by episode time.
+
+        Episodes are ordered by ``valid_at`` (the time the described events occurred)
+        descending, then by ``created_at`` (ingestion time) descending, with ``uuid``
+        as a deterministic tiebreaker. Used by browsing tools that need recency rather
+        than keyset pagination (see :meth:`get_by_group_ids`).
+        """
+        if driver.graph_operations_interface:
+            try:
+                return await driver.graph_operations_interface.episodic_node_get_by_group_ids(
+                    cls, driver, group_ids, limit, None
+                )
+            except NotImplementedError:
+                pass
+
+        limit_query: LiteralString = 'LIMIT $limit' if limit is not None else ''
+
+        records, _, _ = await driver.execute_query(
+            """
+            MATCH (e:Episodic)
+            WHERE e.group_id IN $group_ids
+            RETURN DISTINCT
+            """
+            + (
+                EPISODIC_NODE_RETURN_NEPTUNE
+                if driver.provider == GraphProvider.NEPTUNE
+                else EPISODIC_NODE_RETURN
+            )
+            + """
+            ORDER BY e.valid_at DESC, e.created_at DESC, e.uuid DESC
+            """
+            + limit_query,
+            group_ids=group_ids,
+            limit=limit,
+            routing_='r',
+        )
+
+        episodes = [get_episodic_node_from_record(record) for record in records]
+
+        return episodes
+
+    @classmethod
     async def get_by_group_ids(
         cls,
         driver: GraphDriver,

--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -760,7 +760,10 @@ async def get_episodes(
         from graphiti_core.nodes import EpisodicNode
 
         if effective_group_ids:
-            episodes = await EpisodicNode.get_by_group_ids(
+            # get_episodes is a recency browsing tool: return the most recent episodes
+            # by valid_at rather than the arbitrary uuid-ordered subset that
+            # get_by_group_ids (a keyset-pagination helper) would produce.
+            episodes = await EpisodicNode.get_most_recent_by_group_ids(
                 client.driver, effective_group_ids, limit=max_episodes
             )
         else:

--- a/mcp_server/tests/test_core_parity.py
+++ b/mcp_server/tests/test_core_parity.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock
 import pytest
 from graphiti_core import Graphiti
 from graphiti_core.edges import EntityEdge
-from graphiti_core.nodes import EntityNode
+from graphiti_core.nodes import EntityNode, EpisodicNode
 from graphiti_core.search.search_filters import ComparisonOperator, SearchFilters
 
 # Add the src directory to the path (mirrors the other unit tests)
@@ -275,6 +275,46 @@ class TestCoreSignatureCompatibility:
         )
         assert edge.source_node_uuid == 's'
         assert edge.target_node_uuid == 't'
+
+
+class TestGetMostRecentByGroupIds:
+    """The MCP get_episodes tool must return the most recent episodes by valid_at."""
+
+    def test_get_episodes_uses_recency_helper(self):
+        # GraphitiService.get_episodes must resolve recency through the dedicated
+        # helper, not the uuid-keyed keyset pagination of get_by_group_ids.
+        import graphiti_mcp_server
+
+        source = inspect.getsource(graphiti_mcp_server.get_episodes)
+        assert 'get_most_recent_by_group_ids' in source
+        assert 'get_by_group_ids' not in source
+
+    @pytest.mark.asyncio
+    async def test_helper_orders_by_valid_at_desc_then_created_at(self):
+        driver = AsyncMock()
+        driver.graph_operations_interface = None
+        driver.execute_query.return_value = ([], {}, None)
+
+        await EpisodicNode.get_most_recent_by_group_ids(driver, ['g1'], limit=7)
+
+        driver.execute_query.assert_awaited_once()
+        query = driver.execute_query.await_args.args[0]
+        assert 'ORDER BY e.valid_at DESC, e.created_at DESC, e.uuid DESC' in query
+        assert 'LIMIT $limit' in query
+        kwargs = driver.execute_query.await_args.kwargs
+        assert kwargs['group_ids'] == ['g1']
+        assert kwargs['limit'] == 7
+
+    @pytest.mark.asyncio
+    async def test_helper_omits_limit_clause_when_unbounded(self):
+        driver = AsyncMock()
+        driver.graph_operations_interface = None
+        driver.execute_query.return_value = ([], {}, None)
+
+        await EpisodicNode.get_most_recent_by_group_ids(driver, ['g1'])
+
+        query = driver.execute_query.await_args.args[0]
+        assert 'LIMIT' not in query
 
 
 class TestEntityTypeRegistration:


### PR DESCRIPTION
## Summary

`get_episodes` is a recency browsing tool, but it reused the uuid-keyset pagination helper and returned an arbitrary subset of episodes. Add a dedicated recency-ordered helper using `valid_at`, `created_at`, and `uuid` tie-breakers, and route the MCP tool through it.

Fixes #1724

## Verification

- `git apply --check --recount`
- `git diff --check`
- local verification not run; relying on upstream CI