### PR TITLE
fix(nodes): persist and restore episodic metadata

### DIFF
--- a/graphiti_core/driver/falkordb/operations/episode_node_ops.py
+++ b/graphiti_core/driver/falkordb/operations/episode_node_ops.py
@@ -52,6 +52,10 @@ class FalkorEpisodeNodeOperations(EpisodeNodeOperations):
             'valid_at': node.valid_at,
             'source': node.source.value,
         }
+        episode_data = dict(params)
+        for key, value in (node.episode_metadata or {}).items():
+            episode_data.setdefault(key, value)
+        params['episode_data'] = episode_data
         if tx is not None:
             await tx.run(query, **params)
         else:
@@ -71,6 +75,9 @@ class FalkorEpisodeNodeOperations(EpisodeNodeOperations):
             ep = dict(node)
             ep['source'] = str(ep['source'].value)
             ep.pop('labels', None)
+            metadata = ep.pop('episode_metadata', None) or {}
+            for key, value in metadata.items():
+                ep.setdefault(key, value)
             episodes.append(ep)
 
         query = get_episode_node_save_bulk_query(GraphProvider.FALKORDB)

--- a/graphiti_core/driver/kuzu/operations/episode_node_ops.py
+++ b/graphiti_core/driver/kuzu/operations/episode_node_ops.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import json
 import logging
 from datetime import datetime
 from typing import Any
@@ -50,6 +51,7 @@ class KuzuEpisodeNodeOperations(EpisodeNodeOperations):
             'created_at': node.created_at,
             'valid_at': node.valid_at,
             'source': node.source.value,
+            'episode_metadata': json.dumps(node.episode_metadata or {}),
         }
         if tx is not None:
             await tx.run(query, **params)

--- a/graphiti_core/driver/neo4j/operations/episode_node_ops.py
+++ b/graphiti_core/driver/neo4j/operations/episode_node_ops.py
@@ -52,6 +52,10 @@ class Neo4jEpisodeNodeOperations(EpisodeNodeOperations):
             'valid_at': node.valid_at,
             'source': node.source.value,
         }
+        episode_data = dict(params)
+        for key, value in (node.episode_metadata or {}).items():
+            episode_data.setdefault(key, value)
+        params['episode_data'] = episode_data
         if tx is not None:
             await tx.run(query, **params)
         else:
@@ -71,6 +75,9 @@ class Neo4jEpisodeNodeOperations(EpisodeNodeOperations):
             ep = dict(node)
             ep['source'] = str(ep['source'].value)
             ep.pop('labels', None)
+            metadata = ep.pop('episode_metadata', None) or {}
+            for key, value in metadata.items():
+                ep.setdefault(key, value)
             episodes.append(ep)
 
         query = get_episode_node_save_bulk_query(GraphProvider.NEO4J)

--- a/graphiti_core/driver/neptune/operations/episode_node_ops.py
+++ b/graphiti_core/driver/neptune/operations/episode_node_ops.py
@@ -52,6 +52,11 @@ class NeptuneEpisodeNodeOperations(EpisodeNodeOperations):
             'valid_at': node.valid_at,
             'source': node.source.value,
         }
+        episode_data = dict(params)
+        episode_data['entity_edges'] = '|'.join(str(value) for value in node.entity_edges)
+        for key, value in (node.episode_metadata or {}).items():
+            episode_data.setdefault(key, value)
+        params['episode_data'] = episode_data
         if tx is not None:
             await tx.run(query, **params)
         else:
@@ -71,6 +76,10 @@ class NeptuneEpisodeNodeOperations(EpisodeNodeOperations):
             ep = dict(node)
             ep['source'] = str(ep['source'].value)
             ep.pop('labels', None)
+            metadata = ep.pop('episode_metadata', None) or {}
+            ep['entity_edges'] = '|'.join(str(value) for value in ep.get('entity_edges', []))
+            for key, value in metadata.items():
+                ep.setdefault(key, value)
             episodes.append(ep)
 
         query = get_episode_node_save_bulk_query(GraphProvider.NEPTUNE)

--- a/graphiti_core/driver/record_parsers.py
+++ b/graphiti_core/driver/record_parsers.py
@@ -18,7 +18,13 @@ from typing import Any
 
 from graphiti_core.edges import EntityEdge
 from graphiti_core.helpers import parse_db_date
