### PR TITLE
fix(dedupe): make edge contradiction reasoning explicit

### DIFF
--- a/graphiti_core/prompts/dedupe_edges.py
+++ b/graphiti_core/prompts/dedupe_edges.py
@@ -22,6 +22,13 @@ from .models import Message, PromptFunction, PromptVersion
 
 
 class EdgeDuplicate(BaseModel):
+    reasoning: str = Field(
+        default='',
+        description=(
+            'Briefly reason about duplicates and contradictions before the final arrays. '
+            'For every selected fact, cite its continuous idx number.'
+        ),
+    )
     duplicate_facts: list[int] = Field(
         ...,
         description='List of idx values of duplicate facts (only from EXISTING FACTS range). Empty list if none.',
@@ -81,6 +88,11 @@ EXISTING FACTS are indexed first, followed by FACT INVALIDATION CANDIDATES.
    - A fact from EXISTING FACTS can be both a duplicate AND contradicted (e.g., semantically the same but the new fact updates/supersedes it).
    - Return all contradicted idx values in contradicted_facts.
    - If no contradictions, return an empty list for contradicted_facts.
+
+Before returning the arrays, explain your decision in a short reasoning field. '
+For every duplicate or contradiction, explicitly cite its idx number in the reasoning '
+(for example, "idx 2 is contradicted because the value changed"). Then return the '
+duplicate_facts and contradicted_facts arrays using those same idx values.
 
 <EXAMPLE>
 EXISTING FACT: idx=0, "Alice joined Acme Corp in 2020"

--- a/tests/prompts/test_dedupe_edges.py
+++ b/tests/prompts/test_dedupe_edges.py
@@ -1,0 +1,25 @@
+from graphiti_core.prompts.dedupe_edges import EdgeDuplicate, resolve_edge
+
+
+def test_edge_duplicate_schema_collects_reasoning_before_indices():
+    fields = list(EdgeDuplicate.model_fields)
+
+    assert fields[:3] == ['reasoning', 'duplicate_facts', 'contradicted_facts']
+    assert EdgeDuplicate(
+        reasoning='idx 1 contradicts the new fact',
+        duplicate_facts=[],
+        contradicted_facts=[1],
+    ).contradicted_facts == [1]
+
+
+def test_resolve_edge_prompt_requires_index_reasoning_first():
+    prompt = resolve_edge(
+        {
+            'existing_edges': [{'idx': 0, 'fact': 'A'}],
+            'edge_invalidation_candidates': [{'idx': 1, 'fact': 'B'}],
+            'new_edge': 'C',
+        }
+    )[-1].content
+
+    assert 'reasoning' in prompt.lower()
+    assert 'idx number' in prompt.lower()


### PR DESCRIPTION
Closes #1666

## Summary
- Add a reasoning field to the `EdgeDuplicate` structured response before the final index arrays.
- Require prompt reasoning to cite continuous fact indices before returning duplicate/contradiction lists.
- Keep the field optional for backward compatibility with providers that omit it.

## Design
Structured-output field order gives non-reasoning small models an explicit place to analyze facts before emitting indices. The existing duplicate and contradiction arrays remain unchanged, so downstream validation and invalidation behavior is preserved.

## Tests
- `uv run --with pytest --with pytest-asyncio pytest --confcutdir=tests/prompts tests/prompts/test_dedupe_edges.py tests/utils/maintenance/test_edge_operations.py -q` (11 passed)
- Ruff check and format check on changed files.

## Compatibility/Risks
Additive response-model field with an empty default. This improves the prompt/schema contract but cannot guarantee model accuracy for every provider or model. No external LLM calls were required.
