### PR TITLE
feat(mcp): report suppressed superseded facts, reranker and scores

### DIFF
--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -44,7 +44,12 @@ from services.factories import (
     LLMClientFactory,
 )
 from services.queue_service import QueueService
-from utils.formatting import format_fact_result, to_edge_result, to_node_result
+from utils.formatting import (
+    format_fact_result,
+    is_invalidated,
+    to_edge_result,
+    to_node_result,
+)
 from utils.type_config import (
     build_edge_type_map,
     build_edge_types,
@@ -548,8 +553,10 @@ async def search_nodes(
             NODE_HYBRID_SEARCH_RRF,
         )
 
-        node_config = (
-            NODE_HYBRID_SEARCH_NODE_DISTANCE if center_node_uuid else NODE_HYBRID_SEARCH_RRF
+        node_config, ranker = (
+            (NODE_HYBRID_SEARCH_NODE_DISTANCE, 'node_distance')
+            if center_node_uuid
+            else (NODE_HYBRID_SEARCH_RRF, 'rrf')
         )
         results = await client.search_(
             query=query,
@@ -563,12 +570,19 @@ async def search_nodes(
         nodes = results.nodes[:max_nodes] if results.nodes else []
 
         if not nodes:
-            return NodeSearchResponse(message='No relevant nodes found', nodes=[])
+            return NodeSearchResponse(message='No relevant nodes found', nodes=[], ranker=ranker)
 
-        # Format the results (embeddings stripped by to_node_result)
-        node_results = [to_node_result(node) for node in nodes]
+        # Format the results (embeddings stripped by to_node_result). Scores are
+        # positional and can be shorter than nodes if a reranker returns fewer.
+        scores = results.node_reranker_scores[:max_nodes]
+        node_results = [
+            to_node_result(node, scores[i] if i < len(scores) else None)
+            for i, node in enumerate(nodes)
+        ]
 
-        return NodeSearchResponse(message='Nodes retrieved successfully', nodes=node_results)
+        return NodeSearchResponse(
+            message='Nodes retrieved successfully', nodes=node_results, ranker=ranker
+        )
     except Exception as e:
         error_msg = str(e)
         logger.error(f'Error searching nodes: {error_msg}')
@@ -586,6 +600,7 @@ async def search_memory_facts(
     valid_at_before: str | None = None,
     invalid_at_after: str | None = None,
     invalid_at_before: str | None = None,
+    exclude_invalidated: bool = False,
 ) -> FactSearchResponse | ErrorResponse:
     """Search the graph memory for relevant facts (entity edges).
 
@@ -601,6 +616,17 @@ async def search_memory_facts(
         valid_at_before: Optional ISO-8601 upper bound on a fact's valid_at
         invalid_at_after: Optional ISO-8601 lower bound on a fact's invalid_at
         invalid_at_before: Optional ISO-8601 upper bound on a fact's invalid_at
+        exclude_invalidated: Drop superseded facts (those carrying invalid_at or
+            expired_at) from the results. Off by default: Graphiti is bi-temporal,
+            and a superseded fact is often exactly what the caller wants to see.
+            Turning it on filters the ranked window rather than re-ranking without
+            them, so the response can hold fewer than max_facts facts;
+            `suppressed_invalidated` reports how many were dropped.
+
+    Returns:
+        The facts, the name of the reranker that ordered them (`ranker`), and
+        `suppressed_invalidated` — the number of superseded facts dropped from the
+        window, which is 0 unless `exclude_invalidated` is set.
     """
     global graphiti_service
 
@@ -636,19 +662,63 @@ async def search_memory_facts(
             else []
         )
 
-        relevant_edges = await client.search(
-            group_ids=effective_group_ids,
-            query=query,
-            num_results=max_facts,
-            center_node_uuid=center_node_uuid,
-            search_filter=search_filter,
+        from graphiti_core.search.search_config_recipes import (
+            EDGE_HYBRID_SEARCH_NODE_DISTANCE,
+            EDGE_HYBRID_SEARCH_RRF,
         )
 
-        if not relevant_edges:
-            return FactSearchResponse(message='No relevant facts found', facts=[])
+        # Mirrors Graphiti.search()'s recipe choice, but goes through search_() so the
+        # reranker scores come back with the edges. model_copy is deliberate: the
+        # recipes are module-level singletons and Graphiti.search() sets .limit on the
+        # shared object, which leaks the last caller's limit into concurrent searches.
+        edge_config, ranker = (
+            (EDGE_HYBRID_SEARCH_NODE_DISTANCE, 'node_distance')
+            if center_node_uuid
+            else (EDGE_HYBRID_SEARCH_RRF, 'rrf')
+        )
+        edge_config = edge_config.model_copy(deep=True, update={'limit': max_facts})
 
-        facts = [format_fact_result(edge) for edge in relevant_edges]
-        return FactSearchResponse(message='Facts retrieved successfully', facts=facts)
+        results = await client.search_(
+            query=query,
+            config=edge_config,
+            group_ids=effective_group_ids,
+            center_node_uuid=center_node_uuid,
+            search_filter=search_filter if search_filter is not None else SearchFilters(),
+        )
+
+        relevant_edges = results.edges[:max_facts]
+        # Scores are positional and can be shorter than the edges if a reranker
+        # returns fewer; pair them up rather than assuming equal length.
+        scores = results.edge_reranker_scores[:max_facts]
+        scored = [
+            (edge, scores[i] if i < len(scores) else None) for i, edge in enumerate(relevant_edges)
+        ]
+
+        kept = [pair for pair in scored if not (exclude_invalidated and is_invalidated(pair[0]))]
+        suppressed_invalidated = len(scored) - len(kept)
+
+        if not kept:
+            # Distinguish "nothing matched" from "everything that matched was superseded",
+            # so a caller that filtered does not read an empty result as absence of memory.
+            message = (
+                f'No current facts found; {suppressed_invalidated} superseded fact(s) suppressed'
+                if suppressed_invalidated
+                else 'No relevant facts found'
+            )
+            return FactSearchResponse(
+                message=message,
+                facts=[],
+                ranker=ranker,
+                suppressed_invalidated=suppressed_invalidated,
+            )
+
+        facts = [format_fact_result(edge, score) for edge, score in kept]
+        return FactSearchResponse(
+            message='Facts retrieved successfully',
+            facts=facts,
+            ranker=ranker,
+            suppressed_invalidated=suppressed_invalidated,
+        )
     except Exception as e:
         error_msg = str(e)
         logger.error(f'Error searching facts: {error_msg}')

--- a/mcp_server/src/models/response_types.py
+++ b/mcp_server/src/models/response_types.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 
 class ErrorResponse(TypedDict):
@@ -21,16 +21,25 @@ class NodeResult(TypedDict):
     summary: str | None
     group_id: str
     attributes: dict[str, Any]
+    score: NotRequired[float]
 
 
 class NodeSearchResponse(TypedDict):
     message: str
     nodes: list[NodeResult]
+    # Which reranker produced this ordering. Deployment-visible on purpose: scores
+    # from different rerankers are not comparable, so a client that thresholds on
+    # `score` needs to know which ranker it is thresholding.
+    ranker: str
 
 
 class FactSearchResponse(TypedDict):
     message: str
     facts: list[dict[str, Any]]
+    ranker: str
+    # How many invalidated facts were dropped from the returned window. Always
+    # present; 0 when `exclude_invalidated` is False, since nothing was dropped.
+    suppressed_invalidated: int
 
 
 class EpisodeSearchResponse(TypedDict):

--- a/mcp_server/src/utils/formatting.py
+++ b/mcp_server/src/utils/formatting.py
@@ -8,11 +8,17 @@ from graphiti_core.nodes import EntityNode
 from models.response_types import EdgeResult, NodeResult
 
 
-def to_node_result(node: EntityNode) -> NodeResult:
-    """Build a NodeResult TypedDict from an EntityNode, dropping embeddings."""
+def to_node_result(node: EntityNode, score: float | None = None) -> NodeResult:
+    """Build a NodeResult TypedDict from an EntityNode, dropping embeddings.
+
+    Args:
+        node: The EntityNode to format
+        score: Optional reranker score for this node. Omitted from the result when
+            None, so callers that do not have scores emit the same shape as before.
+    """
     attrs = node.attributes if node.attributes else {}
     attrs = {k: v for k, v in attrs.items() if 'embedding' not in k.lower()}
-    return NodeResult(
+    result = NodeResult(
         uuid=node.uuid,
         name=node.name,
         labels=node.labels if node.labels else [],
@@ -21,6 +27,9 @@ def to_node_result(node: EntityNode) -> NodeResult:
         group_id=node.group_id,
         attributes=attrs,
     )
+    if score is not None:
+        result['score'] = score
+    return result
 
 
 def to_edge_result(edge: EntityEdge) -> EdgeResult:
@@ -61,13 +70,15 @@ def format_node_result(node: EntityNode) -> dict[str, Any]:
     return result
 
 
-def format_fact_result(edge: EntityEdge) -> dict[str, Any]:
+def format_fact_result(edge: EntityEdge, score: float | None = None) -> dict[str, Any]:
     """Format an entity edge into a readable result.
 
     Since EntityEdge is a Pydantic BaseModel, we can use its built-in serialization capabilities.
 
     Args:
         edge: The EntityEdge to format
+        score: Optional reranker score for this edge. Omitted from the result when
+            None, so callers that do not have scores emit the same shape as before.
 
     Returns:
         A dictionary representation of the edge with serialized dates and excluded embeddings
@@ -79,4 +90,16 @@ def format_fact_result(edge: EntityEdge) -> dict[str, Any]:
         },
     )
     result.get('attributes', {}).pop('fact_embedding', None)
+    if score is not None:
+        result['score'] = score
     return result
+
+
+def is_invalidated(edge: EntityEdge) -> bool:
+    """Whether this fact has been superseded.
+
+    ``invalid_at`` is when the fact stopped being true in the world; ``expired_at``
+    is when Graphiti recorded that it had been superseded. Either one marks the
+    fact as no longer current, and edges carry them independently.
+    """
+    return edge.invalid_at is not None or edge.expired_at is not None

--- a/mcp_server/tests/test_search_invalidated_signal.py
+++ b/mcp_server/tests/test_search_invalidated_signal.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Unit tests for the search observability additions to the MCP search tools.
+
+Covers `exclude_invalidated` / `suppressed_invalidated` on `search_memory_facts`,
+the `ranker` label on both search tools, and the per-result `score`. These drive
+the tool functions against a mocked Graphiti client, so they need no database,
+no LLM, and run in the default (non-integration) suite.
+"""
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from graphiti_core import Graphiti
+from graphiti_core.edges import EntityEdge
+from graphiti_core.nodes import EntityNode
+from graphiti_core.search.search_config import SearchResults
+
+# Add the src directory to the path (mirrors the other unit tests)
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+import graphiti_mcp_server as server  # noqa: E402
+from utils.formatting import format_fact_result, is_invalidated, to_node_result  # noqa: E402
+
+NOW = datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)
+
+
+def make_edge(name: str, *, invalid_at=None, expired_at=None) -> EntityEdge:
+    edge = EntityEdge(
+        uuid=f'edge-{name}',
+        group_id='g',
+        source_node_uuid='src',
+        target_node_uuid='tgt',
+        name=name,
+        fact=f'fact about {name}',
+        created_at=NOW,
+        valid_at=NOW,
+        invalid_at=invalid_at,
+    )
+    # expired_at is set by the invalidation write path rather than at construction.
+    edge.expired_at = expired_at
+    return edge
+
+
+def make_node(name: str) -> EntityNode:
+    return EntityNode(uuid=f'node-{name}', name=name, group_id='g', created_at=NOW)
+
+
+@pytest.fixture
+def fake_service(monkeypatch):
+    """Install a graphiti_service whose client returns canned SearchResults."""
+    client = AsyncMock(spec=Graphiti)
+    service = AsyncMock()
+    service.get_client = AsyncMock(return_value=client)
+    monkeypatch.setattr(server, 'graphiti_service', service)
+    return client
+
+
+class TestIsInvalidated:
+    """Either temporal marker retires a fact; they are set independently."""
+
+    def test_live_edge(self):
+        assert is_invalidated(make_edge('live')) is False
+
+    def test_invalid_at_only(self):
+        assert is_invalidated(make_edge('a', invalid_at=NOW)) is True
+
+    def test_expired_at_only(self):
+        # A fact superseded by dedupe carries expired_at with no invalid_at.
+        assert is_invalidated(make_edge('b', expired_at=NOW)) is True
+
+
+class TestSuppressedInvalidated:
+    @pytest.mark.asyncio
+    async def test_off_by_default_returns_everything(self, fake_service):
+        edges = [make_edge('live'), make_edge('dead', invalid_at=NOW)]
+        fake_service.search_.return_value = SearchResults(
+            edges=edges, edge_reranker_scores=[0.9, 0.8]
+        )
+
+        result = await server.search_memory_facts(query='q', group_ids='g')
+
+        assert len(result['facts']) == 2
+        assert result['suppressed_invalidated'] == 0
+
+    @pytest.mark.asyncio
+    async def test_opt_in_drops_and_counts(self, fake_service):
+        edges = [
+            make_edge('live'),
+            make_edge('dead1', invalid_at=NOW),
+            make_edge('dead2', expired_at=NOW),
+        ]
+        fake_service.search_.return_value = SearchResults(
+            edges=edges, edge_reranker_scores=[0.9, 0.8, 0.7]
+        )
+
+        result = await server.search_memory_facts(
+            query='q', group_ids='g', exclude_invalidated=True
+        )
+
+        assert [f['name'] for f in result['facts']] == ['live']
+        assert result['suppressed_invalidated'] == 2
+
+    @pytest.mark.asyncio
+    async def test_all_suppressed_says_so(self, fake_service):
+        """An empty result after filtering must not read as absence of memory."""
+        fake_service.search_.return_value = SearchResults(
+            edges=[make_edge('dead', invalid_at=NOW)], edge_reranker_scores=[0.9]
+        )
+
+        result = await server.search_memory_facts(
+            query='q', group_ids='g', exclude_invalidated=True
+        )
+
+        assert result['facts'] == []
+        assert result['suppressed_invalidated'] == 1
+        assert 'superseded' in result['message']
+        assert result['message'] != 'No relevant facts found'
+
+    @pytest.mark.asyncio
+    async def test_genuinely_empty_keeps_original_message(self, fake_service):
+        fake_service.search_.return_value = SearchResults(edges=[], edge_reranker_scores=[])
+
+        result = await server.search_memory_facts(
+            query='q', group_ids='g', exclude_invalidated=True
+        )
+
+        assert result['facts'] == []
+        assert result['suppressed_invalidated'] == 0
+        assert result['message'] == 'No relevant facts found'
+
+
+class TestRankerAndScores:
+    @pytest.mark.asyncio
+    async def test_facts_report_rrf_without_center_node(self, fake_service):
+        fake_service.search_.return_value = SearchResults(
+            edges=[make_edge('a')], edge_reranker_scores=[0.42]
+        )
+
+        result = await server.search_memory_facts(query='q', group_ids='g')
+
+        assert result['ranker'] == 'rrf'
+        assert result['facts'][0]['score'] == 0.42
+
+    @pytest.mark.asyncio
+    async def test_facts_report_node_distance_with_center_node(self, fake_service):
+        fake_service.search_.return_value = SearchResults(
+            edges=[make_edge('a')], edge_reranker_scores=[0.42]
+        )
+
+        result = await server.search_memory_facts(
+            query='q', group_ids='g', center_node_uuid='node-1'
+        )
+
+        assert result['ranker'] == 'node_distance'
+
+    @pytest.mark.asyncio
+    async def test_nodes_report_ranker_and_scores(self, fake_service):
+        fake_service.search_.return_value = SearchResults(
+            nodes=[make_node('a')], node_reranker_scores=[0.31]
+        )
+
+        result = await server.search_nodes(query='q', group_ids='g')
+
+        assert result['ranker'] == 'rrf'
+        assert result['nodes'][0]['score'] == 0.31
+
+    @pytest.mark.asyncio
+    async def test_ranker_present_on_empty_results(self, fake_service):
+        """A client thresholding on score needs the ranker even with no hits."""
+        fake_service.search_.return_value = SearchResults(edges=[], nodes=[])
+
+        facts = await server.search_memory_facts(query='q', group_ids='g')
+        nodes = await server.search_nodes(query='q', group_ids='g')
+
+        assert facts['ranker'] == 'rrf'
+        assert nodes['ranker'] == 'rrf'
+
+    @pytest.mark.asyncio
+    async def test_missing_scores_are_omitted_not_faked(self, fake_service):
+        """A reranker returning fewer scores than results must not invent zeros."""
+        fake_service.search_.return_value = SearchResults(
+            edges=[make_edge('a'), make_edge('b')], edge_reranker_scores=[0.9]
+        )
+
+        result = await server.search_memory_facts(query='q', group_ids='g')
+
+        assert result['facts'][0]['score'] == 0.9
+        assert 'score' not in result['facts'][1]
+
+
+class TestLimitIsolation:
+    @pytest.mark.asyncio
+    async def test_limit_does_not_leak_into_the_shared_recipe(self, fake_service):
+        """The recipes are module-level singletons; max_facts must not mutate them."""
+        from graphiti_core.search.search_config_recipes import EDGE_HYBRID_SEARCH_RRF
+
+        before = EDGE_HYBRID_SEARCH_RRF.limit
+        fake_service.search_.return_value = SearchResults(edges=[], edge_reranker_scores=[])
+
+        await server.search_memory_facts(query='q', group_ids='g', max_facts=99)
+
+        assert EDGE_HYBRID_SEARCH_RRF.limit == before
+        assert fake_service.search_.call_args.kwargs['config'].limit == 99
+
+
+class TestFormattingHelpers:
+    def test_score_omitted_when_none(self):
+        assert 'score' not in format_fact_result(make_edge('a'))
+        assert 'score' not in to_node_result(make_node('a'))
+
+    def test_score_included_when_given(self):
+        assert format_fact_result(make_edge('a'), 0.5)['score'] == 0.5
+        assert to_node_result(make_node('a'), 0.5)['score'] == 0.5


### PR DESCRIPTION
## Summary

Implements the observability half of #1645: the MCP search tools now report which reranker ordered the results, each result's score, and how many superseded facts were suppressed.

#1647 took the same issue and was closed by its author for a reason worth preserving:

> `exclude_invalidated: true` is the wrong default (...) Graphiti is bi-temporal by design; filtering superseded facts at the read layer discards that, and `invalid_at` is already on every result.

That objection is respected here. The filter is **opt-in and off by default**, and the piece the author said he'd most want exists:

> `suppressed_invalidated` is the piece I'd most want to exist — it delivers the "this expired" signal without returning history the caller didn't ask for, and it doesn't require the filter to default on at all.

The reranker-choice half of #1645 is deliberately **not** here — it was measured net-zero and #1637 covers it.

## What changes

### `search_memory_facts`

| Field | Behavior |
| --- | --- |
| `exclude_invalidated: bool = False` | New parameter. Drops facts carrying `invalid_at` **or** `expired_at`. |
| `suppressed_invalidated: int` | New response field. How many were dropped. Always present; `0` when the filter is off. |
| `ranker: str` | New response field. `rrf` or `node_distance`. |
| `score` | New per-fact field. |

Both temporal markers are checked, not just `invalid_at`: dedupe supersession sets `expired_at` with no `invalid_at`, so testing one alone misses half the retired facts.

An empty result *after* filtering now says so explicitly rather than returning `"No relevant facts found"` — a caller would otherwise read that as absence of memory rather than absence of **current** memory.

### `search_nodes`

Gains `ranker` at the response level and `score` per node.

### Why `ranker` and not just `score`

These tools already switch between RRF and node-distance depending on whether `center_node_uuid` was passed, and scores from different rerankers are not comparable. A client thresholding on `score > 0.4` silently breaks when the ranking changes underneath it, with no error anywhere. `ranker` is emitted even on empty results for that reason.

A score is **omitted** rather than defaulted to `0` when a reranker returns fewer scores than results — a fabricated zero is worse than a missing key for anything that filters on score.

## Implementation notes

**`search_()` instead of `search()`.** Scores only come back on `SearchResults`, so `search_memory_facts` now mirrors the recipe choice `Graphiti.search()` makes rather than calling it. That path sets `.limit` on a module-level recipe singleton, so `max_facts` from one call leaks into concurrent ones; this uses `model_copy` instead, with a test pinning it.

**Filtering applies to the ranked window,** not a re-ranking without the superseded facts. So an opted-in response can hold fewer than `max_facts`. That is deliberate: it keeps this to one query and makes the count exact. Documented in the tool docstring. Happy to switch to a DB-level `expired_at IS NULL` filter if you'd rather have a full window, but that trades the exact count for a second query.

**`graphiti_core` is untouched.** Everything lives in `mcp_server/`.

## Motivating measurement

Production graph on Neo4j — 109 episodes, 887 facts, 143 carrying `invalid_at` (16.1%; 49.2% within one partition). One real query returned **6 superseded facts in its top 8**, two of which contradicted each other, with nothing in the ranking separating them from the 2 current ones.

Worth recording for anyone picking this up, from the #1645 thread and confirmed here: Graphiti stores no back-link from a retired edge to its successor — `edge_operations` just stamps `invalid_at`/`expired_at`. The stale fact and the fact that replaced it are independent edges competing in the same ranking. Without this signal, the caller cannot tell them apart without inspecting `invalid_at` on every result.

## Testing

- 15 new unit tests (`mcp_server/tests/test_search_invalidated_signal.py`) driving both tools against a mocked Graphiti client — no database, no LLM, runs in the default suite.
- Existing non-integration suite: 74 passed, 1 skipped.
- `ruff check`, `ruff format --check`, and `pyright` clean.

Three modules fail collection in the suite both before and after this change (`test_async_operations.py`, `test_cross_encoder_factory.py`, `test_stress_load.py`) — missing optional deps and a test-path import, unrelated to this PR.

— 🤖 Claude Opus 5
