### PR TITLE
fix: accept Neo4j parameters_ keyword

### DIFF
--- a/graphiti_core/driver/neo4j_driver.py
+++ b/graphiti_core/driver/neo4j_driver.py
@@ -158,9 +158,11 @@ class Neo4jDriver(GraphDriver):
                 raise
 
     async def execute_query(self, cypher_query_: LiteralString, **kwargs: Any) -> EagerResult:
-        # Check if database_ is provided in kwargs.
-        # If not populated, set the value to retain backwards compatibility
+        # Preserve Graphiti's params keyword while accepting Neo4j's parameters_ spelling.
         params = kwargs.pop('params', None)
+        neo4j_params = kwargs.pop('parameters_', None)
+        if params is None:
+            params = neo4j_params
         if params is None:
             params = {}
         params.setdefault('database_', self._database)

--- a/tests/driver/test_neo4j_driver.py
+++ b/tests/driver/test_neo4j_driver.py
@@ -1,0 +1,61 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graphiti_core.driver.neo4j_driver import Neo4jDriver
+
+
+@pytest.fixture
+def neo4j_driver() -> Neo4jDriver:
+    client = MagicMock()
+    client.execute_query = AsyncMock(return_value=MagicMock())
+
+    with (
+        patch('graphiti_core.driver.neo4j_driver.AsyncGraphDatabase.driver', return_value=client),
+        patch.object(Neo4jDriver, 'build_indices_and_constraints', new_callable=AsyncMock),
+    ):
+        return Neo4jDriver('bolt://localhost:7687', 'neo4j', 'password')
+
+
+@pytest.mark.asyncio
+async def test_execute_query_accepts_neo4j_parameters_keyword(neo4j_driver: Neo4jDriver):
+    result = await neo4j_driver.execute_query(
+        'MATCH (n {group_id: $group_id}) RETURN n',
+        parameters_={'group_id': 'test-group'},
+    )
+
+    assert result is neo4j_driver.client.execute_query.return_value
+    neo4j_driver.client.execute_query.assert_awaited_once_with(
+        'MATCH (n {group_id: $group_id}) RETURN n',
+        parameters_={'group_id': 'test-group', 'database_': 'neo4j'},
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_query_preserves_graphiti_params_keyword(neo4j_driver: Neo4jDriver):
+    result = await neo4j_driver.execute_query(
+        'MATCH (n {group_id: $group_id}) RETURN n',
+        params={'group_id': 'test-group'},
+    )
+
+    assert result is neo4j_driver.client.execute_query.return_value
+    neo4j_driver.client.execute_query.assert_awaited_once_with(
+        'MATCH (n {group_id: $group_id}) RETURN n',
+        parameters_={'group_id': 'test-group', 'database_': 'neo4j'},
+    )


### PR DESCRIPTION
## Summary
Fix `Neo4jDriver.execute_query()` when callers use Neo4j's native `parameters_` keyword. The wrapper now accepts both `params` and `parameters_` without forwarding the latter twice, while preserving the existing `params` behavior.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation/Tests

## Objective
The public driver wrapper currently leaves `parameters_` in `**kwargs` and also passes its own `parameters_` argument, which raises a duplicate-keyword `TypeError`. This patch keeps the wrapper compatible with both Graphiti's internal convention and Neo4j's public API.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Focused Neo4j driver tests pass: `2 passed`
- [x] Ruff check and format check pass
- [x] Pyright passes for `graphiti_core/driver/neo4j_driver.py`

The full no-external-dependency suite was also run: `296 passed, 11 skipped`; three existing FalkorDB security tests could not run because the local environment did not include the optional FalkorDB dependency.

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Closes #1213

AI assistance was used to investigate the issue, prepare the implementation, and write the regression tests. The submitted diff was manually reviewed and locally validated by the account owner.
