### PR TITLE
fix(attributes): surface cap-dropped attribute fields from add_episode

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -20,7 +20,7 @@ from time import time
 from uuid import uuid4
 
 from dotenv import load_dotenv
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing_extensions import LiteralString
 
 from graphiti_core.cross_encoder.client import CrossEncoderClient
@@ -118,6 +118,7 @@ class AddEpisodeResults(BaseModel):
     edges: list[EntityEdge]
     communities: list[CommunityNode]
     community_edges: list[CommunityEdge]
+    dropped_attributes: dict[str, list[str]] = Field(default_factory=dict)
 
 
 class AddBulkEpisodeResults(BaseModel):
@@ -127,6 +128,7 @@ class AddBulkEpisodeResults(BaseModel):
     edges: list[EntityEdge]
     communities: list[CommunityNode]
     community_edges: list[CommunityEdge]
+    dropped_attributes: dict[str, list[str]] = Field(default_factory=dict)
 
 
 class AddTripletResults(BaseModel):
@@ -639,16 +641,17 @@ class Graphiti:
         nodes: list[EntityNode],
         uuid_map: dict[str, str],
         custom_extraction_instructions: str | None = None,
-    ) -> tuple[list[EntityEdge], list[EntityEdge], list[EntityEdge]]:
+    ) -> tuple[list[EntityEdge], list[EntityEdge], list[EntityEdge], dict[str, set[str]]]:
         """Extract edges from episode(s) and resolve against existing graph.
 
         Returns
         -------
-        tuple[list[EntityEdge], list[EntityEdge], list[EntityEdge]]
-            A tuple of (resolved_edges, invalidated_edges, new_edges) where:
+        tuple[list[EntityEdge], list[EntityEdge], list[EntityEdge], dict[str, set[str]]]
+            A tuple of (resolved_edges, invalidated_edges, new_edges, dropped_by_uuid) where:
             - resolved_edges: All edges after resolution
             - invalidated_edges: Edges invalidated by new information
             - new_edges: Only edges that are new to the graph (not duplicates)
+            - dropped_by_uuid: Mapping of edge uuid -> cap-dropped attribute fields
         """
         episodes = episode if isinstance(episode, list) else [episode]
         primary_episode = episodes[0]
@@ -666,7 +669,12 @@ class Graphiti:
 
         edges = resolve_edge_pointers(extracted_edges, uuid_map)
 
