### PR TITLE
fix: per-list E/I id namespaces in the resolution judge (#1728)

### DIFF
--- a/graphiti_core/prompts/dedupe_edges.py
+++ b/graphiti_core/prompts/dedupe_edges.py
@@ -22,13 +22,15 @@ from .models import Message, PromptFunction, PromptVersion
 
 
 class EdgeDuplicate(BaseModel):
-    duplicate_facts: list[int] = Field(
+    duplicate_facts: list[str] = Field(
         ...,
-        description='List of idx values of duplicate facts (only from EXISTING FACTS range). Empty list if none.',
+        description='List of E-prefixed ids of duplicate facts, e.g. ["E0", "E3"]. '
+        'Only from EXISTING FACTS. Empty list if none.',
     )
-    contradicted_facts: list[int] = Field(
+    contradicted_facts: list[str] = Field(
         ...,
-        description='List of idx values of contradicted facts (from full idx range). Empty list if none.',
+        description='List of E- or I-prefixed ids of contradicted facts, e.g. ["E1", "I2"]. '
+        'Empty list if none.',
     )
 
 
@@ -53,9 +55,9 @@ def resolve_edge(context: dict[str, Any]) -> list[Message]:
 NEVER mark facts as duplicates if they have key differences, particularly around numeric values, dates, or key qualifiers.
 
 IMPORTANT constraints:
-- duplicate_facts: ONLY idx values from EXISTING FACTS (NEVER include FACT INVALIDATION CANDIDATES)
-- contradicted_facts: idx values from EITHER list (EXISTING FACTS or FACT INVALIDATION CANDIDATES)
-- The idx values are continuous across both lists (INVALIDATION CANDIDATES start where EXISTING FACTS end)
+- duplicate_facts: ONLY E-prefixed ids from EXISTING FACTS (NEVER include FACT INVALIDATION CANDIDATES)
+- contradicted_facts: E- or I-prefixed ids from EITHER list (EXISTING FACTS or FACT INVALIDATION CANDIDATES)
+- E and I each number from 0 independently (e.g. E0, E1, ... and I0, I1, ...)
 
 <EXISTING FACTS>
 {context['existing_edges']}
@@ -69,31 +71,37 @@ IMPORTANT constraints:
 {context['new_edge']}
 </NEW FACT>
 
-You will receive TWO lists of facts with CONTINUOUS idx numbering across both lists.
-EXISTING FACTS are indexed first, followed by FACT INVALIDATION CANDIDATES.
+You will receive TWO lists of facts with independent per-list numbering.
+EXISTING FACTS are numbered E0, E1, ... and FACT INVALIDATION CANDIDATES are numbered I0, I1, ...
 
 1. DUPLICATE DETECTION:
-   - If the NEW FACT represents identical factual information as any fact in EXISTING FACTS, return those idx values in duplicate_facts.
+   - If the NEW FACT represents identical factual information as any fact in EXISTING FACTS, return those E-prefixed ids in duplicate_facts.
    - If no duplicates, return an empty list for duplicate_facts.
 
 2. CONTRADICTION DETECTION:
    - Determine which facts the NEW FACT contradicts from either list.
    - A fact from EXISTING FACTS can be both a duplicate AND contradicted (e.g., semantically the same but the new fact updates/supersedes it).
-   - Return all contradicted idx values in contradicted_facts.
+   - Return all contradicted E- or I-prefixed ids in contradicted_facts.
    - If no contradictions, return an empty list for contradicted_facts.
 
 <EXAMPLE>
-EXISTING FACT: idx=0, "Alice joined Acme Corp in 2020"
+EXISTING FACT: id=E0, "Alice joined Acme Corp in 2020"
 NEW FACT: "Alice joined Acme Corp in 2020"
-Result: duplicate_facts=[0], contradicted_facts=[] (identical factual information)
+Result: duplicate_facts=["E0"], contradicted_facts=[] (identical factual information)
 
-EXISTING FACT: idx=1, "Alice works at Acme Corp as a software engineer"
+EXISTING FACT: id=E1, "Alice works at Acme Corp as a software engineer"
 NEW FACT: "Alice works at Acme Corp as a senior engineer"
-Result: duplicate_facts=[], contradicted_facts=[1] (same relationship but updated title — contradiction, NOT a duplicate)
+Result: duplicate_facts=[], contradicted_facts=["E1"] (same relationship but updated title — contradiction, NOT a duplicate)
 
-EXISTING FACT: idx=2, "Bob ran 5 miles on Tuesday"
+EXISTING FACT: id=E2, "Bob ran 5 miles on Tuesday"
+FACT INVALIDATION CANDIDATE: id=I0, "Bob runs 5 miles weekly"
 NEW FACT: "Bob ran 3 miles on Wednesday"
 Result: duplicate_facts=[], contradicted_facts=[] (different events on different days — neither duplicate nor contradiction)
+
+EXISTING FACT: id=E3, "Alice is employed at Acme Corp"
+FACT INVALIDATION CANDIDATE: id=I1, "Alice resigned from Acme Corp in 2024"
+NEW FACT: "Alice returned to Acme Corp in 2026"
+Result: duplicate_facts=[], contradicted_facts=["I1"] (outdated invalidation candidate is contradicted by the new fact)
 </EXAMPLE>
 """,
         ),

--- a/graphiti_core/utils/maintenance/edge_operations.py
+++ b/graphiti_core/utils/maintenance/edge_operations.py
@@ -620,6 +620,25 @@ async def _extract_edge_timestamps(
         logger.warning('Failed to extract timestamps for edge %s', edge.uuid, exc_info=True)
 
 
+def _parse_edge_ids(ids: list[str], related: list[EntityEdge], existing: list[EntityEdge]):
+    """'E3' -> related[3]; 'I2' -> existing[2]. Unknown/malformed -> dropped + warned."""
+    related_out: list[EntityEdge] = []
+    existing_out: list[EntityEdge] = []
+    for raw in ids:
+        try:
+            prefix, num = raw[0], int(raw[1:])
+        except (IndexError, ValueError):
+            logger.warning('LLM returned malformed id %r', raw)
+            continue
+        if prefix == 'E' and 0 <= num < len(related):
+            related_out.append(related[num])
+        elif prefix == 'I' and 0 <= num < len(existing):
+            existing_out.append(existing[num])
+        else:
+            logger.warning('LLM returned out-of-range id %r', raw)
+    return related_out, existing_out
+
+
 async def resolve_extracted_edge(
     llm_client: LLMClient,
     extracted_edge: EntityEdge,
@@ -696,13 +715,13 @@ async def resolve_extracted_edge(
 
     start = time()
 
-    # Prepare context for LLM with continuous indexing
-    related_edges_context = [{'idx': i, 'fact': edge.fact} for i, edge in enumerate(related_edges)]
+    # Prepare context for LLM with per-list E/I namespace ids
+    related_edges_context = [
+        {'id': f'E{i}', 'fact': edge.fact} for i, edge in enumerate(related_edges)
+    ]
 
-    # Invalidation candidates start where duplicate candidates end
-    invalidation_idx_offset = len(related_edges)
     invalidation_edge_candidates_context = [
-        {'idx': invalidation_idx_offset + i, 'fact': existing_edge.fact}
+        {'id': f'I{i}', 'fact': existing_edge.fact}
         for i, existing_edge in enumerate(existing_edges)
     ]
 
@@ -716,11 +735,9 @@ async def resolve_extracted_edge(
         logger.debug(
             'Resolving edge: sent %d EXISTING FACTS%s and %d INVALIDATION CANDIDATES%s',
             len(related_edges),
-            f' (idx 0-{len(related_edges) - 1})' if related_edges else '',
+            f' (ids E0-E{len(related_edges) - 1})' if related_edges else '',
             len(existing_edges),
-            f' (idx {invalidation_idx_offset}-{invalidation_idx_offset + len(existing_edges) - 1})'
-            if existing_edges
-            else '',
+            f' (ids I0-I{len(existing_edges) - 1})' if existing_edges else '',
         )
 
     llm_response = await llm_client.generate_response(
@@ -730,50 +747,26 @@ async def resolve_extracted_edge(
         prompt_name='dedupe_edges.resolve_edge',
     )
     response_object = EdgeDuplicate(**llm_response)
-    duplicate_facts = response_object.duplicate_facts
 
-    # Validate duplicate_facts are in valid range for EXISTING FACTS
-    invalid_duplicates = [i for i in duplicate_facts if i < 0 or i >= len(related_edges)]
-    if invalid_duplicates:
-        logger.warning(
-            'LLM returned invalid duplicate_facts idx values %s (valid range: 0-%d for EXISTING FACTS)',
-            invalid_duplicates,
-            len(related_edges) - 1,
-        )
-
-    duplicate_fact_ids: list[int] = [i for i in duplicate_facts if 0 <= i < len(related_edges)]
+    # Parse E/I prefixed ids: 'E3' -> related_edges[3], 'I2' -> existing_edges[2].
+    # Only related_edges may be merged as duplicates, so I ids in duplicate_facts are invalid.
+    duplicate_related, _ = _parse_edge_ids(response_object.duplicate_facts, related_edges, [])
 
     resolved_edge = extracted_edge
-    for duplicate_fact_id in duplicate_fact_ids:
-        resolved_edge = related_edges[duplicate_fact_id]
+    for duplicate_edge in duplicate_related:
+        resolved_edge = duplicate_edge
         break
 
-    if duplicate_fact_ids and episode is not None:
+    if duplicate_related and episode is not None:
         resolved_edge.episodes.append(episode.uuid)
 
-    # Process contradicted facts (continuous indexing across both lists)
-    contradicted_facts: list[int] = response_object.contradicted_facts
+    # Process contradicted facts: E-part -> related_edges candidates, I-part -> existing_edges candidates
     invalidation_candidates: list[EntityEdge] = []
-
-    # Only process contradictions if there are edges to check against
-    if related_edges or existing_edges:
-        max_valid_idx = len(related_edges) + len(existing_edges) - 1
-        invalid_contradictions = [i for i in contradicted_facts if i < 0 or i > max_valid_idx]
-        if invalid_contradictions:
-            logger.warning(
-                'LLM returned invalid contradicted_facts idx values %s (valid range: 0-%d)',
-                invalid_contradictions,
-                max_valid_idx,
-            )
-
-        # Split contradicted facts into those from related_edges vs existing_edges based on offset
-        for idx in contradicted_facts:
-            if 0 <= idx < len(related_edges):
-                # From EXISTING FACTS (duplicate candidates)
-                invalidation_candidates.append(related_edges[idx])
-            elif invalidation_idx_offset <= idx <= max_valid_idx:
-                # From FACT INVALIDATION CANDIDATES (adjust index by offset)
-                invalidation_candidates.append(existing_edges[idx - invalidation_idx_offset])
+    contradicted_related, contradicted_existing = _parse_edge_ids(
+        response_object.contradicted_facts, related_edges, existing_edges
+    )
+    invalidation_candidates.extend(contradicted_related)
+    invalidation_candidates.extend(contradicted_existing)
 
     # Only extract structured attributes if the edge's relation_type matches an allowed custom type
     # AND the edge model exists for this node pair signature
@@ -842,7 +835,7 @@ async def resolve_extracted_edge(
     invalidated_edges: list[EntityEdge] = resolve_edge_contradictions(
         resolved_edge, invalidation_candidates
     )
-    duplicate_edges: list[EntityEdge] = [related_edges[idx] for idx in duplicate_fact_ids]
+    duplicate_edges: list[EntityEdge] = list(duplicate_related)
 
     return resolved_edge, invalidated_edges, duplicate_edges
 

--- a/tests/utils/maintenance/test_edge_operations.py
+++ b/tests/utils/maintenance/test_edge_operations.py
@@ -237,11 +237,11 @@ async def test_resolve_extracted_edges_keeps_unknown_names(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_resolve_extracted_edge_uses_integer_indices_for_duplicates(mock_llm_client):
-    """Test that resolve_extracted_edge correctly uses integer indices for LLM duplicate detection."""
-    # Mock LLM to return duplicate_facts with integer indices
+async def test_resolve_extracted_edge_uses_prefixed_ids_for_duplicates(mock_llm_client):
+    """Test that resolve_extracted_edge correctly uses E-prefixed ids for LLM duplicate detection."""
+    # Mock LLM to return duplicate_facts with E-prefixed ids
     mock_llm_client.generate_response.return_value = {
-        'duplicate_facts': [0, 1],  # LLM identifies first two related edges as duplicates
+        'duplicate_facts': ['E0', 'E1'],  # LLM identifies first two related edges as duplicates
         'contradicted_facts': [],
     }
 
@@ -267,7 +267,7 @@ async def test_resolve_extracted_edge_uses_integer_indices_for_duplicates(mock_l
         valid_at=datetime.now(timezone.utc),
     )
 
-    # Create multiple related edges - LLM should receive these with integer indices
+    # Create multiple related edges - LLM should receive these with E-prefixed ids
     related_edge_0 = EntityEdge(
         source_node_uuid='source_uuid',
         target_node_uuid='target_uuid',
@@ -318,8 +318,8 @@ async def test_resolve_extracted_edge_uses_integer_indices_for_duplicates(mock_l
     # Verify LLM was called
     mock_llm_client.generate_response.assert_called_once()
 
-    # Verify the system correctly identified duplicates using integer indices
-    # The LLM returned [0, 1], so related_edge_0 and related_edge_1 should be marked as duplicates
+    # Verify the system correctly identified duplicates using E-prefixed ids
+    # The LLM returned ['E0', 'E1'], so related_edge_0 and related_edge_1 should be marked as duplicates
     assert len(duplicates) == 2
     assert related_edge_0 in duplicates
     assert related_edge_1 in duplicates
@@ -329,6 +329,149 @@ async def test_resolve_extracted_edge_uses_integer_indices_for_duplicates(mock_l
     # Check UUID since the episode list gets modified
     assert resolved_edge.uuid == related_edge_0.uuid
     assert episode.uuid in resolved_edge.episodes
+
+
+@pytest.mark.asyncio
+async def test_resolve_extracted_edge_drops_malformed_ids(mock_llm_client, caplog):
+    """Malformed/out-of-range ids (X, E, E999, I-1) are dropped with a warning, never crash."""
+    mock_llm_client.generate_response.return_value = {
+        'duplicate_facts': ['X', 'E', 'E999', 'I-1'],
+        'contradicted_facts': ['X', 'E', 'E999', 'I-1'],
+    }
+
+    extracted_edge = EntityEdge(
+        source_node_uuid='source_uuid',
+        target_node_uuid='target_uuid',
+        name='test_edge',
+        group_id='group_1',
+        fact='User likes running',
+        episodes=[],
+        created_at=datetime.now(timezone.utc),
+        valid_at=datetime.now(timezone.utc),
+        invalid_at=None,
+    )
+
+    episode = EpisodicNode(
+        uuid='episode_uuid',
+        name='Episode',
+        group_id='group_1',
+        source='message',
+        source_description='desc',
+        content='Episode content',
+        valid_at=datetime.now(timezone.utc),
+    )
+
+    related_edges = [
+        EntityEdge(
+            source_node_uuid='source_uuid',
+            target_node_uuid='target_uuid',
+            name='test_edge',
+            group_id='group_1',
+            fact='User likes swimming',
+            episodes=[],
+            created_at=datetime.now(timezone.utc) - timedelta(days=1),
+            valid_at=datetime.now(timezone.utc) - timedelta(days=1),
+            invalid_at=None,
+        )
+    ]
+    existing_edges = [
+        EntityEdge(
+            source_node_uuid='source_uuid',
+            target_node_uuid='target_uuid',
+            name='test_edge',
+            group_id='group_1',
+            fact='User stopped running',
+            episodes=[],
+            created_at=datetime.now(timezone.utc) - timedelta(days=2),
+            valid_at=datetime.now(timezone.utc) - timedelta(days=2),
+            invalid_at=None,
+        )
+    ]
+
+    resolved_edge, invalidated, duplicates = await resolve_extracted_edge(
+        mock_llm_client,
+        extracted_edge,
+        related_edges,
+        existing_edges,
+        episode,
+        edge_type_candidates=None,
+    )
+
+    # Every id is malformed or out of range, so nothing may be resolved to an edge
+    assert duplicates == []
+    assert invalidated == []
+    assert resolved_edge is extracted_edge
+
+    assert 'malformed id' in caplog.text
+    assert 'out-of-range id' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_resolve_extracted_edge_maps_i_ids_to_invalidation_candidates(mock_llm_client):
+    """I-prefixed ids resolve to existing (invalidation) edges, never to related edges.
+
+    Regression test for the offset arithmetic bug: with 3 related and 3 existing
+    edges, an 'I2' id must map to existing_edges[2] and must not touch related_edges.
+    """
+    now = datetime.now(timezone.utc)
+    mock_llm_client.generate_response.return_value = {
+        'duplicate_facts': [],
+        'contradicted_facts': ['I2'],
+    }
+
+    extracted_edge = EntityEdge(
+        source_node_uuid='source_uuid',
+        target_node_uuid='target_uuid',
+        name='test_edge',
+        group_id='group_1',
+        fact='User now enjoys rock climbing',
+        episodes=[],
+        created_at=now,
+        valid_at=now,
+        invalid_at=None,
+    )
+
+    episode = EpisodicNode(
+        uuid='episode_uuid',
+        name='Episode',
+        group_id='group_1',
+        source='message',
+        source_description='desc',
+        content='Episode content',
+        valid_at=now,
+    )
+
+    def make_edge(fact: str, age_days: int) -> EntityEdge:
+        return EntityEdge(
+            source_node_uuid='source_uuid',
+            target_node_uuid='target_uuid',
+            name='test_edge',
+            group_id='group_1',
+            fact=fact,
+            episodes=[],
+            created_at=now - timedelta(days=age_days),
+            valid_at=now - timedelta(days=age_days),
+            invalid_at=None,
+        )
+
+    related_edges = [make_edge(f'Related fact {i}', i + 1) for i in range(3)]
+    existing_edges = [make_edge(f'Existing fact {i}', 10 + i) for i in range(3)]
+
+    resolved_edge, invalidated, duplicates = await resolve_extracted_edge(
+        mock_llm_client,
+        extracted_edge,
+        related_edges,
+        existing_edges,
+        episode,
+        edge_type_candidates=None,
+    )
+
+    # 'I2' must map to existing_edges[2], invalidating it (its valid_at predates the new fact)
+    assert invalidated == [existing_edges[2]]
+    # None of the related edges may be invalidated, and no duplicates were found
+    assert duplicates == []
+    for related in related_edges:
+        assert related not in invalidated
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# PR description — fix: per-list E/I id namespaces in the resolution judge

Reference: #1728 (Bug: Edge invalidation searches the whole graph, so unrelated facts retire each other)

## What this changes

The resolution judge (`dedupe_edges.resolve_edge`) previously numbered both candidate
lists — EXISTING FACTS (related/duplicate candidates) and FACT INVALIDATION CANDIDATES —
in one continuous index range, and the parser reconstructed list membership with offset
arithmetic (`invalidation_idx_offset`). A judge response that was "in range" but belonged
to the wrong list silently retired unrelated facts.

This PR gives each list its own namespace:
- EXISTING FACTS are `E0, E1, ...`
- FACT INVALIDATION CANDIDATES are `I0, I1, ...`
- The parser maps prefixes directly (`E3` -> related[3], `I2` -> existing[2]); malformed
  or out-of-range ids are dropped with a warning instead of computed.

## Why it's correct (not just a style change)

Under the continuous-index scheme, "wrong-but-in-range" is a real failure class: the
judge can return an index that is valid for the combined range but points at the wrong
list. Prefixed ids make that structurally impossible — the prefix IS the list.

## Files changed

- `graphiti_core/prompts/dedupe_edges.py` — response model fields are now `list[str]`
  (E/I-prefixed), prompt constraints and few-shot examples updated to the per-list
  numbering.
- `graphiti_core/utils/maintenance/edge_operations.py` — context building emits
  `{'id': 'E{i}'}` / `{'id': 'I{i}'}`; `invalidation_idx_offset` deleted; parsing replaced
  with `_parse_edge_ids` direct mapping; `max_valid_idx` arithmetic removed.
- `tests/utils/maintenance/test_edge_operations.py` — existing integer-index test renamed
  and updated to E-prefixed mocks; new tests: malformed ids (`'X'`, `'E'`, `'E999'`,
  `'I-1'`) dropped safely; `'I2'` maps to `existing_edges[2]` (the regression that would
  have caught the offset bug).

## Verification

- `pytest tests/utils/maintenance/test_edge_operations.py` — 11 passed.
- ruff + pyright clean on changed files.
- `grep invalidation_idx_offset|max_valid_idx` — no remaining references.

## Real-model measurement (what motivated the change)

Ran the actual resolution path with a real API-class model (deepseek-v4-flash) over a
120-probe corpus (30 each: true duplicates, contradictions, false-similars, renames),
with pre-written ground truth and deterministic scoring. Same corpus, same model, both
code versions:

| class | before (continuous idx) | after (E/I namespaces) |
|---|---|---|
| duplicate | 18/30 | 20/30 |
| contradiction | 0/30 | 0/30 |
| false_similar | 30/30 | 29/30* |
| rename | 0/30 | 0/30 |
| **total** | **48/120** | **49/120** |

*the one false_similar flip was a response-shape parse error, not a semantic regression.

The three duplicate recoveries (duplicate-13/-23/-27) are direct evidence the fix works:
in both arms the raw model output was IDENTICAL (correct `E2`-style ids), and only the
parser differed — the E/I mapping lands merges the continuous-index arithmetic dropped.

## What this does NOT claim (honest scope)

1. The dominant resolution failure is NOT the index scheme: ~50% of harder calls
   (contradiction/rename) return no duplicate/contradiction verdict at all, in BOTH arms.
   Sampling the raw responses showed the model returns valid, correct ids on roughly half
   of those — the failure is judge reliability/stochasticity under this prompt, which this
   PR does not fix.
2. Response-shape fragility is a separate issue: occasionally the model returns the
   injected schema wrapper instead of a filled instance, breaking the parse
   (`ValidationError` on `duplicate_facts`). Worth a follow-up issue.
3. Token limits were verified non-confounding: all calls used max_tokens=16384 (the
   client default, matching production), far above what these small JSON responses need.

Happy to share the harness + corpus (seeded, resumable, deterministic-scored) for
maintainers to reuse.
