### PR TITLE
fix(attributes): preserve prior node attributes when no entity type applies

### DIFF
--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -788,7 +788,10 @@ async def _extract_entity_attributes(
     entity_type: type[BaseModel] | None,
 ) -> dict[str, Any]:
     if entity_type is None or len(entity_type.model_fields) == 0:
-        return {}
+        # No applicable type means nothing to extract, not "extracted nothing": return the
+        # node's prior attributes so the caller's assignment leaves them untouched. Returning
+        # {} here would clear attributes a previous typed pass stored on a deduplicated node.
+        return dict(node.attributes or {})
 
     attributes_context = _build_episode_context(
         # should not include summary

--- a/tests/utils/maintenance/test_node_operations.py
+++ b/tests/utils/maintenance/test_node_operations.py
@@ -918,3 +918,71 @@ async def test_batch_summaries_calls_llm_for_long_summary():
     # LLM should have been called to condense the long summary
     llm_client.generate_response.assert_awaited_once()
     assert node.summary == 'Condensed summary'
+
+
+@pytest.mark.asyncio
+async def test_extract_attributes_preserves_prior_attributes_when_entity_types_none():
+    """Prior attributes survive when no entity types are supplied.
+
+    Mirrors the invariant `add_triplet` already enforces ("merge rather than replace",
+    see `test_add_triplet_empty_attributes_preserved`): an empty extraction result must
+    not clear attributes a previous typed pass stored on the node.
+    """
+    clients, _ = _make_clients()
+    clients.llm_client.generate_response = AsyncMock(return_value={'summaries': []})
+    clients.embedder.create = AsyncMock(return_value=[0.1, 0.2, 0.3])
+    clients.embedder.create_batch = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+    node = EntityNode(
+        name='Alice',
+        group_id='group',
+        labels=['Entity', 'Person'],
+        summary='Existing summary',
+        attributes={'age': 30, 'city': 'New York'},
+    )
+
+    results = await extract_attributes_from_nodes(
+        clients,
+        [node],
+        episode=_make_episode(),
+        previous_episodes=[],
+        entity_types=None,
+    )
+
+    assert results[0].attributes == {'age': 30, 'city': 'New York'}
+
+
+@pytest.mark.asyncio
+async def test_extract_attributes_preserves_prior_attributes_when_label_not_in_entity_types():
+    """Prior attributes survive when the node's label is absent from `entity_types`.
+
+    `entity_types.get(...)` resolves to None for any label not in the map, which takes the
+    same no-applicable-type path as `entity_types=None`.
+    """
+    from pydantic import BaseModel
+
+    class Organization(BaseModel):
+        industry: str | None = None
+
+    clients, _ = _make_clients()
+    clients.llm_client.generate_response = AsyncMock(return_value={'summaries': []})
+    clients.embedder.create = AsyncMock(return_value=[0.1, 0.2, 0.3])
+    clients.embedder.create_batch = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+    node = EntityNode(
+        name='Alice',
+        group_id='group',
+        labels=['Entity', 'Person'],
+        summary='Existing summary',
+        attributes={'age': 30, 'city': 'New York'},
+    )
+
+    results = await extract_attributes_from_nodes(
+        clients,
+        [node],
+        episode=_make_episode(),
+        previous_episodes=[],
+        entity_types={'Organization': Organization},
+    )
+
+    assert results[0].attributes == {'age': 30, 'city': 'New York'}


### PR DESCRIPTION
  ## Summary

  `extract_attributes_from_nodes` assigns `node.attributes = attributes` unconditionally
  (`node_operations.py:763-764`), and `_extract_entity_attributes` returned a bare `{}` whenever no
  entity type applied to the node (`:790-791`). For a node that deduplicates onto an existing stored
  node, that empty dict silently cleared attributes a previous typed pass had extracted.

  The one-line fix returns the node's prior attributes from that early return instead of `{}`.

  ## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Performance improvement
  - [ ] Documentation/Tests

  ## Objective

  Not a new feature — restoring an invariant the codebase already asserts in three places:

  1. The typed path deliberately preserves prior values via
     `apply_capped_attributes(..., merge_mode='overlay')` → `{**prior_attributes, **kept}`
     (`attribute_utils.py:245-246`). Only the no-applicable-type early return bypassed it.
  2. The comment at the call site already claims the invariant the code then broke:
     *"`_extract_entity_attributes` returns the already-merged attribute dict (overlay of prior +
     cap-kept fields), so direct assignment is the merge."* That held only on the typed path.
  3. `add_triplet` enforces the same rule explicitly (`graphiti.py:1676`):
     ```python
     # Update attributes dictionary (merge rather than replace)
     if source_node.attributes:
         resolved_source.attributes.update(source_node.attributes)
     ```
     covered by `test_add_triplet_empty_attributes_preserved` (`tests/test_add_triplet.py:433`) —
     *"Test that nodes with empty attributes don't overwrite existing attributes."*

  Returning prior attributes makes the call site's documented contract true on **both** paths, so no
  guard is needed there and the two behaviours converge.

  ## Root cause

  `_extract_entity_attributes` conflates "no applicable type, nothing to extract" with "extracted
  nothing":

  ```python
  if entity_type is None or len(entity_type.model_fields) == 0:
      return {}
  ```

  The loss reaches storage because the deduplicated node is the database node:

  - `_promote_resolved_node` returns the existing candidate (`dedup_helpers.py:177/181`), and
    `get_entity_node_from_record` populates `attributes` from the record (`nodes.py:1052-1054`).
  - `get_entity_node_save_query` replaces attributes wholesale — `SET n = $entity_data` for
    Neo4j/FalkorDB/Neptune, `n.attributes = $attributes` for Kuzu (`node_db_queries.py:137`).

  Two paths reach the early return:

  1. `entity_types=None` on a later episode, for a node whose attributes were written by an earlier
     call that *did* pass `entity_types`.
  2. `entity_types` supplied but missing the node's label — `entity_types.get(...)` then resolves to
     `None`. Note `next((item for item in node.labels if item != 'Entity'), '')` (`:752`) yields `''`
     for a node whose only label is `Entity`, so that lookup takes the same path.

  Provider-agnostic; not specific to any backend.

  ## Changes

  - `graphiti_core/utils/maintenance/node_operations.py`: `_extract_entity_attributes` returns

