### PR TITLE
fix(mcp): route FalkorDB UUID operations to tenant graphs

### DIFF
--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -17,6 +17,7 @@ from dotenv import load_dotenv
 from graphiti_core import Graphiti
 from graphiti_core.edges import EntityEdge
 from graphiti_core.nodes import EntityNode, EpisodeType, SagaNode
+from graphiti_core.search.search_config import SearchResults
 from graphiti_core.search.search_filters import SearchFilters
 from graphiti_core.utils.maintenance.graph_data_operations import clear_data
 from mcp.server.fastmcp import FastMCP
@@ -44,6 +45,15 @@ from services.factories import (
     LLMClientFactory,
 )
 from services.queue_service import QueueService
+from utils.falkor_routing import (
+    ENTITY_EDGE_UUID_QUERY,
+    EPISODE_UUID_QUERY,
+    EPISODE_UUIDS_QUERY,
+    client_bound_to,
+    driver_for_uuid,
+    drivers_for_uuids,
+    is_falkor,
+)
 from utils.formatting import format_fact_result, to_edge_result, to_node_result
 from utils.type_config import (
     build_edge_type_map,
@@ -659,10 +669,14 @@ async def delete_entity_edge(uuid: str) -> SuccessResponse | ErrorResponse:
     try:
         client = await graphiti_service.get_client()
 
-        # Get the entity edge by UUID
-        entity_edge = await EntityEdge.get_by_uuid(client.driver, uuid)
-        # Delete the edge using its delete method
-        await entity_edge.delete(client.driver)
+        driver = client.driver
+        if is_falkor(driver):
+            driver, group_id = await driver_for_uuid(driver, ENTITY_EDGE_UUID_QUERY, uuid)
+            if group_id is None:
+                return ErrorResponse(error=f'Entity edge with UUID {uuid} not found')
+
+        entity_edge = await EntityEdge.get_by_uuid(driver, uuid)
+        await entity_edge.delete(driver)
         return SuccessResponse(message=f'Entity edge with UUID {uuid} deleted successfully')
     except Exception as e:
         error_msg = str(e)
@@ -690,8 +704,17 @@ async def delete_episode(uuid: str) -> SuccessResponse | ErrorResponse:
         client = await graphiti_service.get_client()
 
         # remove_episode cascades cleanup of episode-created entities/edges,
-        # unlike EpisodicNode.delete which would orphan them.
-        await client.remove_episode(uuid)
+        # unlike EpisodicNode.delete which would orphan them. FalkorDB stores
+        # each group in a separate graph, so route the cascade to the graph
+        # containing this UUID without rebinding the shared client.
+        driver = client.driver
+        if is_falkor(driver):
+            driver, group_id = await driver_for_uuid(driver, EPISODE_UUID_QUERY, uuid)
+            if group_id is None:
+                return ErrorResponse(error=f'Episode with UUID {uuid} not found')
+            await type(client).remove_episode(client_bound_to(client, driver), uuid)
+        else:
+            await client.remove_episode(uuid)
         return SuccessResponse(message=f'Episode with UUID {uuid} deleted successfully')
     except Exception as e:
         error_msg = str(e)
@@ -714,11 +737,13 @@ async def get_entity_edge(uuid: str) -> dict[str, Any] | ErrorResponse:
     try:
         client = await graphiti_service.get_client()
 
-        # Get the entity edge directly using the EntityEdge class method
-        entity_edge = await EntityEdge.get_by_uuid(client.driver, uuid)
+        driver = client.driver
+        if is_falkor(driver):
+            driver, group_id = await driver_for_uuid(driver, ENTITY_EDGE_UUID_QUERY, uuid)
+            if group_id is None:
+                return ErrorResponse(error=f'Entity edge with UUID {uuid} not found')
 
-        # Use the format_fact_result function to serialize the edge
-        # Return the Python dict directly - MCP will handle serialization
+        entity_edge = await EntityEdge.get_by_uuid(driver, uuid)
         return format_fact_result(entity_edge)
     except Exception as e:
         error_msg = str(e)
@@ -999,8 +1024,20 @@ async def get_episode_entities(
 
     try:
         client = await graphiti_service.get_client()
-
-        results = await client.get_nodes_and_edges_by_episode(episode_uuids)
+        if is_falkor(client.driver):
+            # Episode UUIDs may span tenant graphs. Resolve and batch them with
+            # one probe per graph before invoking the existing provenance query.
+            buckets = await drivers_for_uuids(client.driver, EPISODE_UUIDS_QUERY, episode_uuids)
+            nodes, edges = [], []
+            for driver, uuids in buckets.values():
+                partial = await type(client).get_nodes_and_edges_by_episode(
+                    client_bound_to(client, driver), uuids
+                )
+                nodes.extend(partial.nodes)
+                edges.extend(partial.edges)
+            results = SearchResults(nodes=nodes, edges=edges)
+        else:
+            results = await client.get_nodes_and_edges_by_episode(episode_uuids)
 
         return EpisodeEntitiesResponse(
             message=f'Retrieved provenance for {len(episode_uuids)} episode(s)',

--- a/mcp_server/src/services/queue_service.py
+++ b/mcp_server/src/services/queue_service.py
@@ -20,6 +20,9 @@ class QueueService:
         self._queue_workers: dict[str, bool] = {}
         # Store the graphiti client after initialization
         self._graphiti_client: Any = None
+        # Graphiti.add_episode rebinds the shared client's driver to group_id.
+        # Per-group workers must not overlap that mutation across tenant graphs.
+        self._write_lock: asyncio.Lock | None = None
 
     async def add_episode_task(
         self, group_id: str, process_func: Callable[[], Awaitable[None]]
@@ -96,6 +99,7 @@ class QueueService:
             graphiti_client: The graphiti client instance to use for processing episodes
         """
         self._graphiti_client = graphiti_client
+        self._write_lock = asyncio.Lock()
         logger.info('Queue service initialized with graphiti client')
 
     async def add_episode(
@@ -154,25 +158,28 @@ class QueueService:
             try:
                 logger.info(f'Processing episode {uuid} for group {group_id}')
 
-                # Process the episode using the graphiti client
-                await self._graphiti_client.add_episode(
-                    name=name,
-                    episode_body=content,
-                    source_description=source_description,
-                    source=episode_type,
-                    group_id=group_id,
-                    reference_time=reference_time or datetime.now(timezone.utc),
-                    entity_types=entity_types,
-                    edge_types=edge_types,
-                    edge_type_map=edge_type_map,
-                    excluded_entity_types=excluded_entity_types,
-                    previous_episode_uuids=previous_episode_uuids,
-                    custom_extraction_instructions=custom_extraction_instructions,
-                    update_communities=update_communities,
-                    saga=saga,
-                    saga_previous_episode_uuid=saga_previous_episode_uuid,
-                    uuid=uuid,
-                )
+                # Serialize across all group workers. Graphiti.add_episode
+                # rebinds the shared driver's graph for the duration of a write.
+                assert self._write_lock is not None
+                async with self._write_lock:
+                    await self._graphiti_client.add_episode(
+                        name=name,
+                        episode_body=content,
+                        source_description=source_description,
+                        source=episode_type,
+                        group_id=group_id,
+                        reference_time=reference_time or datetime.now(timezone.utc),
+                        entity_types=entity_types,
+                        edge_types=edge_types,
+                        edge_type_map=edge_type_map,
+                        excluded_entity_types=excluded_entity_types,
+                        previous_episode_uuids=previous_episode_uuids,
+                        custom_extraction_instructions=custom_extraction_instructions,
+                        update_communities=update_communities,
+                        saga=saga,
+                        saga_previous_episode_uuid=saga_previous_episode_uuid,
+                        uuid=uuid,
+                    )
 
                 logger.info(f'Successfully processed episode {uuid} for group {group_id}')
 

--- a/mcp_server/src/utils/falkor_routing.py
+++ b/mcp_server/src/utils/falkor_routing.py
@@ -1,0 +1,79 @@
+"""Route MCP operations to the FalkorDB graph that owns their data."""
+
+from __future__ import annotations
+
+from copy import copy
+from typing import Any
+
+ENTITY_EDGE_UUID_QUERY = 'MATCH ()-[e:RELATES_TO {uuid: $uuid}]->() RETURN e.uuid AS uuid LIMIT 1'
+EPISODE_UUID_QUERY = 'MATCH (e:Episodic {uuid: $uuid}) RETURN e.uuid AS uuid LIMIT 1'
+EPISODE_UUIDS_QUERY = 'MATCH (e:Episodic) WHERE e.uuid IN $uuids RETURN e.uuid AS uuid'
+
+
+class AmbiguousUuidError(ValueError):
+    """Raised when one UUID exists in multiple tenant graphs."""
+
+
+def is_falkor(driver: Any) -> bool:
+    """Return whether a driver exposes FalkorDB's per-graph API."""
+    client = getattr(driver, 'client', None)
+    return hasattr(driver, 'clone') and hasattr(client, 'list_graphs')
+
+
+def driver_for_group(driver: Any, group_id: str) -> Any:
+    """Return a non-initializing driver view bound to one FalkorDB graph."""
+    if getattr(driver, '_database', None) == group_id:
+        return driver
+    scoped_driver = copy(driver)
+    scoped_driver._database = group_id
+    return scoped_driver
+
+
+async def driver_for_uuid(driver: Any, match_cypher: str, uuid: str) -> tuple[Any, str | None]:
+    """Find the sole FalkorDB graph containing a UUID."""
+    match: tuple[Any, str] | None = None
+    for group_id in await driver.client.list_graphs():
+        scoped_driver = driver_for_group(driver, group_id)
+        records, _, _ = await scoped_driver.execute_query(match_cypher, uuid=uuid, routing_='r')
+        if not records:
+            continue
+        if match is not None:
+            raise AmbiguousUuidError(
+                f'UUID {uuid} exists in multiple FalkorDB graphs: {match[1]}, {group_id}'
+            )
+        match = scoped_driver, group_id
+    return match if match is not None else (driver, None)
+
+
+async def drivers_for_uuids(
+    driver: Any, match_cypher: str, uuids: list[str]
+) -> dict[str, tuple[Any, list[str]]]:
+    """Resolve UUIDs to tenant graphs with one query per graph."""
+    requested_uuids = list(dict.fromkeys(uuids))
+    owners: dict[str, str] = {}
+    buckets: dict[str, tuple[Any, list[str]]] = {}
+
+    for group_id in await driver.client.list_graphs():
+        scoped_driver = driver_for_group(driver, group_id)
+        records, _, _ = await scoped_driver.execute_query(
+            match_cypher, uuids=requested_uuids, routing_='r'
+        )
+        matched_uuids = {record['uuid'] for record in records}
+        for uuid in requested_uuids:
+            if uuid not in matched_uuids:
+                continue
+            if uuid in owners:
+                raise AmbiguousUuidError(
+                    f'UUID {uuid} exists in multiple FalkorDB graphs: {owners[uuid]}, {group_id}'
+                )
+            owners[uuid] = group_id
+            buckets.setdefault(group_id, (scoped_driver, []))[1].append(uuid)
+
+    return buckets
+
+
+def client_bound_to(client: Any, driver: Any) -> Any:
+    """Return a shallow Graphiti client view bound to a scoped driver."""
+    scoped_client = copy(client)
+    scoped_client.driver = driver
+    return scoped_client

--- a/mcp_server/tests/test_falkor_routing.py
+++ b/mcp_server/tests/test_falkor_routing.py
@@ -1,0 +1,223 @@
+"""Regression tests for FalkorDB MCP graph routing."""
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from graphiti_core.search.search_config import SearchResults
+
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+import graphiti_mcp_server as server  # noqa: E402
+from services.queue_service import QueueService  # noqa: E402
+from utils.falkor_routing import (  # noqa: E402
+    ENTITY_EDGE_UUID_QUERY,
+    EPISODE_UUIDS_QUERY,
+    AmbiguousUuidError,
+    driver_for_uuid,
+    drivers_for_uuids,
+)
+
+
+class FakeFalkorClient:
+    def __init__(self, graph_uuids: dict[str, set[str]]):
+        self.graph_uuids = graph_uuids
+        self.queries: list[tuple[str, tuple[str, ...]]] = []
+        self.clone_calls = 0
+
+    async def list_graphs(self) -> list[str]:
+        return list(self.graph_uuids)
+
+
+class FakeFalkorDriver:
+    def __init__(
+        self,
+        graph_uuids: dict[str, set[str]],
+        database: str = 'default_db',
+        client: FakeFalkorClient | None = None,
+    ):
+        self._database = database
+        self.client = client or FakeFalkorClient(graph_uuids)
+
+    def clone(self, database: str) -> 'FakeFalkorDriver':
+        self.client.clone_calls += 1
+        return FakeFalkorDriver(self.client.graph_uuids, database, self.client)
+
+    async def execute_query(
+        self,
+        _query: str,
+        *,
+        uuid: str | None = None,
+        uuids: list[str] | None = None,
+        **_kwargs,
+    ):
+        requested = (uuid,) if uuid is not None else tuple(uuids or [])
+        self.client.queries.append((self._database, requested))
+        matches = self.client.graph_uuids[self._database].intersection(requested)
+        return [{'uuid': value} for value in matches], None, None
+
+
+class FakeGraphiti:
+    def __init__(self, driver: FakeFalkorDriver):
+        self.driver = driver
+        self.max_coroutines = 10
+        self.deleted_episodes: list[tuple[str, str]] = []
+        self.provenance_calls: list[tuple[str, tuple[str, ...]]] = []
+
+    async def remove_episode(self, uuid: str) -> None:
+        self.deleted_episodes.append((self.driver._database, uuid))
+
+    async def get_nodes_and_edges_by_episode(self, uuids: list[str]) -> SearchResults:
+        self.provenance_calls.append((self.driver._database, tuple(uuids)))
+        return SearchResults()
+
+
+class FakeGraphitiService:
+    def __init__(self, client: FakeGraphiti):
+        self.client = client
+
+    async def get_client(self) -> FakeGraphiti:
+        return self.client
+
+
+@pytest.mark.asyncio
+async def test_driver_for_uuid_finds_owning_graph_without_rebinding_shared_driver():
+    driver = FakeFalkorDriver({'default_db': set(), 'group-a': {'edge-1'}})
+
+    scoped, group_id = await driver_for_uuid(driver, ENTITY_EDGE_UUID_QUERY, 'edge-1')
+
+    assert group_id == 'group-a'
+    assert scoped._database == 'group-a'
+    assert driver._database == 'default_db'
+    assert driver.client.clone_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_driver_for_uuid_rejects_cross_graph_collision():
+    driver = FakeFalkorDriver({'group-a': {'duplicate'}, 'group-b': {'duplicate'}})
+
+    with pytest.raises(AmbiguousUuidError, match='group-a, group-b'):
+        await driver_for_uuid(driver, ENTITY_EDGE_UUID_QUERY, 'duplicate')
+
+    assert driver.client.clone_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_episode_routes_cascade_to_owning_graph(monkeypatch):
+    client = FakeGraphiti(FakeFalkorDriver({'default_db': set(), 'group-a': {'episode-1'}}))
+    monkeypatch.setattr(server, 'graphiti_service', FakeGraphitiService(client))
+
+    response = await server.delete_episode('episode-1')
+
+    assert response['message'] == 'Episode with UUID episode-1 deleted successfully'
+    assert client.deleted_episodes == [('group-a', 'episode-1')]
+    assert client.driver._database == 'default_db'
+
+
+@pytest.mark.asyncio
+async def test_get_and_delete_entity_edge_use_owning_graph(monkeypatch):
+    client = FakeGraphiti(FakeFalkorDriver({'default_db': set(), 'group-b': {'edge-1'}}))
+    monkeypatch.setattr(server, 'graphiti_service', FakeGraphitiService(client))
+
+    edge = SimpleNamespace(delete=AsyncMock())
+    get_by_uuid = AsyncMock(return_value=edge)
+    monkeypatch.setattr(server.EntityEdge, 'get_by_uuid', get_by_uuid)
+    monkeypatch.setattr(server, 'format_fact_result', lambda _edge: {'uuid': 'edge-1'})
+
+    assert await server.get_entity_edge('edge-1') == {'uuid': 'edge-1'}
+    response = await server.delete_entity_edge('edge-1')
+
+    assert response['message'] == 'Entity edge with UUID edge-1 deleted successfully'
+    assert [call.args[0]._database for call in get_by_uuid.await_args_list] == [
+        'group-b',
+        'group-b',
+    ]
+    assert [call.args[0]._database for call in edge.delete.await_args_list] == ['group-b']
+    assert client.driver._database == 'default_db'
+
+
+@pytest.mark.asyncio
+async def test_get_episode_entities_batches_uuids_by_owning_graph(monkeypatch):
+    client = FakeGraphiti(
+        FakeFalkorDriver(
+            {
+                'default_db': set(),
+                'group-a': {'episode-a'},
+                'group-b': {'episode-b'},
+            }
+        )
+    )
+    monkeypatch.setattr(server, 'graphiti_service', FakeGraphitiService(client))
+
+    response = await server.get_episode_entities(['episode-b', 'episode-a'])
+
+    assert response['nodes'] == []
+    assert response['edges'] == []
+    assert set(client.provenance_calls) == {
+        ('group-b', ('episode-b',)),
+        ('group-a', ('episode-a',)),
+    }
+    assert client.driver._database == 'default_db'
+    assert client.driver.client.queries == [
+        ('default_db', ('episode-b', 'episode-a')),
+        ('group-a', ('episode-b', 'episode-a')),
+        ('group-b', ('episode-b', 'episode-a')),
+    ]
+    assert client.driver.client.clone_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_drivers_for_uuids_rejects_cross_graph_collision():
+    driver = FakeFalkorDriver({'group-a': {'duplicate'}, 'group-b': {'duplicate'}})
+
+    with pytest.raises(AmbiguousUuidError, match='group-a, group-b'):
+        await drivers_for_uuids(driver, EPISODE_UUIDS_QUERY, ['duplicate'])
+
+
+@pytest.mark.asyncio
+async def test_queue_serializes_driver_rebinding_across_groups():
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+
+    class BlockingGraphiti:
+        def __init__(self):
+            self.active = 0
+            self.max_active = 0
+            self.groups: list[str] = []
+
+        async def add_episode(self, **kwargs) -> None:
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+            self.groups.append(kwargs['group_id'])
+            if len(self.groups) == 1:
+                first_entered.set()
+                await release_first.wait()
+            self.active -= 1
+
+    client = BlockingGraphiti()
+    service = QueueService()
+    await service.initialize(client)
+    common = {
+        'name': 'episode',
+        'content': 'body',
+        'source_description': 'test',
+        'episode_type': 'text',
+        'entity_types': None,
+        'uuid': None,
+    }
+
+    await service.add_episode(group_id='group-a', **common)
+    await service.add_episode(group_id='group-b', **common)
+    await asyncio.wait_for(first_entered.wait(), timeout=1)
+    await asyncio.sleep(0)
+
+    assert client.max_active == 1
+    release_first.set()
+    await asyncio.wait_for(service._episode_queues['group-a'].join(), timeout=1)
+    await asyncio.wait_for(service._episode_queues['group-b'].join(), timeout=1)
+
+    assert client.groups == ['group-a', 'group-b']
+    assert client.max_active == 1


### PR DESCRIPTION
## Summary

- Resolve UUID-keyed MCP reads and deletes against the FalkorDB graph that owns the requested data.
- Reject UUIDs found in multiple tenant graphs rather than reading or deleting an arbitrary match.
- Batch provenance resolution with one probe per graph and avoid `FalkorDriver.clone()` index-build side effects during reads.
- Serialize queued cross-group writes because `Graphiti.add_episode()` mutates the shared driver binding.

## Problem

FalkorDB stores each `group_id` as a physical graph. The remaining UUID-keyed MCP handlers bypass group-aware routing and query whichever graph the shared driver currently targets. Concurrent per-group queue workers can also race while `Graphiti.add_episode()` rebinds that shared driver. Both cases can report missing data or operate on the wrong tenant graph.

`get_episodes` is intentionally not changed here because current `main` already routes `EpisodicNode.get_by_group_ids` through the merged FalkorDB operations fix.

Fixes #1651.

## Verification

- `python -m pytest -q tests/test_falkor_routing.py tests/test_core_parity.py` - 34 passed.
- `python -m ruff format --check ...` and `python -m ruff check ...` - clean.
- `python -m pyright --pythonpath <venv-python> src/utils/falkor_routing.py src/graphiti_mcp_server.py src/services/queue_service.py` - 0 errors.
- Mutation checks fail when UUID matching, duplicate detection, non-initializing driver scoping, or cross-group write serialization is removed.
- Live FalkorDB reproduction confirmed cross-graph edge lookup, cross-graph episode deletion, and distinct-group concurrent writes on the patched MCP service.