### PR TITLE
feat(llm): add optional timeout and extra_body to LLMConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,12 @@ graphiti = Graphiti(
 
 Ensure Ollama is running (`ollama serve`) and that you have pulled the models you want to use.
 
+`LLMConfig` also accepts optional `timeout` (seconds) and `extra_body` settings for
+OpenAI-compatible chat-completions endpoints. Both default to `None`, so existing request
+payloads are unchanged when they are omitted. `extra_body` is passed through unchanged for
+provider-specific options such as vLLM guided decoding; support is server-dependent, and
+some servers (including Ollama) may ignore individual options.
+
 ### Structured output and small models
 
 Graphiti depends on structured (JSON) output for entity/edge extraction and deduplication, and works best with models

--- a/graphiti_core/llm_client/config.py
+++ b/graphiti_core/llm_client/config.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from enum import Enum
+from typing import Any
 
 DEFAULT_MAX_TOKENS = 16384
 DEFAULT_TEMPERATURE = 1
@@ -42,6 +43,8 @@ class LLMConfig:
         temperature: float = DEFAULT_TEMPERATURE,
         max_tokens: int = DEFAULT_MAX_TOKENS,
         small_model: str | None = None,
+        timeout: float | None = None,
+        extra_body: dict[str, Any] | None = None,
     ):
         """
         Initialize the LLMConfig with the provided parameters.
@@ -59,10 +62,30 @@ class LLMConfig:
 
                 small_model (str, optional): The specific LLM model to use for generating responses of simpler prompts.
                                                                 Defaults to "gpt-4.1-nano".
+
+                timeout (float, optional): Per-request timeout in seconds for providers that support it.
+                    Defaults to ``None``, which leaves the provider SDK default unchanged.
+
+                extra_body (dict, optional): Provider-specific request-body fields for OpenAI-compatible
+                    endpoints. Support varies by server; unsupported fields may be ignored. Defaults to ``None``.
         """
+        if timeout is not None:
+            if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
+                raise TypeError('timeout must be a float or None')
+            if timeout < 0:
+                raise ValueError('timeout must be greater than or equal to zero')
+
+        if extra_body is not None:
+            if not isinstance(extra_body, dict):
+                raise TypeError('extra_body must be a dict or None')
+            if not all(isinstance(key, str) for key in extra_body):
+                raise TypeError('extra_body keys must be strings')
+
         self.base_url = base_url
         self.api_key = api_key
         self.model = model
         self.small_model = small_model
         self.temperature = temperature
         self.max_tokens = max_tokens
+        self.timeout = float(timeout) if timeout is not None else None
+        self.extra_body = extra_body

--- a/graphiti_core/llm_client/openai_generic_client.py
+++ b/graphiti_core/llm_client/openai_generic_client.py
@@ -55,6 +55,8 @@ class OpenAIGenericClient(LLMClient):
         temperature (float): The temperature to use for generating responses.
         max_tokens (int): The maximum number of tokens to generate in a response.
         structured_output_mode (StructuredOutputMode): How structured output is requested.
