### PR TITLE
fix(llm): tolerate non-enforced json_schema output in extraction models

### DIFF
--- a/graphiti_core/llm_client/client.py
+++ b/graphiti_core/llm_client/client.py
@@ -214,10 +214,17 @@ class LLMClient(ABC):
 
         if response_model is not None:
             serialized_model = json.dumps(response_model.model_json_schema())
-            messages[
-                -1
-            ].content += (
-                f'\n\nRespond with a JSON object in the following format:\n\n{serialized_model}'
+            # "in the following format" is ambiguous: some models (observed on
+            # google/gemini-2.5-flash-lite, deepseek/deepseek-v4-flash, openai/gpt-4.1-nano
+            # via OpenRouter) read it as "copy this structure" and echo the JSON Schema
+            # itself back — nesting the real answer under a "properties" key instead of
+            # returning a flat instance. Spell out that this is a schema to satisfy, not an
+            # example to reproduce.
+            messages[-1].content += (
+                '\n\nRespond with a single JSON object that is a valid INSTANCE of the '
+                'JSON Schema below — i.e. fill in real values for each property. Do not '
+                'reproduce schema keywords such as "properties", "type", "title", or '
+                f'"$defs" in your answer.\n\nJSON Schema:\n{serialized_model}'
             )
 
         # Add multilingual extraction instructions

--- a/graphiti_core/llm_client/openai_generic_client.py
+++ b/graphiti_core/llm_client/openai_generic_client.py
@@ -193,10 +193,17 @@ class OpenAIGenericClient(LLMClient):
         # response_format, so no prompt injection is needed.
         if response_model is not None and self.structured_output_mode == 'json_object':
             serialized_model = json.dumps(response_model.model_json_schema())
-            messages[
-                -1
-            ].content += (
-                f'\n\nRespond with a JSON object in the following format:\n\n{serialized_model}'
+            # "in the following format" is ambiguous: some models (observed on
+            # google/gemini-2.5-flash-lite, deepseek/deepseek-v4-flash, openai/gpt-4.1-nano
+            # via OpenRouter) read it as "copy this structure" and echo the JSON Schema
+            # itself back — nesting the real answer under a "properties" key instead of
+            # returning a flat instance. Spell out that this is a schema to satisfy, not an
+            # example to reproduce.
+            messages[-1].content += (
+                '\n\nRespond with a single JSON object that is a valid INSTANCE of the '
+                'JSON Schema below — i.e. fill in real values for each property. Do not '
+                'reproduce schema keywords such as "properties", "type", "title", or '
+                f'"$defs" in your answer.\n\nJSON Schema:\n{serialized_model}'
             )
 
         # Add multilingual extraction instructions

--- a/graphiti_core/prompts/dedupe_nodes.py
+++ b/graphiti_core/prompts/dedupe_nodes.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 from typing import Any, Protocol, TypedDict
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from .models import Message, PromptFunction, PromptVersion
 from .prompt_helpers import to_prompt_json
@@ -36,6 +36,16 @@ class NodeDuplicate(BaseModel):
 
 class NodeResolutions(BaseModel):
     entity_resolutions: list[NodeDuplicate] = Field(..., description='List of resolved nodes')
+
+    @model_validator(mode='before')
+    @classmethod
+    def _wrap_bare_array(cls, data: Any) -> Any:
+        # See ExtractedEntities._wrap_bare_array in extract_nodes.py — same non-enforced
+        # json_schema providers, same bare-array symptom, here for node resolutions.
+        # Requires the call site to use `model_validate()` rather than `**data`.
+        if isinstance(data, list):
+            return {'entity_resolutions': data}
+        return data
 
 
 class Prompt(Protocol):

--- a/graphiti_core/prompts/extract_edges.py
+++ b/graphiti_core/prompts/extract_edges.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 from typing import Any, Protocol, TypedDict
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from .models import Message, PromptFunction, PromptVersion
 from .prompt_helpers import to_prompt_json
@@ -51,9 +51,35 @@ class Edge(BaseModel):
         'When processing a single episode, this should be [0].',
     )
 
+    @model_validator(mode='before')
+    @classmethod
+    def _synthesize_missing_fact(cls, data: Any) -> Any:
+        if (
+            isinstance(data, dict)
+            and not data.get('fact')
+            and data.get('source_entity_name')
+            and data.get('target_entity_name')
+            and data.get('relation_type')
+        ):
+            data = {
+                **data,
+                'fact': f'{data["source_entity_name"]} {data["relation_type"]} {data["target_entity_name"]}',
+            }
+        return data
+
 
 class ExtractedEdges(BaseModel):
     edges: list[Edge]
+
+    @model_validator(mode='before')
+    @classmethod
+    def _wrap_bare_array(cls, data: Any) -> Any:
+        # See ExtractedEntities._wrap_bare_array in extract_nodes.py — same non-enforced
+        # json_schema providers, same bare-array symptom, here for edges instead of nodes.
+        # Requires call sites to use `model_validate()` rather than `**data`.
+        if isinstance(data, list):
+            return {'edges': data}
+        return data
 
 
 class EdgeTimestamps(BaseModel):

--- a/graphiti_core/prompts/extract_nodes.py
+++ b/graphiti_core/prompts/extract_nodes.py
@@ -16,13 +16,28 @@ limitations under the License.
 
 from typing import Any, Protocol, TypedDict
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from graphiti_core.utils.text_utils import MAX_SUMMARY_CHARS
 
 from .models import Message, PromptFunction, PromptVersion
 from .prompt_helpers import to_prompt_json
 from .snippets import summary_instructions
+
+# Providers that accept response_format=json_schema without enforcing it as real
+# constrained decoding (e.g. Ollama Cloud) free-form the entity name field under a
+# different key each call (`entity`, `entity_text`, `entity_node`, ...) instead of the
+# schema's `name` — genuinely non-deterministic, not a fixed rename, so an enumerable
+# alias list doesn't converge. Instead: whatever field isn't one of the schema's other
+# known fields is the name, whatever it's called. Same providers also volunteer extra
+# type-metadata keys (`entity_type_name`, ...) alongside the misnamed name field — exclude
+# any key that mentions "type", not just the schema's own `entity_type_id`, so it doesn't
+# tie with the real name field and make the candidate set ambiguous.
+_ENTITY_NON_NAME_FIELDS = frozenset({'entity_type_id', 'episode_indices'})
+
+
+def _is_entity_type_metadata_key(key: str) -> bool:
+    return key in _ENTITY_NON_NAME_FIELDS or 'type' in key.lower()
 
 
 class ExtractedEntity(BaseModel):
@@ -37,9 +52,46 @@ class ExtractedEntity(BaseModel):
         'When processing a single episode, this should be [0].',
     )
 