-from graphiti_core.nodes import CommunityNode, EntityNode, EpisodeType, EpisodicNode
+from graphiti_core.nodes import (
+    CommunityNode,
+    EntityNode,
+    EpisodeType,
+    EpisodicNode,
+    _parse_episode_metadata,
+)
 
 
 def entity_node_from_record(record: Any) -> EntityNode:
@@ -105,6 +111,7 @@ def episodic_node_from_record(record: Any) -> EpisodicNode:
         name=record['name'],
         source_description=record['source_description'],
         entity_edges=record['entity_edges'],
+        episode_metadata=_parse_episode_metadata(record.get('episode_metadata')),
     )
 
 

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -995,6 +995,7 @@ class Graphiti:
         custom_extraction_instructions: str | None = None,
         saga: str | SagaNode | None = None,
         saga_previous_episode_uuid: str | None = None,
+        episode_metadata: dict[str, object] | None = None,
     ) -> AddEpisodeResults:
         """
         Process an episode and update the graph.
@@ -1108,8 +1109,11 @@ class Graphiti:
                         source_description=source_description,
                         created_at=now,
                         valid_at=reference_time,
+                        episode_metadata=episode_metadata,
                     )
                 )
+                if uuid is not None and episode_metadata is not None:
+                    episode.episode_metadata = episode_metadata
 
                 # Create default edge type map
                 edge_type_map_default = (
@@ -1328,6 +1332,7 @@ class Graphiti:
                         group_id=group_id,
                         created_at=now,
                         valid_at=episode.reference_time,
+                        episode_metadata=episode.episode_metadata,
                     )
                     for episode in bulk_episodes
                 ]

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -1043,6 +1043,8 @@ class Graphiti:
             query to find the most recent episode. Useful for efficiently adding multiple episodes
             to the same saga in sequence. The returned AddEpisodeResults.episode.uuid can be passed
             as this parameter for the next episode.
+        episode_metadata : dict[str, object] | None
+            Optional customer-defined metadata to persist on the episodic node for filtering.
 
         Returns
         -------

--- a/graphiti_core/models/nodes/node_db_queries.py
+++ b/graphiti_core/models/nodes/node_db_queries.py
@@ -32,8 +32,7 @@ def get_episode_node_save_query(provider: GraphProvider) -> str:
         case GraphProvider.NEPTUNE:
             return """
                 MERGE (n:Episodic {uuid: $uuid})
-                SET n = {uuid: $uuid, name: $name, group_id: $group_id, source_description: $source_description, source: $source, content: $content,
-                entity_edges: join([x IN coalesce($entity_edges, []) | toString(x) ], '|'), created_at: $created_at, valid_at: $valid_at}
+                SET n = $episode_data
                 RETURN n.uuid AS uuid
             """
         case GraphProvider.KUZU:
@@ -48,20 +47,19 @@ def get_episode_node_save_query(provider: GraphProvider) -> str:
                     n.content = $content,
                     n.valid_at = $valid_at,
                     n.entity_edges = $entity_edges
+                    , n.episode_metadata = $episode_metadata
                 RETURN n.uuid AS uuid
             """
         case GraphProvider.FALKORDB:
             return """
                 MERGE (n:Episodic {uuid: $uuid})
-                SET n = {uuid: $uuid, name: $name, group_id: $group_id, source_description: $source_description, source: $source, content: $content,
-                entity_edges: $entity_edges, created_at: $created_at, valid_at: $valid_at}
+                SET n = $episode_data
                 RETURN n.uuid AS uuid
             """
         case _:  # Neo4j
             return """
                 MERGE (n:Episodic {uuid: $uuid})
-                SET n = {uuid: $uuid, name: $name, group_id: $group_id, source_description: $source_description, source: $source, content: $content,
-                entity_edges: $entity_edges, created_at: $created_at, valid_at: $valid_at}
+                SET n = $episode_data
                 RETURN n.uuid AS uuid
             """
 
@@ -72,9 +70,7 @@ def get_episode_node_save_bulk_query(provider: GraphProvider) -> str:
             return """
                 UNWIND $episodes AS episode
                 MERGE (n:Episodic {uuid: episode.uuid})
-                SET n = {uuid: episode.uuid, name: episode.name, group_id: episode.group_id, source_description: episode.source_description,
-                    source: episode.source, content: episode.content,
-                entity_edges: join([x IN coalesce(episode.entity_edges, []) | toString(x) ], '|'), created_at: episode.created_at, valid_at: episode.valid_at}
+                SET n = episode
                 RETURN n.uuid AS uuid
             """
         case GraphProvider.KUZU:
