### PR TITLE
fix(compat): use typing extensions for TypedDict

### DIFF
--- a/graphiti_core/prompts/dedupe_edges.py
+++ b/graphiti_core/prompts/dedupe_edges.py
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Protocol, TypedDict
+from typing import Any, Protocol
+from typing_extensions import TypedDict
 
 from pydantic import BaseModel, Field
 

--- a/graphiti_core/prompts/dedupe_nodes.py
+++ b/graphiti_core/prompts/dedupe_nodes.py
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Protocol, TypedDict
+from typing import Any, Protocol
+from typing_extensions import TypedDict
 
 from pydantic import BaseModel, Field
 

--- a/graphiti_core/prompts/eval.py
+++ b/graphiti_core/prompts/eval.py
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Protocol, TypedDict
+from typing import Any, Protocol
+from typing_extensions import TypedDict
 
 from pydantic import BaseModel, Field
 

--- a/graphiti_core/prompts/extract_edges.py
+++ b/graphiti_core/prompts/extract_edges.py
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Protocol, TypedDict
+from typing import Any, Protocol
+from typing_extensions import TypedDict
 
 from pydantic import BaseModel, Field
 

--- a/graphiti_core/prompts/extract_nodes.py
+++ b/graphiti_core/prompts/extract_nodes.py
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Protocol, TypedDict
+from typing import Any, Protocol
+from typing_extensions import TypedDict
 
 from pydantic import BaseModel, Field
 

--- a/graphiti_core/prompts/extract_nodes_and_edges.py
+++ b/graphiti_core/prompts/extract_nodes_and_edges.py
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Protocol, TypedDict
+from typing import Any, Protocol
+from typing_extensions import TypedDict
 
 from pydantic import BaseModel, Field
 

--- a/graphiti_core/prompts/lib.py
+++ b/graphiti_core/prompts/lib.py
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Protocol, TypedDict
+from typing import Any, Protocol
+from typing_extensions import TypedDict
 
 from .dedupe_edges import Prompt as DedupeEdgesPrompt
 from .dedupe_edges import Versions as DedupeEdgesVersions

--- a/graphiti_core/prompts/summarize_nodes.py
+++ b/graphiti_core/prompts/summarize_nodes.py
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Protocol, TypedDict
+from typing import Any, Protocol
+from typing_extensions import TypedDict
 
 from pydantic import BaseModel, Field
 

--- a/graphiti_core/prompts/summarize_sagas.py
+++ b/graphiti_core/prompts/summarize_sagas.py
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Protocol, TypedDict
+from typing import Any, Protocol
+from typing_extensions import TypedDict
 
 from pydantic import BaseModel, Field
 


### PR DESCRIPTION
﻿## What changed

Use typing_extensions.TypedDict throughout the prompt modules that are imported by the MCP server and core package.

## Why

Pydantic 2 requires typing_extensions.TypedDict on Python versions before 3.12. Importing the standard-library TypedDict on Python 3.10 can fail during schema generation, preventing the server from starting.

The change is limited to the affected compatibility imports.

Fixes #718
