### PR TITLE
fix(dedup): catch exact-name duplicates below the cosine gate via a fulltext candidate pass

### DIFF
--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -40,7 +40,7 @@ from graphiti_core.prompts.extract_nodes import (
     SummarizedEntities,
 )
 from graphiti_core.search.search_filters import SearchFilters
-from graphiti_core.search.search_utils import node_similarity_search
+from graphiti_core.search.search_utils import node_fulltext_search, node_similarity_search
 from graphiti_core.utils.datetime_utils import utc_now
 from graphiti_core.utils.maintenance.attribute_utils import apply_capped_attributes
 from graphiti_core.utils.maintenance.dedup_helpers import (
@@ -410,9 +410,18 @@ async def _collect_candidate_nodes(
     existing_nodes_override: list[EntityNode] | None,
 ) -> list[list[EntityNode]]:
     """Search per extracted name and return ordered candidates for each extracted node."""
-    search_results = await _semantic_candidate_search(clients, extracted_nodes)
+    semantic_results = await _semantic_candidate_search(clients, extracted_nodes)
+    fulltext_results = await _fulltext_candidate_search(clients, extracted_nodes)
 
-    return [_merge_candidate_nodes(result, existing_nodes_override) for result in search_results]
+    # Semantic hits come first so their cosine ordering is preserved; the fulltext
+    # pass appends exact-name matches whose embeddings fall below
+    # NODE_DEDUP_COSINE_MIN_SCORE and would otherwise never reach the
+    # deterministic exact-match step (e.g. short acronyms). _merge_candidate_nodes
+    # dedupes by uuid, so overlapping hits collapse.
+    return [
+        _merge_candidate_nodes([*semantic, *fulltext], existing_nodes_override)
+        for semantic, fulltext in zip(semantic_results, fulltext_results, strict=True)
+    ]
 
 
 async def _semantic_candidate_search(
@@ -445,6 +454,36 @@ async def _semantic_candidate_search(
                     NODE_DEDUP_COSINE_MIN_SCORE,
                 )
                 for node, query_vector in zip(extracted_nodes, query_vectors, strict=True)
+            ]
+        )
+    )
+
+
+async def _fulltext_candidate_search(
+    clients: GraphitiClients,
+    extracted_nodes: list[EntityNode],
+) -> list[list[EntityNode]]:
+    """Run a BM25 fulltext search per extracted name.
+
+    Embedding similarity alone misses exact-name duplicates whose vectors score
+    below NODE_DEDUP_COSINE_MIN_SCORE (short, low-entropy strings such as
+    acronyms are especially prone). A fulltext pass on the name surfaces those
+    candidates so the deterministic exact-match step can merge them.
+    """
+    if not extracted_nodes:
+        return []
+
+    return list(
+        await semaphore_gather(
+            *[
+                node_fulltext_search(
+                    clients.driver,
+                    node.name,
+                    SearchFilters(),
+                    [node.group_id],
+                    NODE_DEDUP_CANDIDATE_LIMIT,
+                )
+                for node in extracted_nodes
             ]
         )
     )

--- a/tests/utils/maintenance/test_node_operations.py
+++ b/tests/utils/maintenance/test_node_operations.py
@@ -68,6 +68,21 @@ def _semantic_candidates(candidate_groups: list[list[EntityNode]]):
     return fake_search
 
 
+@pytest.fixture(autouse=True)
+def _default_fulltext_search(monkeypatch):
+    """Default the fulltext candidate pass to empty so tests that only stub the
+    semantic search keep exercising the semantic path. Individual tests override
+    this to assert the fulltext pass surfaces below-cosine exact-name matches."""
+
+    async def _empty(_clients, extracted_nodes):
+        return [[] for _ in extracted_nodes]
+
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations._fulltext_candidate_search',
+        _empty,
+    )
+
+
 @pytest.mark.asyncio
 async def test_resolve_nodes_exact_match_skips_llm(monkeypatch):
     clients, llm_generate = _make_clients()
@@ -224,6 +239,70 @@ async def test_collect_candidate_nodes_dedupes_and_merges_override(monkeypatch):
     assert len(result[0]) == 1
     assert result[0][0].uuid == candidate.uuid
     semantic_search_mock.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_collect_candidate_nodes_merges_fulltext_below_cosine(monkeypatch):