+        config.timeout (float | None): Optional per-request timeout in seconds.
+        config.extra_body (dict | None): Optional provider-specific request-body fields.
     """
 
     def __init__(
@@ -152,13 +154,21 @@ class OpenAIGenericClient(LLMClient):
             elif m.role == 'system':
                 openai_messages.append({'role': 'system', 'content': m.content})
         try:
-            response = await self.client.chat.completions.create(
-                model=self.model or DEFAULT_MODEL,
-                messages=openai_messages,
-                temperature=self.temperature,
-                max_tokens=max_tokens,
-                response_format=self._build_response_format(response_model),  # type: ignore[arg-type]
-            )
+            request_kwargs: dict[str, Any] = {
+                'model': self.model or DEFAULT_MODEL,
+                'messages': openai_messages,
+                'temperature': self.temperature,
+                'max_tokens': max_tokens,
+                'response_format': self._build_response_format(response_model),
+            }
+            # Omit unset optional fields to preserve the historical request shape and
+            # let the OpenAI SDK choose its own default timeout.
+            if self.config.timeout is not None:
+                request_kwargs['timeout'] = self.config.timeout
+            if self.config.extra_body is not None:
+                request_kwargs['extra_body'] = self.config.extra_body
+
+            response = await self.client.chat.completions.create(**request_kwargs)
             result = response.choices[0].message.content or ''
             # An empty body (refusal, length finish_reason, or a flaky endpoint) would make
             # json.loads raise a cryptic JSONDecodeError; surface a clear error instead.

--- a/tests/llm_client/test_openai_generic_client.py
+++ b/tests/llm_client/test_openai_generic_client.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from types import SimpleNamespace
 
@@ -55,6 +56,85 @@ def _make_client(content: str = '{"foo": "bar"}', error: Exception | None = None
         **kwargs,
     )
     return client, completions
+
+
+@pytest.mark.asyncio
+async def test_llm_config_timeout_and_extra_body_are_forwarded():
+    extra_body = {'guided_json': {'type': 'object'}, 'top_k': 20}
+    completions = DummyChatCompletions()
+    client = OpenAIGenericClient(
+        config=LLMConfig(
+            api_key='test',
+            model='test-model',
+            timeout=12.5,
+            extra_body=extra_body,
+        ),
+        client=DummyClient(completions),
+    )
+
+    await client._generate_response(_messages(), response_model=ResponseModel)
+
+    call = completions.create_calls[0]
+    assert call['timeout'] == 12.5
+    assert call['extra_body'] == extra_body
+
+
+@pytest.mark.asyncio
+async def test_llm_config_optional_fields_are_omitted_by_default():
+    client, completions = _make_client()
+
+    await client._generate_response(_messages(), response_model=ResponseModel)
+
+    call = completions.create_calls[0]
+    assert 'timeout' not in call
+    assert 'extra_body' not in call
+
+
+@pytest.mark.asyncio
+async def test_timeout_and_extra_body_are_preserved_across_retry():
+    extra_body = {'top_k': 20}
+    completions = DummyChatCompletions(error=ValueError('bad response'))
+    client = OpenAIGenericClient(
+        config=LLMConfig(
+            api_key='test',
+            model='test-model',
+            timeout=1.0,
+            extra_body=extra_body,
+        ),
+        client=DummyClient(completions),
+    )
+
+    with pytest.raises(ValueError):
+        await client.generate_response(_messages(), response_model=ResponseModel)
+
+    assert len(completions.create_calls) == 1
+    assert completions.create_calls[0]['timeout'] == 1.0
+    assert completions.create_calls[0]['extra_body'] == extra_body
+
+
+@pytest.mark.asyncio
+async def test_cancellation_is_not_swallowed_or_retried():
+    completions = DummyChatCompletions(error=asyncio.CancelledError())
+    client = OpenAIGenericClient(
+        config=LLMConfig(api_key='test', model='test-model', timeout=1.0),
+        client=DummyClient(completions),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await client.generate_response(_messages(), response_model=ResponseModel)
+
+    assert len(completions.create_calls) == 1
+
+
+def test_llm_config_rejects_invalid_optional_field_types():
+    with pytest.raises(TypeError, match='timeout'):
+        LLMConfig(timeout='10')  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match='extra_body'):
+        LLMConfig(extra_body=['invalid'])  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match='timeout'):
+        LLMConfig(timeout=-1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add optional `timeout` and `extra_body` fields to `LLMConfig`.
- Forward configured values to OpenAI-compatible chat completions while omitting unset values.
- Document provider-dependent `extra_body` support and add regression coverage.

## Design
- Preserve positional and default behavior by adding fields after existing `LLMConfig` arguments.
- Validate timeout type/range and extra_body mapping/key types at configuration construction.
- Build request kwargs conditionally in `OpenAIGenericClient`; cancellation and existing retry behavior remain governed by the existing async/retry path.

## Tests
- `GRAPHITI_TELEMETRY_ENABLED=false .venv/bin/pytest --confcutdir=tests/llm_client tests/llm_client/test_openai_generic_client.py tests/llm_client/test_openai_client.py tests/llm_client/test_azure_openai_client.py -q` (34 passed)
- `.venv/bin/ruff check ...` and `.venv/bin/ruff format --check ...` (passed)
- `git diff --check` (passed)

## Compatibility/Risks
- Both fields default to `None`; existing request payloads are unchanged when omitted.
- `extra_body` support is endpoint-dependent and may be ignored by compatible servers.
- Full `uv sync --extra dev` and repository-wide Pyright were unavailable on macOS x86_64 because the locked Torch version has no compatible wheel; focused Pyright could not resolve third-party imports in the lightweight environment.

Closes #1759
