### PR TITLE
fix(embedder): pin encoding_format=float on OpenAI embedding calls

### DIFF
--- a/graphiti_core/embedder/openai.py
+++ b/graphiti_core/embedder/openai.py
@@ -55,12 +55,19 @@ class OpenAIEmbedder(EmbedderClient):
         self, input_data: str | list[str] | Iterable[int] | Iterable[Iterable[int]]
     ) -> list[float]:
         result = await self.client.embeddings.create(
-            input=input_data, model=self.config.embedding_model
+            input=input_data, model=self.config.embedding_model,
+            encoding_format='float',
         )
         return result.data[0].embedding[: self.config.embedding_dim]
 
     async def create_batch(self, input_data_list: list[str]) -> list[list[float]]:
+        # Pinned explicitly: left unset, the OpenAI SDK negotiates 'base64',
+        # and gateways fronting non-OpenAI providers reject the parameter
+        # outright — litellm to Vertex AI fails every call for
+        # gemini-embedding-001. 'float' is the API default and the portable
+        # choice.
         result = await self.client.embeddings.create(
-            input=input_data_list, model=self.config.embedding_model
+            input=input_data_list, model=self.config.embedding_model,
+            encoding_format='float',
         )
         return [embedding.embedding[: self.config.embedding_dim] for embedding in result.data]

--- a/graphiti_core/embedder/openai.py
+++ b/graphiti_core/embedder/openai.py
@@ -55,7 +55,8 @@ class OpenAIEmbedder(EmbedderClient):
         self, input_data: str | list[str] | Iterable[int] | Iterable[Iterable[int]]
     ) -> list[float]:
         result = await self.client.embeddings.create(
-            input=input_data, model=self.config.embedding_model,
+            input=input_data,
+            model=self.config.embedding_model,
             encoding_format='float',
         )
         return result.data[0].embedding[: self.config.embedding_dim]
@@ -67,7 +68,8 @@ class OpenAIEmbedder(EmbedderClient):
         # gemini-embedding-001. 'float' is the API default and the portable
         # choice.
         result = await self.client.embeddings.create(
-            input=input_data_list, model=self.config.embedding_model,
+            input=input_data_list,
+            model=self.config.embedding_model,
             encoding_format='float',
         )
         return [embedding.embedding[: self.config.embedding_dim] for embedding in result.data]


### PR DESCRIPTION
## Problem

`OpenAIEmbedder` calls `embeddings.create()` without specifying `encoding_format`. Left unset, the OpenAI SDK negotiates **base64** on its own — and gateways fronting non-OpenAI providers reject the parameter outright:

```
litellm.UnsupportedParamsError: vertex_ai does not support parameters:
{'encoding_format': 'base64'}, for model=gemini-embedding-001
```

Every embedding call fails, so ingestion cannot proceed at all behind such a gateway. Hit in practice with LiteLLM proxying to Vertex AI for `gemini-embedding-001`.

## Fix

Pin `encoding_format='float'` on both `create()` and `create_batch()`. It is the API default and the portable choice, so this is a no-op against OpenAI itself while unblocking OpenAI-compatible gateways.

## Notes

- Split out of #1777 deliberately: that PR adds a driver, whereas this touches shared core code affecting **every** backend, and should be reviewable — or droppable — on its own.
- Leaving it to callers is not reachable today: `OpenAIEmbedderConfig` exposes no way to pass the parameter through.