+    """The fulltext pass contributes candidates the semantic pass misses."""
+    clients, _ = _make_clients()
+
+    fulltext_only = EntityNode(name='DGIA', group_id='group', labels=['Entity'])
+    extracted = EntityNode(name='DGIA', group_id='group', labels=['Entity'])
+
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations._semantic_candidate_search',
+        AsyncMock(return_value=[[]]),
+    )
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations._fulltext_candidate_search',
+        AsyncMock(return_value=[[fulltext_only]]),
+    )
+
+    result = await _collect_candidate_nodes(
+        clients,
+        [extracted],
+        existing_nodes_override=None,
+    )
+
+    assert len(result) == 1
+    assert [n.uuid for n in result[0]] == [fulltext_only.uuid]
+
+
+@pytest.mark.asyncio
+async def test_resolve_nodes_fulltext_catches_below_cosine_exact_match(monkeypatch):
+    """Exact-name duplicates whose embeddings fall below NODE_DEDUP_COSINE_MIN_SCORE
+    must still be resolved via the fulltext candidate pass (regression for short
+    acronyms accumulating duplicate nodes)."""
+    clients, llm_generate = _make_clients()
+
+    candidate = EntityNode(name='DGIA', group_id='group', labels=['Entity'])
+    extracted = EntityNode(name='DGIA', group_id='group', labels=['Entity'])
+
+    # Semantic search misses it: the name embedding scores below the cosine gate.
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations._semantic_candidate_search',
+        _semantic_candidates([[]]),
+    )
+
+    # Fulltext surfaces the exact-name node regardless of embedding distance.
+    async def _fulltext(_clients, extracted_nodes):
+        return [[candidate] for _ in extracted_nodes]
+
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations._fulltext_candidate_search',
+        _fulltext,
+    )
+
+    resolved, uuid_map, _ = await resolve_extracted_nodes(
+        clients,
+        [extracted],
+        episode=_make_episode(),
+        previous_episodes=[],
+    )
+
+    assert resolved[0].uuid == candidate.uuid
+    assert uuid_map[extracted.uuid] == candidate.uuid
+    llm_generate.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`resolve_extracted_nodes` builds its dedup candidate pool through `_semantic_candidate_search` only — `node_similarity_search` gated by `NODE_DEDUP_COSINE_MIN_SCORE` (0.6). The deterministic exact-match step in `dedup_helpers.py` (`_resolve_with_similarity` → `_normalize_string_exact`) is correct, but it only ever sees candidates that already survived the embedding gate.

So two nodes with the **identical** name are never compared when their name embeddings score below 0.6 against each other — no matter how identical the strings are. Short, low-entropy strings (acronyms, initialisms) are especially prone: as reported in #1734, four separate `"DGIA"` `Entity` nodes accumulated in a single `group_id`, with 5 of 6 pairwise cosine similarities below 0.6.

## Fix

Add `_fulltext_candidate_search`: a BM25 fulltext pass on the extracted node name (the same `node_fulltext_search` used by hybrid search), run per extracted node and merged into the candidate pool alongside the semantic hits.

- Semantic hits are kept first so their cosine ordering is preserved.
- `_merge_candidate_nodes` already dedupes by `uuid`, so overlapping hits between the two passes collapse cleanly.
- The deterministic exact-match step then sees the exact-name node regardless of embedding distance.

## Tests

- `test_collect_candidate_nodes_merges_fulltext_below_cosine` — a candidate found only by the fulltext pass (semantic returns nothing) still reaches the pool.
- `test_resolve_nodes_fulltext_catches_below_cosine_exact_match` — an exact-name duplicate that the semantic search misses is now resolved deterministically, without an LLM call.
- Existing tests default the fulltext pass to empty via an autouse fixture, so they keep exercising the semantic path unchanged.

`make format`/`ruff` clean; full `tests/utils/maintenance/test_node_operations.py` suite (34 tests) passes.

Fixes #1734

🤖 Generated with [Claude Code](https://claude.com/claude-code)