-        resolved_edges, invalidated_edges, new_edges = await resolve_extracted_edges(
+        (
+            resolved_edges,
+            invalidated_edges,
+            new_edges,
+            dropped_by_uuid,
+        ) = await resolve_extracted_edges(
             self.clients,
             edges,
             primary_episode,
@@ -675,7 +683,7 @@ class Graphiti:
             edge_type_map,
         )
 
-        return resolved_edges, invalidated_edges, new_edges
+        return resolved_edges, invalidated_edges, new_edges, dropped_by_uuid
 
     async def _process_episode_data(
         self,
@@ -821,7 +829,9 @@ class Graphiti:
         edge_types: dict[str, type[BaseModel]] | None,
         edge_type_map: dict[tuple[str, str], list[str]],
         episodes: list[EpisodicNode],
-    ) -> tuple[list[EntityNode], list[EntityEdge], list[EntityEdge], dict[str, str]]:
+    ) -> tuple[
+        list[EntityNode], list[EntityEdge], list[EntityEdge], dict[str, str], dict[str, set[str]]
+    ]:
         """Resolve nodes and edges against the existing graph."""
         nodes_by_uuid: dict[str, EntityNode] = {
             node.uuid: node for nodes in nodes_by_episode.values() for node in nodes
@@ -872,7 +882,9 @@ class Graphiti:
             nodes_by_episode_unique[episode_uuid] = updated_nodes
 
         # Extract attributes for resolved nodes
-        hydrated_nodes_results: list[list[EntityNode]] = await semaphore_gather(
+        hydrated_nodes_results: list[
+            tuple[list[EntityNode], dict[str, set[str]]]
+        ] = await semaphore_gather(
             *[
                 extract_attributes_from_nodes(
                     self.clients,
@@ -885,7 +897,10 @@ class Graphiti:
             ]
         )
 
-        final_hydrated_nodes = [node for nodes in hydrated_nodes_results for node in nodes]
+        final_hydrated_nodes = [node for result in hydrated_nodes_results for node in result[0]]
+        dropped_by_uuid: dict[str, set[str]] = {}
+        for result in hydrated_nodes_results:
+            dropped_by_uuid.update(result[1])
 
         # Resolve edges with updated pointers
         edges_by_episode_unique: dict[str, list[EntityEdge]] = {}
@@ -920,8 +935,9 @@ class Graphiti:
             invalidated_edges.extend(result[1])
             # result[2] is new_edges - not used in bulk flow since attributes
             # are extracted before edge resolution
+            dropped_by_uuid.update(result[3])
 
-        return final_hydrated_nodes, resolved_edges, invalidated_edges, uuid_map
+        return final_hydrated_nodes, resolved_edges, invalidated_edges, uuid_map, dropped_by_uuid
 
     @handle_multiple_group_ids
     async def retrieve_episodes(
@@ -1141,6 +1157,7 @@ class Graphiti:
                     resolved_edges,
                     invalidated_edges,
                     new_edges,
+                    edge_dropped_by_uuid,
                 ) = await self._extract_and_resolve_edges(
                     episode,
                     extracted_nodes,
@@ -1157,7 +1174,7 @@ class Graphiti:
 
                 # Extract node attributes - only pass new edges for summary generation
                 # to avoid duplicating facts that already exist in the graph
-                hydrated_nodes = await extract_attributes_from_nodes(
+                hydrated_nodes, node_dropped_by_uuid = await extract_attributes_from_nodes(
                     self.clients,
                     nodes,
                     episode,
@@ -1213,6 +1230,14 @@ class Graphiti:
 
                 logger.info(f'Completed add_episode in {(end - start) * 1000} ms')
 
+                dropped_attributes = {
+                    uuid: sorted(fields)
+                    for uuid, fields in {
+                        **node_dropped_by_uuid,
+                        **edge_dropped_by_uuid,
+                    }.items()
+                }
+
                 return AddEpisodeResults(
                     episode=episode,
                     episodic_edges=episodic_edges,
@@ -1220,6 +1245,7 @@ class Graphiti:
                     edges=entity_edges,
                     communities=communities,
                     community_edges=community_edges,
+                    dropped_attributes=dropped_attributes,
                 )
 
             except Exception as e:
@@ -1384,6 +1410,7 @@ class Graphiti:
                     resolved_edges,
                     invalidated_edges,
                     final_uuid_map,
+                    dropped_by_uuid,
                 ) = await self._resolve_nodes_and_edges_bulk(
                     nodes_by_episode,
                     edges_by_episode,
@@ -1472,6 +1499,10 @@ class Graphiti:
 
                 logger.info(f'Completed add_episode_bulk in {(end - start) * 1000} ms')
 
+                dropped_attributes = {
+                    uuid: sorted(fields) for uuid, fields in dropped_by_uuid.items()
+                }
+
                 return AddBulkEpisodeResults(
                     episodes=episodes,
                     episodic_edges=resolved_episodic_edges,
@@ -1479,6 +1510,7 @@ class Graphiti:
                     edges=resolved_edges + invalidated_edges,
                     communities=[],
                     community_edges=[],
+                    dropped_attributes=dropped_attributes,
                 )
 
             except Exception as e:
@@ -1737,7 +1769,7 @@ class Graphiti:
             )
         ).edges
 
-        resolved_edge, invalidated_edges, _ = await resolve_extracted_edge(
+        resolved_edge, invalidated_edges, _, _ = await resolve_extracted_edge(
             self.llm_client,
             edge,
             related_edges,

--- a/graphiti_core/utils/bulk_utils.py
+++ b/graphiti_core/utils/bulk_utils.py
@@ -541,7 +541,7 @@ async def dedupe_edges_bulk(
             dedupe_tuples.append((episode_tuples[i][0], edge, candidates))
 
     bulk_edge_resolutions: list[
-        tuple[EntityEdge, EntityEdge, list[EntityEdge]]
+        tuple[EntityEdge, EntityEdge, list[EntityEdge], set[str]]
     ] = await semaphore_gather(
         *[
             resolve_extracted_edge(
@@ -558,7 +558,7 @@ async def dedupe_edges_bulk(
 
     # For now we won't track edge invalidation
     duplicate_pairs: list[tuple[str, str]] = []
-    for i, (_, _, duplicates) in enumerate(bulk_edge_resolutions):
+    for i, (_, _, duplicates, _) in enumerate(bulk_edge_resolutions):
         episode, edge, candidates = dedupe_tuples[i]
         for duplicate in duplicates:
             duplicate_pairs.append((edge.uuid, duplicate.uuid))

--- a/graphiti_core/utils/maintenance/edge_operations.py
+++ b/graphiti_core/utils/maintenance/edge_operations.py
@@ -330,16 +330,18 @@ async def resolve_extracted_edges(
     edge_types: dict[str, type[BaseModel]],
     edge_type_map: dict[tuple[str, str], list[str]],
     existing_edges_override: list[EntityEdge] | None = None,
-) -> tuple[list[EntityEdge], list[EntityEdge], list[EntityEdge]]:
+) -> tuple[list[EntityEdge], list[EntityEdge], list[EntityEdge], dict[str, set[str]]]:
     """Resolve extracted edges against existing graph context.
 
     Returns
     -------
-    tuple[list[EntityEdge], list[EntityEdge], list[EntityEdge]]
-        A tuple of (resolved_edges, invalidated_edges, new_edges) where:
+    tuple[list[EntityEdge], list[EntityEdge], list[EntityEdge], dict[str, set[str]]]
+        A tuple of (resolved_edges, invalidated_edges, new_edges, dropped_by_uuid) where:
         - resolved_edges: All edges after resolution (may include existing edges if duplicates found)
         - invalidated_edges: Edges that were invalidated/contradicted by new information
         - new_edges: Only edges that are new to the graph (not duplicates of existing edges)
+        - dropped_by_uuid: Mapping of ``edge.uuid -> dropped field names`` for
+          attributes removed by ``apply_capped_attributes`` during the merge.
     """
     # Fast path: deduplicate exact matches within the extracted edges before parallel processing
     seen: dict[tuple[str, str, str], EntityEdge] = {}
@@ -486,7 +488,7 @@ async def resolve_extracted_edges(
         edge_types_lst.append(extracted_edge_types)
 
     # resolve edges with related edges in the graph and find invalidation candidates
-    results: list[tuple[EntityEdge, list[EntityEdge], list[EntityEdge]]] = list(
+    results: list[tuple[EntityEdge, list[EntityEdge], list[EntityEdge], set[str]]] = list(
         await semaphore_gather(
             *[
                 resolve_extracted_edge(
@@ -511,10 +513,14 @@ async def resolve_extracted_edges(
     resolved_edges: list[EntityEdge] = []
     invalidated_edges: list[EntityEdge] = []
     new_edges: list[EntityEdge] = []
+    dropped_by_uuid: dict[str, set[str]] = {}
     for extracted_edge, result in zip(extracted_edges, results, strict=True):
         resolved_edge = result[0]
         invalidated_edge_chunk = result[1]
         # result[2] is duplicate_edges list
+        dropped = result[3]
+        if dropped:
+            dropped_by_uuid[resolved_edge.uuid] = dropped
 
         resolved_edges.append(resolved_edge)
         invalidated_edges.extend(invalidated_edge_chunk)
@@ -532,7 +538,7 @@ async def resolve_extracted_edges(
         create_entity_edge_embeddings(embedder, invalidated_edges),
     )
 
-    return resolved_edges, invalidated_edges, new_edges
+    return resolved_edges, invalidated_edges, new_edges, dropped_by_uuid
 
 
 def resolve_edge_contradictions(
@@ -627,7 +633,7 @@ async def resolve_extracted_edge(
     existing_edges: list[EntityEdge],
     episode: EpisodicNode,
     edge_type_candidates: dict[str, type[BaseModel]] | None = None,
-) -> tuple[EntityEdge, list[EntityEdge], list[EntityEdge]]:
+) -> tuple[EntityEdge, list[EntityEdge], list[EntityEdge], set[str]]:
     """Resolve an extracted edge against existing graph context.
 
     Parameters
@@ -647,12 +653,15 @@ async def resolve_extracted_edge(
 
     Returns
     -------
-    tuple[EntityEdge, list[EntityEdge], list[EntityEdge]]
-        The resolved edge, any duplicates, and edges to invalidate.
+    tuple[EntityEdge, list[EntityEdge], list[EntityEdge], set[str]]
+        The resolved edge, any duplicates, edges to invalidate, and the set of
+        attribute field names dropped by ``apply_capped_attributes`` during the
+        merge (empty when no attributes were cap-dropped).
     """
     if len(related_edges) == 0 and len(existing_edges) == 0:
         # Still extract custom attributes and timestamps even when no dedup needed
         edge_model = edge_type_candidates.get(extracted_edge.name) if edge_type_candidates else None
+        dropped: set[str] = set()
         if edge_model is not None and len(edge_model.model_fields) != 0:
             edge_attributes_context = {
                 'fact': extracted_edge.fact,
@@ -666,7 +675,7 @@ async def resolve_extracted_edge(
                 prompt_name='extract_edges.extract_attributes',
                 attribute_extraction=True,
             )
-            merged, _ = apply_capped_attributes(
+            merged, dropped = apply_capped_attributes(
                 edge_attributes_response,
                 edge_model,
                 extracted_edge.attributes,
@@ -679,7 +688,7 @@ async def resolve_extracted_edge(
 
         await _extract_edge_timestamps(llm_client, extracted_edge, episode)
 
-        return extracted_edge, [], []
+        return extracted_edge, [], [], dropped
 
     # Fast path: if the fact text and endpoints already exist verbatim, reuse the matching edge.
     normalized_fact = _normalize_string_exact(extracted_edge.fact)
@@ -692,7 +701,7 @@ async def resolve_extracted_edge(
             resolved = edge
             if episode is not None and episode.uuid not in resolved.episodes:
                 resolved.episodes.append(episode.uuid)
-            return resolved, [], []
+            return resolved, [], [], set()
 
     start = time()
 
@@ -778,6 +787,7 @@ async def resolve_extracted_edge(
     # Only extract structured attributes if the edge's relation_type matches an allowed custom type
     # AND the edge model exists for this node pair signature
     edge_model = edge_type_candidates.get(resolved_edge.name) if edge_type_candidates else None
+    dropped: set[str] = set()
     if edge_model is not None and len(edge_model.model_fields) != 0:
         edge_attributes_context = {
             'fact': resolved_edge.fact,
@@ -793,7 +803,7 @@ async def resolve_extracted_edge(
             attribute_extraction=True,
         )
 
-        merged, _ = apply_capped_attributes(
+        merged, dropped = apply_capped_attributes(
             edge_attributes_response,
             edge_model,
             resolved_edge.attributes,
@@ -844,7 +854,7 @@ async def resolve_extracted_edge(
     )
     duplicate_edges: list[EntityEdge] = [related_edges[idx] for idx in duplicate_fact_ids]
 
-    return resolved_edge, invalidated_edges, duplicate_edges
+    return resolved_edge, invalidated_edges, duplicate_edges, dropped
 
 
 async def filter_existing_duplicate_of_edges(

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -733,7 +733,17 @@ async def extract_attributes_from_nodes(
     edges: list[EntityEdge] | None = None,
     skip_fact_appending: bool = False,
     include_type_descriptions: bool = False,
-) -> list[EntityNode]:
+) -> tuple[list[EntityNode], dict[str, set[str]]]:
+    """Extract and merge attributes for a set of nodes.
+
+    Returns
+    -------
+    tuple[list[EntityNode], dict[str, set[str]]]
+        The hydrated nodes and a mapping of ``node.uuid -> dropped field names``
+        for attributes removed by ``apply_capped_attributes`` during the overlay
+        merge (so callers can distinguish "LLM never proposed it" from
+        "proposed but dropped for exceeding the length cap").
+    """
     llm_client = clients.llm_client
     embedder = clients.embedder
 
@@ -741,7 +751,7 @@ async def extract_attributes_from_nodes(
     edges_by_node = _build_edges_by_node(edges)
 
     # Extract attributes in parallel (per-entity calls)
-    attribute_results: list[dict[str, Any]] = await semaphore_gather(
+    attribute_results: list[tuple[dict[str, Any], set[str]]] = await semaphore_gather(
         *[
             _extract_entity_attributes(
                 llm_client,
@@ -759,9 +769,12 @@ async def extract_attributes_from_nodes(
     )
 
     # _extract_entity_attributes returns the already-merged attribute dict
-    # (overlay of prior + cap-kept fields), so direct assignment is the merge.
-    for node, attributes in zip(nodes, attribute_results, strict=True):
+    # (overlay of prior + cap-kept fields) plus the set of cap-dropped fields.
+    dropped_by_uuid: dict[str, set[str]] = {}
+    for node, (attributes, dropped) in zip(nodes, attribute_results, strict=True):
         node.attributes = attributes
+        if dropped:
+            dropped_by_uuid[node.uuid] = dropped
 
     # Extract summaries in batch
     await _extract_entity_summaries_batch(
@@ -777,7 +790,7 @@ async def extract_attributes_from_nodes(
 
     await create_entity_node_embeddings(embedder, nodes)
 
-    return nodes
+    return nodes, dropped_by_uuid
 
 
 async def _extract_entity_attributes(
@@ -786,9 +799,9 @@ async def _extract_entity_attributes(
     episode: EpisodicNode | list[EpisodicNode] | None,
     previous_episodes: list[EpisodicNode] | None,
     entity_type: type[BaseModel] | None,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], set[str]]:
     if entity_type is None or len(entity_type.model_fields) == 0:
-        return {}
+        return {}, set()
 
     attributes_context = _build_episode_context(
         # should not include summary
@@ -812,7 +825,7 @@ async def _extract_entity_attributes(
 
     # Overlay merge: cap-dropped or LLM-omitted fields keep prior values.
     # See attribute_utils for the merge_mode contract; the edge path uses 'replace'.
-    merged, _ = apply_capped_attributes(
+    merged, dropped = apply_capped_attributes(
         llm_response,
         entity_type,
         node.attributes,
@@ -827,7 +840,7 @@ async def _extract_entity_attributes(
     # values that the merge above just preserved.
     entity_type(**merged)
 
-    return merged
+    return merged, dropped
 
 
 async def _extract_entity_summaries_batch(

--- a/tests/test_add_triplet.py
+++ b/tests/test_add_triplet.py
@@ -127,7 +127,7 @@ async def test_add_triplet_merges_attributes(
         patch('graphiti_core.graphiti.resolve_extracted_edge') as mock_resolve_edge,
     ):
         mock_search.return_value = Mock(edges=[])
-        mock_resolve_edge.return_value = (edge, [], [])
+        mock_resolve_edge.return_value = (edge, [], [], set())
 
         await graphiti.add_triplet(user_source, edge, user_target)
 
@@ -203,7 +203,7 @@ async def test_add_triplet_updates_summary(
         patch('graphiti_core.graphiti.resolve_extracted_edge') as mock_resolve_edge,
     ):
         mock_search.return_value = Mock(edges=[])
-        mock_resolve_edge.return_value = (edge, [], [])
+        mock_resolve_edge.return_value = (edge, [], [], set())
 
         await graphiti.add_triplet(user_source, edge, user_target)
 
@@ -274,7 +274,7 @@ async def test_add_triplet_updates_labels(
         patch('graphiti_core.graphiti.resolve_extracted_edge') as mock_resolve_edge,
     ):
         mock_search.return_value = Mock(edges=[])
-        mock_resolve_edge.return_value = (edge, [], [])
+        mock_resolve_edge.return_value = (edge, [], [], set())
 
         await graphiti.add_triplet(user_source, edge, user_target)
 
@@ -331,7 +331,7 @@ async def test_add_triplet_with_new_nodes_no_uuid(
     with patch('graphiti_core.graphiti.search') as mock_search:
         mock_search.return_value = Mock(edges=[])
         with patch('graphiti_core.graphiti.resolve_extracted_edge') as mock_resolve_edge:
-            mock_resolve_edge.return_value = (edge, [], [])
+            mock_resolve_edge.return_value = (edge, [], [], set())
 
             result = await graphiti.add_triplet(user_source, edge, user_target)
 
@@ -416,7 +416,7 @@ async def test_add_triplet_preserves_existing_attributes(
         patch('graphiti_core.graphiti.resolve_extracted_edge') as mock_resolve_edge,
     ):
         mock_search.return_value = Mock(edges=[])
-        mock_resolve_edge.return_value = (edge, [], [])
+        mock_resolve_edge.return_value = (edge, [], [], set())
 
         await graphiti.add_triplet(user_source, edge, user_target)
 
@@ -491,7 +491,7 @@ async def test_add_triplet_empty_attributes_preserved(
         patch('graphiti_core.graphiti.resolve_extracted_edge') as mock_resolve_edge,
     ):
         mock_search.return_value = Mock(edges=[])
-        mock_resolve_edge.return_value = (edge, [], [])
+        mock_resolve_edge.return_value = (edge, [], [], set())
 
         await graphiti.add_triplet(user_source, edge, user_target)
 
@@ -759,7 +759,7 @@ async def test_add_triplet_edge_uuid_with_different_nodes_creates_new_edge(
     ):
         mock_search.return_value = Mock(edges=[])
         # Return the edge as-is (simulating no deduplication)
-        mock_resolve_edge.return_value = (new_edge_with_same_uuid, [], [])
+        mock_resolve_edge.return_value = (new_edge_with_same_uuid, [], [], set())
 
         result = await graphiti.add_triplet(alice, new_edge_with_same_uuid, charlie)
 
@@ -843,7 +843,7 @@ async def test_add_triplet_edge_uuid_with_same_nodes_updates_edge(
         patch('graphiti_core.graphiti.resolve_extracted_edge') as mock_resolve_edge,
     ):
         mock_search.return_value = Mock(edges=[])
-        mock_resolve_edge.return_value = (updated_edge, [], [])
+        mock_resolve_edge.return_value = (updated_edge, [], [], set())
 
         result = await graphiti.add_triplet(alice, updated_edge, bob)
 

--- a/tests/utils/maintenance/test_bulk_utils.py
+++ b/tests/utils/maintenance/test_bulk_utils.py
@@ -273,9 +273,9 @@ async def test_dedupe_edges_bulk_deduplicates_within_episode(monkeypatch):
                 and related.fact.strip().lower() == extracted_edge.fact.strip().lower()
             ):
                 # Return the related edge and mark extracted_edge as duplicate
-                return related, [], [related]
+                return related, [], [related], set()
         # Otherwise return the extracted edge as-is
-        return extracted_edge, [], []
+        return extracted_edge, [], [], set()
 
     monkeypatch.setattr(bulk_utils, 'resolve_extracted_edge', mock_resolve_extracted_edge)
 

--- a/tests/utils/maintenance/test_edge_operations.py
+++ b/tests/utils/maintenance/test_edge_operations.py
@@ -136,7 +136,7 @@ async def test_resolve_extracted_edge_exact_fact_short_circuit(
         )
     ]
 
-    resolved_edge, duplicate_edges, invalidated = await resolve_extracted_edge(
+    resolved_edge, duplicate_edges, invalidated, dropped = await resolve_extracted_edge(
         mock_llm_client,
         extracted,
         related_edges,
@@ -144,6 +144,8 @@ async def test_resolve_extracted_edge_exact_fact_short_circuit(
         mock_current_episode,
         edge_type_candidates=None,
     )
+
+    assert dropped == set()
 
     assert resolved_edge is related_edges[0]
     assert resolved_edge.episodes.count(mock_current_episode.uuid) == 1
@@ -154,6 +156,60 @@ async def test_resolve_extracted_edge_exact_fact_short_circuit(
 
 class OccurredAtEdge(BaseModel):
     """Edge model stub for OCCURRED_AT."""
+
+
+@pytest.mark.asyncio
+async def test_resolve_extracted_edge_surfaces_dropped_attributes(monkeypatch):
+    """Attribute fields dropped by the length cap must be returned in the dropped set."""
+    from pydantic import Field
+
+    from graphiti_core.utils.maintenance import edge_operations as edge_ops
+
+    monkeypatch.setattr(edge_ops, '_extract_edge_timestamps', AsyncMock(return_value=None))
+
+    class _ReviewEdge(BaseModel):
+        review: str | None = Field(default=None, max_length=2000, description='Review text')
+
+    extracted = EntityEdge(
+        source_node_uuid='source_uuid',
+        target_node_uuid='target_uuid',
+        name='REVIEWED',
+        group_id='group_1',
+        fact='User reviewed product',
+        episodes=[],
+        created_at=datetime.now(timezone.utc),
+        valid_at=None,
+        invalid_at=None,
+    )
+
+    episode = EpisodicNode(
+        uuid='episode_uuid',
+        name='Episode',
+        group_id='group_1',
+        source='message',
+        source_description='desc',
+        content='Episode content',
+        valid_at=datetime.now(timezone.utc),
+    )
+
+    llm_client = MagicMock()
+    llm_client.generate_response = AsyncMock(return_value={'review': 'x' * 5000})
+
+    resolved_edge, invalidated, duplicates, dropped = await resolve_extracted_edge(
+        llm_client,
+        extracted,
+        [],
+        [],
+        episode,
+        edge_type_candidates={'REVIEWED': _ReviewEdge},
+    )
+
+    assert resolved_edge is extracted
+    assert invalidated == []
+    assert duplicates == []
+    assert dropped == {'review'}
+    # replace merge mode: cap-dropped field falls back to the prior value (absent here)
+    assert 'review' not in resolved_edge.attributes
 
 
 @pytest.mark.asyncio
@@ -222,7 +278,7 @@ async def test_resolve_extracted_edges_keeps_unknown_names(monkeypatch):
     edge_types = {'OCCURRED_AT': OccurredAtEdge}
     edge_type_map = {('Event', 'Entity'): ['OCCURRED_AT']}
 
-    resolved_edges, invalidated_edges, new_edges = await resolve_extracted_edges(
+    resolved_edges, invalidated_edges, new_edges, dropped_by_uuid = await resolve_extracted_edges(
         clients,
         [extracted_edge],
         episode,
@@ -230,6 +286,8 @@ async def test_resolve_extracted_edges_keeps_unknown_names(monkeypatch):
         edge_types,
         edge_type_map,
     )
+
+    assert dropped_by_uuid == {}
 
     assert resolved_edges[0].name == 'INTERACTED_WITH'
     assert invalidated_edges == []
@@ -306,7 +364,7 @@ async def test_resolve_extracted_edge_uses_integer_indices_for_duplicates(mock_l
 
     related_edges = [related_edge_0, related_edge_1, related_edge_2]
 
-    resolved_edge, invalidated, duplicates = await resolve_extracted_edge(
+    resolved_edge, invalidated, duplicates, _ = await resolve_extracted_edge(
         mock_llm_client,
         extracted_edge,
         related_edges,
@@ -352,7 +410,7 @@ async def test_resolve_extracted_edges_fast_path_deduplication(monkeypatch):
     ):
         nonlocal resolve_call_count
         resolve_call_count += 1
-        return extracted_edge, [], []
+        return extracted_edge, [], [], set()
 
     # Mock semaphore_gather to execute awaitable immediately
     async def immediate_gather(*aws, max_coroutines=None):
@@ -433,7 +491,7 @@ async def test_resolve_extracted_edges_fast_path_deduplication(monkeypatch):
         valid_at=datetime.now(timezone.utc),
     )
 
-    resolved_edges, invalidated_edges, new_edges = await resolve_extracted_edges(
+    resolved_edges, invalidated_edges, new_edges, _ = await resolve_extracted_edges(
         clients,
         [edge1, edge2, edge3],
         episode,
@@ -755,7 +813,7 @@ async def test_resolve_extracted_edge_overcap_attribute_preserves_prior(monkeypa
         valid_at=datetime.now(timezone.utc),
     )
 
-    resolved, dupes, invalidated = await resolve_extracted_edge(
+    resolved, dupes, invalidated, _ = await resolve_extracted_edge(
         llm_client,
         extracted_edge,
         related_edges=[],

--- a/tests/utils/maintenance/test_node_operations.py
+++ b/tests/utils/maintenance/test_node_operations.py
@@ -856,7 +856,7 @@ async def test_extract_attributes_from_nodes_with_callback():
         call_tracker.append(n.name)
         return 'User' not in n.labels
 
-    results = await extract_attributes_from_nodes(
+    results, dropped_by_uuid = await extract_attributes_from_nodes(
         clients,
         [node1, node2],
         episode=episode,
@@ -876,6 +876,53 @@ async def test_extract_attributes_from_nodes_with_callback():
 
     assert node1_result.summary == 'Old1'
     assert node2_result.summary == 'Old2'
+
+    # No attribute extraction was requested (entity_types=None), so nothing dropped
+    assert dropped_by_uuid == {}
+
+
+@pytest.mark.asyncio
+async def test_extract_attributes_from_nodes_surfaces_dropped_fields():
+    """Attribute fields dropped by the length cap must be surfaced per node uuid."""
+    from pydantic import BaseModel, Field
+
+    class _User(BaseModel):
+        name: str | None = None
+        bio: str | None = Field(default=None, max_length=2000, description='Long bio')
+
+    clients, llm_generate = _make_clients()
+
+    # First call (attribute extraction) returns an over-cap bio; the second
+    # call (batch summary) returns a condensed summary. The bio field's
+    # explicit max_length=2000 is the effective cap.
+    llm_generate.side_effect = [
+        {'bio': 'x' * 5000, 'name': 'Ada'},
+        {'summaries': []},
+    ]
+    clients.embedder.create = AsyncMock(return_value=[0.1, 0.2, 0.3])
+    clients.embedder.create_batch = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+    node = EntityNode(
+        name='Ada',
+        group_id='group',
+        labels=['Entity', 'User'],
+        attributes={'name': 'Ada', 'bio': 'Original bio'},
+    )
+    episode = _make_episode()
+
+    results, dropped_by_uuid = await extract_attributes_from_nodes(
+        clients,
+        [node],
+        episode=episode,
+        previous_episodes=[],
+        entity_types={'User': _User},
+    )
+
+    assert len(results) == 1
+    # Overlay merge keeps the prior value for the cap-dropped field.
+    assert results[0].attributes['bio'] == 'Original bio'
+    assert results[0].attributes['name'] == 'Ada'
+    assert dropped_by_uuid == {node.uuid: {'bio'}}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1757

## What

`apply_capped_attributes()` already computes and returns the `dropped` set of field names removed for exceeding the length cap — but every call site discarded it with `merged, _ = ...`, so an `INFO` log line was the only observable signal that an attribute was silently removed from an entity or edge. A caller of `add_episode()` had no way to tell "the LLM never proposed this field" from "the LLM proposed it but it was dropped for length".

This PR threads the dropped set through both extraction paths and surfaces it on the public result:

- **Node path** — `_extract_entity_attributes()` now returns `(merged, dropped)`; `extract_attributes_from_nodes()` returns `(nodes, dropped_by_uuid)`.
- **Edge path** — `resolve_extracted_edge()` and `resolve_extracted_edges()` return the dropped set / a `dropped_by_uuid` aggregate as an added tuple element.
- **Public API** — `AddEpisodeResults` and `AddBulkEpisodeResults` gain a `dropped_attributes: dict[str, list[str]]` field mapping entity/edge uuid → sorted dropped field names (empty by default, so existing deserialization is unaffected). `add_episode()`/`add_episode_bulk()` merge the node + edge maps into it.
- `bulk_utils` and `add_triplet` unpack the added tuple element (they don't need the info yet).

## Why

Silent, unsignaled data loss. When the LLM emits an over-length attribute, the merged result simply lacks the field — indistinguishable from the field never being proposed. The new field gives programmatic access to exactly which fields were dropped and for which entities/edges, without relying on parsing log lines.

## Tests

- `test_extract_attributes_from_nodes_surfaces_dropped_fields` — node path: over-cap `bio` with an explicit `max_length` is dropped, prior value retained by the overlay merge, and reported in `dropped_by_uuid`.
- `test_resolve_extracted_edge_surfaces_dropped_attributes` — edge path: over-cap `review` reported in the returned dropped set, absent from merged attributes (replace mode).
- Updated existing mocks/callers for the 4-tuple and 2-tuple returns.

Full non-DB unit suite passes (116 tests in `tests/utils/maintenance/` + `test_add_triplet.py`); ruff check + format clean; pyright clean on changed files (only pre-existing `dotenv` import resolution issue in `graphiti.py` when deps are missing).
