### PR TITLE
fix: preserve node attributes when no entity type applies (#1763)

### DIFF
--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -788,7 +788,7 @@ async def _extract_entity_attributes(
     entity_type: type[BaseModel] | None,
 ) -> dict[str, Any]:
     if entity_type is None or len(entity_type.model_fields) == 0:
-        return {}
+        return dict(node.attributes or {})
 
     attributes_context = _build_episode_context(
         # should not include summary

--- a/tests/utils/maintenance/test_node_operations.py
+++ b/tests/utils/maintenance/test_node_operations.py
@@ -879,6 +879,37 @@ async def test_extract_attributes_from_nodes_with_callback():
 
 
 @pytest.mark.asyncio
+async def test_extract_attributes_from_nodes_preserves_attributes_without_entity_type():
+    """Regression test for #1763: attributes must not be wiped when no entity type applies."""
+    clients, _ = _make_clients()
+    clients.llm_client.generate_response = AsyncMock(return_value={'summaries': []})
+    clients.embedder.create = AsyncMock(return_value=[0.1, 0.2, 0.3])
+    clients.embedder.create_batch = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+    node = EntityNode(
+        name='Alice',
+        group_id='group',
+        labels=['Entity', 'Person'],
+        summary='Old summary',
+        attributes={'age': 30, 'city': 'New York'},
+    )
+
+    episode = _make_episode()
+
+    # entity_types=None means no entity type applies to any node.
+    results = await extract_attributes_from_nodes(
+        clients,
+        [node],
+        episode=episode,
+        previous_episodes=[],
+        entity_types=None,
+    )
+
+    result = results[0]
+    assert result.attributes == {'age': 30, 'city': 'New York'}
+
+
+@pytest.mark.asyncio
 async def test_batch_summaries_calls_llm_for_long_summary():
     """Test that LLM is called when summary exceeds character limit."""
     from graphiti_core.edges import EntityEdge


### PR DESCRIPTION
## Summary
- \`_extract_entity_attributes\` returned \`{}\` when a node had no matching entity type, and \`extract_attributes_from_nodes\` assigned that directly onto \`node.attributes\` — silently wiping attributes a previous typed extraction pass had stored (e.g. re-ingesting the same node without \`entity_types\`, or with a different type set).
- Now returns the node's prior attributes (\`dict(node.attributes or {})\`) instead, matching the merge contract already used by the typed extraction path (overlay merge in \`apply_capped_attributes\`).

Fixes #1763

## Test plan
- [x] Added regression test \`test_extract_attributes_from_nodes_preserves_attributes_without_entity_type\` in \`tests/utils/maintenance/test_node_operations.py\`, reproducing the exact scenario from the issue
- [x] \`ruff format\` / \`ruff check\` clean on changed files
- [x] Full \`tests/utils/maintenance/test_node_operations.py\` suite passes (34/34)