@@ -88,23 +84,22 @@ def get_episode_node_save_bulk_query(provider: GraphProvider) -> str:
                     n.source_description = $source_description,
                     n.content = $content,
                     n.valid_at = $valid_at,
-                    n.entity_edges = $entity_edges
+                    n.entity_edges = $entity_edges,
+                    n.episode_metadata = $episode_metadata
                 RETURN n.uuid AS uuid
             """
         case GraphProvider.FALKORDB:
             return """
                 UNWIND $episodes AS episode
                 MERGE (n:Episodic {uuid: episode.uuid})
-                SET n = {uuid: episode.uuid, name: episode.name, group_id: episode.group_id, source_description: episode.source_description, source: episode.source, content: episode.content, 
-                entity_edges: episode.entity_edges, created_at: episode.created_at, valid_at: episode.valid_at}
+                SET n = episode
                 RETURN n.uuid AS uuid
             """
         case _:  # Neo4j
             return """
                 UNWIND $episodes AS episode
                 MERGE (n:Episodic {uuid: episode.uuid})
-                SET n = {uuid: episode.uuid, name: episode.name, group_id: episode.group_id, source_description: episode.source_description, source: episode.source, content: episode.content, 
-                entity_edges: episode.entity_edges, created_at: episode.created_at, valid_at: episode.valid_at}
+                SET n = episode
                 RETURN n.uuid AS uuid
             """
 
@@ -118,7 +113,8 @@ EPISODIC_NODE_RETURN = """
     e.source_description AS source_description,
     e.content AS content,
     e.valid_at AS valid_at,
-    e.entity_edges AS entity_edges
+    e.entity_edges AS entity_edges,
+    properties(e) AS episode_metadata
 """
 
 EPISODIC_NODE_RETURN_NEPTUNE = """
@@ -130,7 +126,8 @@ EPISODIC_NODE_RETURN_NEPTUNE = """
     e.group_id AS group_id,
     e.source_description AS source_description,
     e.source AS source,
-    split(e.entity_edges, ",") AS entity_edges
+    split(e.entity_edges, ",") AS entity_edges,
+    properties(e) AS episode_metadata
 """
 
 

--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -354,6 +354,8 @@ class EpisodicNode(Node):
             episode_args['episode_metadata'] = json.dumps(self.episode_metadata or {})
         else:
             episode_data = dict(episode_args)
+            if driver.provider == GraphProvider.NEPTUNE:
+                episode_data['entity_edges'] = '|'.join(str(value) for value in self.entity_edges)
             for key, value in (self.episode_metadata or {}).items():
                 if key not in episode_data:
                     episode_data[key] = value

--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -350,6 +350,15 @@ class EpisodicNode(Node):
             'source': self.source.value,
         }
 
+        if driver.provider == GraphProvider.KUZU:
+            episode_args['episode_metadata'] = json.dumps(self.episode_metadata or {})
+        else:
+            episode_data = dict(episode_args)
+            for key, value in (self.episode_metadata or {}).items():
+                if key not in episode_data:
+                    episode_data[key] = value
+            episode_args['episode_data'] = episode_data
+
         result = await driver.execute_query(
             get_episode_node_save_query(driver.provider), **episode_args
         )
@@ -1044,7 +1053,30 @@ def get_episodic_node_from_record(record: Any) -> EpisodicNode:
         name=record['name'],
         source_description=record['source_description'],
         entity_edges=record['entity_edges'],
+        episode_metadata=_parse_episode_metadata(record.get('episode_metadata')),
     )
