### PR TITLE
fix(neo4j): route database_ to connection kwarg (#1481)

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -112,4 +112,5 @@ jobs:
             tests/test_edge_int.py \
             tests/cross_encoder/test_bge_reranker_client_int.py \
             tests/driver/test_falkordb_driver.py \
+            tests/driver/test_neo4j_driver.py \
             -m "not integration"

--- a/graphiti_core/driver/neo4j_driver.py
+++ b/graphiti_core/driver/neo4j_driver.py
@@ -158,15 +158,23 @@ class Neo4jDriver(GraphDriver):
                 raise
 
     async def execute_query(self, cypher_query_: LiteralString, **kwargs: Any) -> EagerResult:
-        # Check if database_ is provided in kwargs.
-        # If not populated, set the value to retain backwards compatibility
         params = kwargs.pop('params', None)
         if params is None:
             params = {}
-        params.setdefault('database_', self._database)
+
+        # `database_` must be forwarded as a driver-level kwarg on Neo4j's
+        # execute_query — not as a Cypher parameter, where it is silently
+        # ignored and every query routes to the connection's home database.
+        # Accept it from either `params` or `kwargs` for backwards compatibility.
+        database = params.pop('database_', None) or kwargs.pop('database_', None) or self._database
 
         try:
-            result = await self.client.execute_query(cypher_query_, parameters_=params, **kwargs)
+            result = await self.client.execute_query(
+                cypher_query_,
+                parameters_=params,
+                database_=database,
+                **kwargs,
+            )
         except Exception as e:
             logger.error(f'Error executing Neo4j query: {e}\n{cypher_query_}\n{params}')
             raise

--- a/tests/driver/test_neo4j_driver.py
+++ b/tests/driver/test_neo4j_driver.py
@@ -1,0 +1,136 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.neo4j_driver import Neo4jDriver
+
+
+def _build_driver(database: str = 'neo4j') -> tuple[Neo4jDriver, MagicMock]:
+    """Instantiate a Neo4jDriver with a mocked underlying async client.
+
+    Suppresses the background ``build_indices_and_constraints`` task that
+    ``__init__`` normally schedules when a running loop is present, so tests
+    exercise only the code under test.
+    """
+    mock_client = MagicMock()
+    mock_client.execute_query = AsyncMock(return_value=MagicMock())
+    with (
+        patch(
+            'graphiti_core.driver.neo4j_driver.AsyncGraphDatabase.driver',
+            return_value=mock_client,
+        ),
+        patch(
+            'graphiti_core.driver.neo4j_driver.asyncio.get_running_loop',
+            side_effect=RuntimeError,
+        ),
+    ):
+        driver = Neo4jDriver(
+            uri='bolt://localhost:7687',
+            user='neo4j',
+            password='password',
+            database=database,
+        )
+    return driver, mock_client
+
+
+class TestNeo4jDriverProvider:
+    def test_provider(self):
+        driver, _ = _build_driver()
+        assert driver.provider == GraphProvider.NEO4J
+
+
+class TestNeo4jDriverDatabaseRouting:
+    """Regression tests for issue #1481.
+
+    Neo4j's driver expects `database_` as a top-level keyword argument to
+    ``execute_query``; when it is nested inside ``parameters_`` it becomes an
+    unused Cypher variable and the query is silently routed to the connection's
+    home database rather than the configured one.
+    """
+
+    @pytest.mark.asyncio
+    async def test_configured_database_is_passed_as_connection_kwarg(self):
+        driver, mock_client = _build_driver(database='mydb')
+
+        await driver.execute_query('MATCH (n) RETURN n')
+
+        call_kwargs = mock_client.execute_query.call_args.kwargs
+        assert call_kwargs.get('database_') == 'mydb'
+        # `database_` must NOT be smuggled into Cypher parameters.
+        assert 'database_' not in call_kwargs.get('parameters_', {})
+
+    @pytest.mark.asyncio
+    async def test_default_database_is_used_when_none_configured(self):
+        driver, mock_client = _build_driver()  # defaults to 'neo4j'
+
+        await driver.execute_query('MATCH (n) RETURN n')
+
+        call_kwargs = mock_client.execute_query.call_args.kwargs
+        assert call_kwargs.get('database_') == 'neo4j'
+        assert 'database_' not in call_kwargs.get('parameters_', {})
+
+    @pytest.mark.asyncio
+    async def test_explicit_database_kwarg_overrides_configured_default(self):
+        driver, mock_client = _build_driver(database='mydb')
+
+        await driver.execute_query('MATCH (n) RETURN n', database_='override_db')
+
+        call_kwargs = mock_client.execute_query.call_args.kwargs
+        assert call_kwargs.get('database_') == 'override_db'
+        assert 'database_' not in call_kwargs.get('parameters_', {})
+
+    @pytest.mark.asyncio
+    async def test_database_nested_in_params_is_promoted_to_connection_kwarg(self):
+        """Backwards compatibility: honor callers that stuck database_ inside `params`."""
+        driver, mock_client = _build_driver(database='mydb')
+
+        await driver.execute_query(
+            'MATCH (n) RETURN n',
+            params={'database_': 'legacy_db', 'name': 'Alice'},
+        )
+
+        call_kwargs = mock_client.execute_query.call_args.kwargs
+        assert call_kwargs.get('database_') == 'legacy_db'
+        # The Cypher-level parameters must not carry the driver-level knob.
+        assert 'database_' not in call_kwargs.get('parameters_', {})
+        # But other Cypher parameters must pass through untouched.
+        assert call_kwargs.get('parameters_', {}).get('name') == 'Alice'
+
+
+class TestNeo4jDriverExecuteQueryPassthrough:
+    """Sanity checks that unrelated kwargs continue to work as before."""
+
+    @pytest.mark.asyncio
+    async def test_routing_kwarg_is_forwarded_at_connection_level(self):
+        driver, mock_client = _build_driver()
+
+        await driver.execute_query('MATCH (n) RETURN n', routing_='r')
+
+        call_kwargs = mock_client.execute_query.call_args.kwargs
+        assert call_kwargs.get('routing_') == 'r'
+
+    @pytest.mark.asyncio
+    async def test_extra_kwargs_are_forwarded(self):
+        driver, mock_client = _build_driver()
+
+        await driver.execute_query('MATCH (n {name: $name}) RETURN n', name='Alice')
+
+        call_kwargs = mock_client.execute_query.call_args.kwargs
+        assert call_kwargs.get('name') == 'Alice'


### PR DESCRIPTION
## Summary

Fixes #1481.

`Neo4jDriver.execute_query` was placing `database_` inside `parameters_` (the Cypher variables dict) rather than passing it as a driver-level kwarg to Neo4j's `execute_query`. As a result, `database_` was treated as an unused Cypher parameter and silently ignored — every query routed to the connection's home database regardless of the `database` value passed to `Neo4jDriver(...)`. Only writes that went through `session(database=...)` explicitly (e.g. `transaction()`) hit the intended database.

## Fix

Route `database_` to the driver-level kwarg on `AsyncDriver.execute_query`. Accept it from either `params` or `kwargs` for backwards compatibility so callers that historically stuck it in `params` keep working.

```python
database = (
    params.pop('database_', None)
    or kwargs.pop('database_', None)
    or self._database
)
result = await self.client.execute_query(
    cypher_query_,
    parameters_=params,
    database_=database,
    **kwargs,
)
```

## Tests

New `tests/driver/test_neo4j_driver.py` — 7 tests, mock-only (no live Neo4j required):

- `test_configured_database_is_passed_as_connection_kwarg` — the core regression for #1481
- `test_default_database_is_used_when_none_configured`
- `test_explicit_database_kwarg_overrides_configured_default`
- `test_database_nested_in_params_is_promoted_to_connection_kwarg` — backwards compat
- `test_routing_kwarg_is_forwarded_at_connection_level`
- `test_extra_kwargs_are_forwarded`
- `test_provider`

Added the new file to the `database-integration-tests` job in `.github/workflows/unit_tests.yml`, mirroring the existing `test_falkordb_driver.py` entry.

## Verified locally

- `ruff format` + `ruff check` — clean
- `pyright graphiti_core/driver/neo4j_driver.py` — 0 errors, 0 warnings
- `pytest tests/driver/test_falkordb_driver.py tests/driver/test_neo4j_driver.py` — 32 passed, 1 skipped
- Full unit suite with CI's ignore list — 366 passed, 11 skipped, no regressions

## Test plan

- [x] Regression test fails on unmodified `main` (asserts `database_` is a top-level kwarg; observed `{'parameters_': {'database_': 'mydb'}}` on main)
- [x] Regression test passes after fix
- [x] Full unit suite passes
- [x] `ruff` + `pyright` clean