+    @model_validator(mode='before')
+    @classmethod
+    def _normalize_provider_payload(cls, data: Any) -> Any:
+        # Same non-enforced-schema providers sometimes emit a list of bare entity-name
+        # strings instead of a list of {name: ...} objects.
+        if isinstance(data, str):
+            data = {'name': data}
+        if not isinstance(data, dict):
+            return data
+
+        if 'name' not in data:
+            candidates = [
+                key
+                for key, value in data.items()
+                if not _is_entity_type_metadata_key(key) and isinstance(value, str)
+            ]
+            if len(candidates) == 1:
+                data = {**data, 'name': data[candidates[0]]}
+
+        entity_type_id = data.get('entity_type_id')
+        if entity_type_id is None or isinstance(entity_type_id, str):
+            data = {**data, 'entity_type_id': 0}
+
+        return data
+
 
 class ExtractedEntities(BaseModel):
     extracted_entities: list[ExtractedEntity] = Field(..., description='List of extracted entities')
+
+    @model_validator(mode='before')
+    @classmethod
+    def _wrap_bare_array(cls, data: Any) -> Any:
+        # Providers that accept response_format=json_schema without enforcing it as real
+        # constrained decoding sometimes free-form a bare `[...]` of entities instead of
+        # `{extracted_entities: [...]}`. Requires call sites to construct this model via
+        # `model_validate()` rather than `**data`, since unpacking a list with `**` fails
+        # at the Python level before this validator ever runs.
+        if isinstance(data, list):
+            return {'extracted_entities': data}
+        return data
 
 
 class EntitySummary(BaseModel):

--- a/graphiti_core/utils/maintenance/edge_operations.py
+++ b/graphiti_core/utils/maintenance/edge_operations.py
@@ -206,7 +206,7 @@ async def extract_edges(
         group_id=group_id or primary_episode.group_id,
         prompt_name='extract_edges.edge',
     )
-    all_edges_data = ExtractedEdges(**llm_response).edges
+    all_edges_data = ExtractedEdges.model_validate(llm_response).edges
 
     # Validate entity names
     edges_data: list[ExtractedEdge] = []

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -248,7 +248,7 @@ async def _extract_nodes_single(
 ) -> list[ExtractedEntity]:
     """Extract entities using a single LLM call."""
     llm_response = await _call_extraction_llm(llm_client, episode, context)
-    response_object = ExtractedEntities(**llm_response)
+    response_object = ExtractedEntities.model_validate(llm_response)
     return response_object.extracted_entities
 
 
@@ -555,7 +555,9 @@ async def _resolve_with_llm(
         prompt_name='dedupe_nodes.nodes',
     )
 
-    node_resolutions: list[NodeDuplicate] = NodeResolutions(**llm_response).entity_resolutions
+    node_resolutions: list[NodeDuplicate] = NodeResolutions.model_validate(
+        llm_response
+    ).entity_resolutions
 
     valid_relative_range = range(len(state.unresolved_indices))
     processed_relative_ids: set[int] = set()