+
+
+def _parse_episode_metadata(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return json.loads(value) if value else None
+    if isinstance(value, dict):
+        reserved = {
+            'uuid',
+            'name',
+            'group_id',
+            'created_at',
+            'source',
+            'source_description',
+            'content',
+            'valid_at',
+            'entity_edges',
+            'episode_metadata',
+        }
+        return {key: item for key, item in value.items() if key not in reserved}
+    return None
 
 
 def get_entity_node_from_record(record: Any, provider: GraphProvider) -> EntityNode:

--- a/graphiti_core/utils/bulk_utils.py
+++ b/graphiti_core/utils/bulk_utils.py
@@ -166,6 +166,8 @@ async def add_nodes_and_edges_bulk_tx(
         if driver.provider == GraphProvider.KUZU:
             episode['episode_metadata'] = json.dumps(metadata)
         else:
+            if driver.provider == GraphProvider.NEPTUNE:
+                episode['entity_edges'] = '|'.join(str(value) for value in episode['entity_edges'])
             for key, value in metadata.items():
                 episode.setdefault(key, value)
 

--- a/graphiti_core/utils/bulk_utils.py
+++ b/graphiti_core/utils/bulk_utils.py
@@ -105,6 +105,7 @@ class RawEpisode(BaseModel):
     source_description: str
     source: EpisodeType
     reference_time: datetime
+    episode_metadata: dict[str, Any] | None = None
 
 
 async def retrieve_previous_episodes_bulk(
@@ -161,6 +162,12 @@ async def add_nodes_and_edges_bulk_tx(
     for episode in episodes:
         episode['source'] = str(episode['source'].value)
         episode.pop('labels', None)
+        metadata = episode.pop('episode_metadata', None) or {}
+        if driver.provider == GraphProvider.KUZU:
+            episode['episode_metadata'] = json.dumps(metadata)
+        else:
+            for key, value in metadata.items():
+                episode.setdefault(key, value)
 
     nodes = []
 

--- a/tests/test_episode_metadata.py
+++ b/tests/test_episode_metadata.py
@@ -49,4 +49,3 @@ async def test_episodic_node_save_passes_metadata():
 
     kwargs = driver.execute_query.await_args.kwargs
     assert kwargs['episode_data']['customer_id'] == 'customer-1'
-

--- a/tests/test_episode_metadata.py
+++ b/tests/test_episode_metadata.py
@@ -1,0 +1,52 @@
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.record_parsers import episodic_node_from_record
+from graphiti_core.nodes import EpisodeType, EpisodicNode
+
+
+def _record(metadata):
+    return {
+        'content': 'content',
+        'created_at': datetime(2025, 1, 1, tzinfo=timezone.utc),
+        'valid_at': datetime(2025, 1, 1, tzinfo=timezone.utc),
+        'uuid': 'episode-1',
+        'group_id': 'group',
+        'source': 'text',
+        'name': 'Episode',
+        'source_description': 'test',
+        'entity_edges': [],
+        'episode_metadata': metadata,
+    }
+
+
+def test_episodic_node_record_restores_metadata():
+    metadata = {'customer_id': 'customer-1', 'priority': 3}
+
+    episode = episodic_node_from_record(_record(metadata))
+
+    assert episode.episode_metadata == metadata
+
+
+@pytest.mark.asyncio
+async def test_episodic_node_save_passes_metadata():
+    driver = MagicMock(provider=GraphProvider.NEO4J, graph_operations_interface=None)
+    driver.execute_query = AsyncMock(return_value=([], [], None))
+    episode = EpisodicNode(
+        name='Episode',
+        group_id='group',
+        source=EpisodeType.text,
+        source_description='test',
+        content='content',
+        valid_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        episode_metadata={'customer_id': 'customer-1'},
+    )
+
+    await episode.save(driver)
+
+    kwargs = driver.execute_query.await_args.kwargs
+    assert kwargs['episode_data']['customer_id'] == 'customer-1'
+


### PR DESCRIPTION
Closes #1769

## Summary
- Add an `episode_metadata` input to `Graphiti.add_episode()` and the bulk path.
- Persist metadata across Neo4j, FalkorDB, Neptune, and Kuzu save operations.
- Restore metadata from read paths with reserved-field filtering and add regression coverage.

## Design
Neo4j/FalkorDB/Neptune flatten caller metadata into top-level node properties, matching `EntityNode.attributes`; Kuzu stores JSON because it requires fixed properties. Reads reconstruct the model field without leaking reserved episode fields.

## Tests
- `uv run --with pytest --with pytest-asyncio pytest --confcutdir=tests tests/test_episode_metadata.py -q` (2 passed)
- Ruff check and format check on changed files.

## Compatibility/Risks
Additive public parameter with `None` default. Metadata must obey the existing backend property-value constraints; nested values unsupported by a backend may still be rejected. Live database integration tests were not run because Neo4j/FalkorDB/Neptune/Kuzu services were unavailable.
