### PR TITLE
fix(falkordb): pin redis<8.1 in falkordb and falkordblite extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,12 @@ groq = ["groq>=0.2.0"]
 google-genai = ["google-genai>=1.62.0"]
 # Deprecated: the upstream Kuzu project is unmaintained; this extra will be removed in a future release.
 kuzu = ["kuzu>=0.11.3"]
-falkordb = ["falkordb>=1.1.2,<2.0.0"]
-# redis<9 pin: redis-py 8.x breaks falkordblite's embedded server startup
-falkordblite = ["falkordblite>=0.5.0; python_version>='3.12'", "redis<9; python_version>='3.12'"]
+falkordb = ["falkordb>=1.1.2,<2.0.0", "redis<8.1"]
+# redis<8.1 pin: redis-py 8.1.0 breaks FalkorDriver construction (Is_Cluster
+# builds a sync redis.Redis from async pool kwargs — FalkorDB/falkordb-py#261).
+# falkordblite needs the same ceiling: redis-py 8.1.0 also breaks its embedded
+# server startup, and the old <9 pin did not exclude it.
+falkordblite = ["falkordblite>=0.5.0; python_version>='3.12'", "redis<8.1; python_version>='3.12'"]
 voyageai = ["voyageai>=0.2.3"]
 gliner2 = ["gliner2>=1.2.0; python_version>='3.11'"]
 neo4j-opensearch = ["boto3>=1.39.16", "opensearch-py>=3.0.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -1141,6 +1141,7 @@ dev = [
 ]
 falkordb = [
     { name = "falkordb" },
+    { name = "redis" },
 ]
 falkordblite = [
     { name = "falkordblite", marker = "python_full_version >= '3.12'" },
@@ -1219,7 +1220,8 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "redis", marker = "python_full_version >= '3.12' and extra == 'falkordblite'", specifier = "<9" },
+    { name = "redis", marker = "python_full_version >= '3.12' and extra == 'falkordblite'", specifier = "<8.1" },
+    { name = "redis", marker = "extra == 'falkordb'", specifier = "<8.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.1" },
     { name = "sentence-transformers", marker = "extra == 'dev'", specifier = ">=3.2.1" },
     { name = "sentence-transformers", marker = "extra == 'sentence-transformers'", specifier = ">=3.2.1" },


### PR DESCRIPTION
Closes #1756

## Problem

A clean `pip install graphiti-core[falkordb]` resolved `redis==8.1.0`, and constructing a `FalkorDriver` against a real FalkorDB instance then raised a `TypeError` before any query was issued. Root cause is upstream in `falkordb-py` (FalkorDB/falkordb-py#261: `Is_Cluster` builds a sync `redis.Redis` from async pool kwargs), but graphiti-core's own dependency metadata made it reach every user by default.

The existing `falkordblite` guard (`redis<9`) was also ineffective for the same reason: the breakage starts at redis **8.1.0**, and `8.1.0 < 9` — that extra only worked because the root lockfile pinned lower for unrelated reasons.

## Fix

- `falkordb` extra: add `redis<8.1`
- `falkordblite` extra: tighten `redis<9` → `redis<8.1` (and document why the old ceiling was wrong)
- `uv.lock`: reflect the new constraints in both `[package.optional-dependencies]` and `requires-dist` metadata

## Verification

`uv pip install --dry-run` against both extras now downgrades redis from the broken `8.1.0` to `8.0.1`:

```
 - redis==8.1.0
 + redis==8.0.1
```

`uv lock --check` passes with the minimal, targeted lockfile diff (only the redis constraint lines changed — no platform-marker churn).