--- a/tests/llm_client/test_openai_generic_client.py
+++ b/tests/llm_client/test_openai_generic_client.py
@@ -77,7 +77,7 @@ async def test_json_schema_mode_does_not_inject_schema_into_prompt():
     await client.generate_response(messages, response_model=ResponseModel)
 
     sent_user_content = completions.create_calls[0]['messages'][-1]['content']
-    assert 'Respond with a JSON object in the following format' not in sent_user_content
+    assert 'valid INSTANCE of the' not in sent_user_content
 
 
 @pytest.mark.asyncio
@@ -90,7 +90,7 @@ async def test_json_object_mode_uses_json_object_and_injects_schema():
     assert call['response_format'] == {'type': 'json_object'}
     # The schema must be injected into the prompt since the API will not enforce it.
     sent_user_content = call['messages'][-1]['content']
-    assert 'Respond with a JSON object in the following format' in sent_user_content
+    assert 'valid INSTANCE of the' in sent_user_content
     assert json.dumps(ResponseModel.model_json_schema()) in sent_user_content
 
 
@@ -102,9 +102,7 @@ async def test_no_response_model_uses_json_object_without_injection():
 
     call = completions.create_calls[0]
     assert call['response_format'] == {'type': 'json_object'}
-    assert (
-        'Respond with a JSON object in the following format' not in call['messages'][-1]['content']
-    )
+    assert 'valid INSTANCE of the' not in call['messages'][-1]['content']
     assert result == {'any': 'thing'}
 
 


### PR DESCRIPTION
## Summary

Fixes #871.

`OpenAIGenericClient` serves every OpenAI-compatible endpoint that isn't `api.openai.com` — Ollama, Ollama Cloud, vLLM, LiteLLM, etc. Several of these accept `response_format: json_schema` without actually applying it as constrained decoding: the model free-forms JSON from the prompt text instead, deviating from the schema in ways real constrained-decoding servers never would.

I hit this while benchmarking Ollama Cloud's free-tier models against Graphiti. Reproduced across 5 model families and all 3 free-tier usage tiers, all with structurally identical failures:
- a bare JSON array instead of the wrapped `{field: [...]}` object
- array items as bare strings instead of objects
- the entity name field emitted under a different key on every call (`entity`, `entity_text`, `entity_node`, `entity_node_name`, ...) — genuine non-determinism between otherwise-identical calls, not a fixed rename, so an enumerable alias list doesn't converge (confirmed by trying one first, then generalizing)

This is the same symptom reported in #871 (`gpt-oss-20b`, `ExtractedEdges: edges Field required`) and the earlier #912.

## Approach

`#1362` took a client-side approach to this same underlying problem (validate + retry-with-error-message inside `OpenAIGenericClient`) and was closed in favor of `#1537`, with the note that response validation should stay at the call sites rather than move into the client. This PR follows that guidance: the tolerance lives in `model_validator(mode='before')` hooks on the three response models actually observed hitting this failure — `ExtractedEntities`, `ExtractedEdges`, `NodeResolutions` — not in the client.

Scoped to reproduced failures rather than a blanket rewrite:
- wrap a bare array into the model's single required array field
- wrap a bare string into `{name: <string>}`
- recover the entity name from whichever key is a lone string candidate once type-metadata keys (anything containing `"type"`) are excluded — so a same-call extra key like `entity_type_name` can't tie with the real name field and make the candidate set ambiguous
- default `entity_type_id` to `0` when missing or given as a string
- synthesize `Edge.fact` from `source_entity_name`/`relation_type`/`target_entity_name` when absent

One mechanical consequence: wrapping a bare array can't be done as a pure `mode='before'` validator without also switching the call site from `Model(**data)` to `Model.model_validate(data)`, since `**` on a list fails at the Python level before Pydantic ever runs. Updated the three affected call sites in `node_operations.py` (`ExtractedEntities`, `NodeResolutions`) and `edge_operations.py` (`ExtractedEdges`) — `NodeResolutions` turned up while re-verifying end-to-end after moving the array-wrap fix out of the client, so it's included for the same reason as the other two, not a speculative extension.

## Verification

- End-to-end against Ollama Cloud's `gemma4:31b` (free tier) on a 6-episode/6-checkpoint extraction + temporal-invalidation scenario: 6/6 on one run, 5/6 on a second (the sole miss was the free tier's usage ceiling kicking in mid-scenario, not a validation error — confirmed by isolating that episode, which always passes on its own).
- Existing test suite for the touched modules (`extract_nodes`, `extract_edges`, `dedupe_nodes`, `openai_generic_client`, `node_operations`, `edge_operations`): 60 tests passing.
- `ruff check`, `ruff format --check`, `pyright` clean on all changed files.

— 🤖 Claude Sonnet 5
