### PR TITLE
feat(anthropic): cache the system prompt with an ephemeral breakpoint (#1723)

### DIFF
--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -285,8 +285,21 @@ class AnthropicClient(LLMClient):
         try:
             # Create the appropriate tool based on whether response_model is provided
             tools, tool_choice = self._create_tool(response_model)
+            # Mark the system prompt as an ephemeral prompt-cache breakpoint.
+            # The system prompt (and the tool definitions, which are rendered
+            # before it) is large and identical across the many extraction calls
+            # a single run makes, so caching it lets repeat calls read the prefix
+            # at the cache-read rate instead of paying full input price every time.
+            # A bare string requests no cache; the block form below does.
+            system_blocks: list[anthropic.types.TextBlockParam] = [
+                {
+                    'type': 'text',
+                    'text': system_message.content,
+                    'cache_control': {'type': 'ephemeral'},
+                }
+            ]
             result = await self.client.messages.create(
-                system=system_message.content,
+                system=system_blocks,
                 max_tokens=max_creation_tokens,
                 temperature=self.temperature,
                 messages=user_messages_cast,


### PR DESCRIPTION
## What

The Anthropic client passes the system prompt as a bare string:

```python
result = await self.client.messages.create(
    system=system_message.content,
    ...
)
```

A bare string requests **no** prompt caching, so `cache_control` never appears on the Anthropic path and no caching is applied — exactly as reported in #1723. Graphiti's system prompt (and the tool definitions, which Anthropic renders *before* the system block) is large and identical across the many extraction calls a single run makes, so every call re-pays full input price for that prefix.

This wraps the system prompt in a `text` block with an ephemeral cache breakpoint:

```python
system_blocks: list[anthropic.types.TextBlockParam] = [
    {
        'type': 'text',
        'text': system_message.content,
        'cache_control': {'type': 'ephemeral'},
    }
]
result = await self.client.messages.create(
    system=system_blocks,
    ...
)
```

Because the breakpoint sits on the last block before `messages`, it caches the tool definitions **and** the system prompt together (render order is `tools` → `system` → `messages`), which is the whole stable prefix for a structured-extraction call.

## Why it's safe

- **Output is unchanged** — `cache_control` only affects billing/caching, not what the model generates.
- **No new failure mode** — if the prefix is below the model's minimum cacheable size, it silently isn't cached (no error).
- **No dependency change** — `anthropic.types.TextBlockParam` and its `cache_control` field are available across the declared floor (`anthropic>=0.49.0`).

## Scope

This addresses the first half of #1723 (no cache breakpoint is ever emitted). It intentionally does **not** touch the `MODEL_EFFORT` half of that issue — wiring reasoning-effort control into the Anthropic branch is a separate, larger change and is better decided on its own. Happy to follow up on that separately if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
