### PR TITLE
fix(mcp): allow extending/disabling transport DNS-rebinding protection (#1745)

### DIFF
--- a/mcp_server/config/config.yaml
+++ b/mcp_server/config/config.yaml
@@ -9,7 +9,16 @@ server:
   transport: "http"  # Options: stdio, sse (deprecated), http
   host: "0.0.0.0"
   port: 8000
-  
+  # DNS-rebinding protection (http/sse transports). By default only localhost Host
+  # headers are accepted, so requests forwarded by a reverse proxy are rejected with
+  # 421. Extend the allowlist with the public hostname, or disable it when a trusted
+  # proxy already validates Host/Origin.
+  # allowed_hosts:
+  #   - "memory.example.com"
+  # allowed_origins:
+  #   - "https://memory.example.com"
+  # disable_transport_security: false
+
 llm:
   provider: "openai"  # Options: openai, azure_openai, anthropic, gemini, groq
   model: ${MODEL_NAME:gpt-5.5}

--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -82,6 +82,32 @@ class ServerConfig(BaseModel):
     )
     host: str = Field(default='0.0.0.0', description='Server host')
     port: int = Field(default=8000, description='Server port')
+    allowed_hosts: list[str] = Field(
+        default_factory=list,
+        description=(
+            'Additional Host header values accepted by the MCP transport '
+            'DNS-rebinding protection, on top of the localhost defaults — e.g. the '
+            'public hostname when running behind a reverse proxy. Wildcards such as '
+            '"memory.example.com" or "*.example.com:*" are supported. Ignored when '
+            'disable_transport_security is set.'
+        ),
+    )
+    allowed_origins: list[str] = Field(
+        default_factory=list,
+        description=(
+            'Additional Origin header values accepted by the MCP transport '
+            'DNS-rebinding protection, on top of the localhost defaults. Ignored '
+            'when disable_transport_security is set.'
+        ),
+    )
+    disable_transport_security: bool = Field(
+        default=False,
+        description=(
+            'Disable the MCP transport DNS-rebinding protection entirely. Use only '
+            'when the server sits behind a trusted proxy that already validates the '
+            'Host and Origin headers.'
+        ),
+    )
 
 
 class OpenAIProviderConfig(BaseModel):

--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -20,6 +20,7 @@ from graphiti_core.nodes import EntityNode, EpisodeType, SagaNode
 from graphiti_core.search.search_filters import SearchFilters
 from graphiti_core.utils.maintenance.graph_data_operations import clear_data
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import BaseModel
 from starlette.responses import JSONResponse
 
@@ -1236,6 +1237,31 @@ async def initialize_server() -> ServerConfig:
         mcp.settings.host = config.server.host
     if config.server.port:
         mcp.settings.port = config.server.port
+
+    # Reconcile the transport DNS-rebinding protection with the configured host.
+    # FastMCP auto-enables a localhost-only allowlist at construction time (before
+    # the configured host is known), so a server bound to a non-localhost host — the
+    # default here, and the normal reverse-proxy deployment shape — 421-rejects every
+    # request that arrives with a non-localhost Host header. These knobs let a
+    # deployment extend the allowlist or opt out entirely without silently weakening
+    # the default.
+    if config.server.disable_transport_security:
+        mcp.settings.transport_security = TransportSecuritySettings(
+            enable_dns_rebinding_protection=False,
+        )
+    elif config.server.allowed_hosts or config.server.allowed_origins:
+        # Keep the SDK's localhost defaults so local health checks keep working.
+        localhost_hosts = ['127.0.0.1:*', 'localhost:*', '[::1]:*']
+        localhost_origins = [
+            'http://127.0.0.1:*',
+            'http://localhost:*',
+            'http://[::1]:*',
+        ]
+        mcp.settings.transport_security = TransportSecuritySettings(
+            enable_dns_rebinding_protection=True,
+            allowed_hosts=localhost_hosts + config.server.allowed_hosts,
+            allowed_origins=localhost_origins + config.server.allowed_origins,
+        )
 
     # Return MCP configuration for transport
     return config.server


### PR DESCRIPTION
Fixes #1745.

## The bug

`FastMCP.__init__` auto-enables DNS-rebinding protection with a **localhost-only** allowlist whenever it is constructed with the default host:

```python
# mcp/server/fastmcp/server.py
if transport_security is None and host in ("127.0.0.1", "localhost", "::1"):
    transport_security = TransportSecuritySettings(
        enable_dns_rebinding_protection=True,
        allowed_hosts=["127.0.0.1:*", "localhost:*", "[::1]:*"], ...
    )
```

`graphiti_mcp_server.py` constructs `mcp = FastMCP('Graphiti Agent Memory', ...)` at import time with **no** `transport_security` argument, so protection turns on with the localhost allowlist. `config.server.host` (which defaults to `0.0.0.0`) is only applied to `mcp.settings.host` **afterwards**, too late to affect that decision — and it never touches `transport_security`.

Result: behind any reverse proxy / API gateway (the normal Kubernetes shape, and the default `0.0.0.0` bind), every request with a non-localhost `Host` header is rejected:

```
mcp.server.transport_security - WARNING - Invalid Host header: memory.example.com
"POST /mcp HTTP/1.1" 421 Misdirected Request
```

There was previously no CLI flag, config key, or env var to extend the allowlist or turn the protection off.

## The fix

Three opt-in `ServerConfig` fields (defaults preserve current behavior exactly):

- `server.allowed_hosts` — extra `Host` values, **added to** the localhost defaults
- `server.allowed_origins` — extra `Origin` values, added to the localhost defaults
- `server.disable_transport_security` — turn the protection off entirely for deployments behind a trusted proxy

They are applied to `mcp.settings.transport_security` right after the host/port are set in `initialize_server()`. This works because the SDK reads `self.settings.transport_security` lazily when it builds the SSE / streamable-HTTP app (at `.run_*_async()` time), not at construction — so a post-construction assignment takes effect.

When `allowed_hosts`/`allowed_origins` are provided, the SDK's localhost entries are kept so local health checks keep working.

The shipped `config/config.yaml` gets commented examples for discoverability.

## Verification

- `ruff check` (repo `mcp_server` ruleset: E, F, UP, B, SIM, I; line-length 100) — clean.
- `py_compile` on both changed Python files — clean.
- Confirmed against the installed MCP SDK (1.28.x) that `TransportSecuritySettings` is consumed from `settings.transport_security` at app-build time (`security_settings=self.settings.transport_security`), so the late assignment is honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