- `graphiti_core/utils/maintenance/node_operations.py`: `_extract_entity_attributes` returns
  `dict(node.attributes or {})` from the no-applicable-type early return, with a comment explaining
  why. `len(model_fields) == 0` gets the same preservation.
- `tests/utils/maintenance/test_node_operations.py`: two regression tests, one per path above.

The edge attribute path is intentionally `merge_mode='replace'` and is untouched. No call sites
needed to change — the fix lives entirely in the extraction helper.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

Both new tests fail against `main` with `assert {} == {'age': 30, 'city': 'New York'}` and pass with
the fix. Full unit suite as CI runs it (`DISABLE_NEO4J/FALKORDB/KUZU/NEPTUNE=1`,
`-m "not integration"`): **403 passed, 42 skipped**. `make lint` clean (ruff + pyright 0 errors).

The new tests reuse the existing `_make_clients()` helper, so they need no database and run in the
default unit-test job.

**A note that may be worth acting on separately:** the test that encodes this invariant,
`test_add_triplet_empty_attributes_preserved`, depends on the `graph_driver` fixture, which
parametrizes over `drivers` — and that list is empty when all four backends are disabled, as they are
in `unit_tests.yml`. So the test that would have caught this regression does not run in the job that
gates PRs. That may be why this slipped through. Happy to open a separate issue if useful.

## Breaking Changes
- [ ] This PR contains breaking changes

Behaviour change is strictly in the direction of not losing data. Any caller depending on attributes
being cleared when `entity_types` is omitted would be relying on the bug; the equivalent
already-documented behaviour on the `add_triplet` path is preservation.

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary — comment at the fix site; no user-facing docs affected
- [x] No secrets or sensitive information committed

## Related Issues

Closes #1763