### PR TITLE
feat(mcp): read across every group with '*', and echo the scope read

### DIFF
--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -46,12 +46,14 @@ from services.factories import (
 from services.queue_service import QueueService
 from utils.formatting import format_fact_result, to_edge_result, to_node_result
 from utils.type_config import (
+    ALL_GROUPS,
     build_edge_type_map,
     build_edge_types,
     build_entity_types,
     build_fact_search_filters,
     coerce_group_ids,
     parse_reference_time,
+    resolve_read_group_ids,
 )
 
 # Load .env file from mcp_server directory
@@ -511,7 +513,12 @@ async def search_nodes(
     Args:
         query: The search query
         group_ids: Optional group ID, or list of group IDs, to filter results (a single
-            string is accepted and treated as a one-element list)
+            string is accepted and treated as a one-element list). Pass '*' to read
+            across every group. Omitted means the server's configured default group,
+            so a single-tenant deployment never widens its scope by accident. The
+            group actually read is echoed back as `searched_group_ids` (None = all),
+            so an empty result reports its scope rather than reading as "nothing
+            exists".
         max_nodes: Maximum number of nodes to return (default: 10)
         entity_types: Optional list of entity type names (node labels) to filter by
         center_node_uuid: Optional UUID of a node to center the search around. Results
@@ -525,15 +532,10 @@ async def search_nodes(
     try:
         client = await graphiti_service.get_client()
 
-        # Accept a scalar group_id or a list; fall back to the default when omitted.
+        # Accept a scalar group_id or a list; '*' widens the read to every group,
+        # omission keeps it on the configured default.
         group_ids = coerce_group_ids(group_ids)
-        effective_group_ids = (
-            group_ids
-            if group_ids is not None
-            else [config.graphiti.group_id]
-            if config.graphiti.group_id
-            else []
-        )
+        effective_group_ids = resolve_read_group_ids(group_ids, config.graphiti.group_id)
 
         # Create search filters
         search_filters = SearchFilters(
@@ -563,12 +565,20 @@ async def search_nodes(
         nodes = results.nodes[:max_nodes] if results.nodes else []
 
         if not nodes:
-            return NodeSearchResponse(message='No relevant nodes found', nodes=[])
+            return NodeSearchResponse(
+                message='No relevant nodes found',
+                nodes=[],
+                searched_group_ids=effective_group_ids,
+            )
 
         # Format the results (embeddings stripped by to_node_result)
         node_results = [to_node_result(node) for node in nodes]
 
-        return NodeSearchResponse(message='Nodes retrieved successfully', nodes=node_results)
+        return NodeSearchResponse(
+            message='Nodes retrieved successfully',
+            nodes=node_results,
+            searched_group_ids=effective_group_ids,
+        )
     except Exception as e:
         error_msg = str(e)
         logger.error(f'Error searching nodes: {error_msg}')
@@ -592,7 +602,12 @@ async def search_memory_facts(
     Args:
         query: The search query
         group_ids: Optional group ID, or list of group IDs, to filter results (a single
-            string is accepted and treated as a one-element list)
+            string is accepted and treated as a one-element list). Pass '*' to read
+            across every group. Omitted means the server's configured default group,
+            so a single-tenant deployment never widens its scope by accident. The
+            group actually read is echoed back as `searched_group_ids` (None = all),
+            so an empty result reports its scope rather than reading as "nothing
+            exists".
         max_facts: Maximum number of facts to return (default: 10)
         center_node_uuid: Optional UUID of a node to center the search around
         edge_types: Optional list of edge (fact) type names to filter by
@@ -626,15 +641,10 @@ async def search_memory_facts(
 
         client = await graphiti_service.get_client()
 
-        # Accept a scalar group_id or a list; fall back to the default when omitted.
+        # Accept a scalar group_id or a list; '*' widens the read to every group,
+        # omission keeps it on the configured default.
         group_ids = coerce_group_ids(group_ids)
-        effective_group_ids = (
-            group_ids
-            if group_ids is not None
-            else [config.graphiti.group_id]
-            if config.graphiti.group_id
-            else []
-        )
+        effective_group_ids = resolve_read_group_ids(group_ids, config.graphiti.group_id)
 
         relevant_edges = await client.search(
             group_ids=effective_group_ids,
@@ -645,10 +655,18 @@ async def search_memory_facts(
         )
 
         if not relevant_edges:
-            return FactSearchResponse(message='No relevant facts found', facts=[])
+            return FactSearchResponse(
+                message='No relevant facts found',
+                facts=[],
+                searched_group_ids=effective_group_ids,
+            )
 
         facts = [format_fact_result(edge) for edge in relevant_edges]
-        return FactSearchResponse(message='Facts retrieved successfully', facts=facts)
+        return FactSearchResponse(
+            message='Facts retrieved successfully',
+            facts=facts,
+            searched_group_ids=effective_group_ids,
+        )
     except Exception as e:
         error_msg = str(e)
         logger.error(f'Error searching facts: {error_msg}')
@@ -746,7 +764,11 @@ async def get_episodes(
 
     Args:
         group_ids: Optional group ID, or list of group IDs, to filter results (a single
-            string is accepted and treated as a one-element list)
+            string is accepted and treated as a one-element list). Omitted means the
+            server's configured default group. Unlike the search tools this one
+            cannot serve the whole graph -- it needs a concrete group, and returns an
+            error rather than an empty list when none resolves. The group read is
+            echoed back as `searched_group_ids`.
         max_episodes: Maximum number of episodes to return (default: 10)
     """
     global graphiti_service
@@ -757,30 +779,35 @@ async def get_episodes(
     try:
         client = await graphiti_service.get_client()
 
-        # Accept a scalar group_id or a list; fall back to the default when omitted.
+        # Accept a scalar group_id or a list; '*' widens the read to every group,
+        # omission keeps it on the configured default.
         group_ids = coerce_group_ids(group_ids)
-        effective_group_ids = (
-            group_ids
-            if group_ids is not None
-            else [config.graphiti.group_id]
-            if config.graphiti.group_id
-            else []
-        )
+        effective_group_ids = resolve_read_group_ids(group_ids, config.graphiti.group_id)
 
         # Get episodes from the driver directly
         from graphiti_core.nodes import EpisodicNode
 
-        if effective_group_ids:
-            episodes = await EpisodicNode.get_by_group_ids(
-                client.driver, effective_group_ids, limit=max_episodes
+        if not effective_group_ids:
+            # get_by_group_ids needs a concrete list, so this tool cannot serve the
+            # whole graph the way the search tools can. Say so instead of returning
+            # an empty list, which reads as "there are no episodes".
+            return ErrorResponse(
+                error=(
+                    'get_episodes requires a concrete group: pass group_ids, or set a '
+                    "default group_id on the server. '*' is not supported here."
+                )
             )
-        else:
-            # If no group IDs, we need to use a different approach
-            # For now, return empty list when no group IDs specified
-            episodes = []
+
+        episodes = await EpisodicNode.get_by_group_ids(
+            client.driver, effective_group_ids, limit=max_episodes
+        )
 
         if not episodes:
-            return EpisodeSearchResponse(message='No episodes found', episodes=[])
+            return EpisodeSearchResponse(
+                message='No episodes found',
+                episodes=[],
+                searched_group_ids=effective_group_ids,
+            )
 
         # Format the results
         episode_results = []
@@ -799,7 +826,9 @@ async def get_episodes(
             episode_results.append(episode_dict)
 
         return EpisodeSearchResponse(
-            message='Episodes retrieved successfully', episodes=episode_results
+            message='Episodes retrieved successfully',
+            episodes=episode_results,
+            searched_group_ids=effective_group_ids,
         )
     except Exception as e:
         error_msg = str(e)
@@ -1054,6 +1083,20 @@ async def clear_graph(
 
         if not effective_group_ids:
             return ErrorResponse(error='No group IDs specified for clearing')
+
+        # '*' widens a *read* to every group. Refuse it here rather than let it
+        # through: clear_data would take it as a literal group name, match nothing,
+        # and report "cleared successfully for group IDs: *" — a success message for
+        # a destructive call that did nothing, on the one tool where being wrong
+        # about scope is unrecoverable.
+        if ALL_GROUPS in effective_group_ids:
+            return ErrorResponse(
+                error=(
+                    f"'{ALL_GROUPS}' is not accepted by clear_graph: it selects every "
+                    'group for reads, and clearing every group must be spelled out '
+                    'one group at a time.'
+                )
+            )
 
         # Clear data for the specified group IDs
         await clear_data(client.driver, group_ids=effective_group_ids)

--- a/mcp_server/src/models/response_types.py
+++ b/mcp_server/src/models/response_types.py
@@ -26,16 +26,28 @@ class NodeResult(TypedDict):
 class NodeSearchResponse(TypedDict):
     message: str
     nodes: list[NodeResult]
+    # Which partitions this read actually covered; None means every group.
+    # Present so an empty result reports its scope instead of reading as
+    # "there is nothing" when it really means "nothing in that one group".
+    searched_group_ids: list[str] | None
 
 
 class FactSearchResponse(TypedDict):
     message: str
     facts: list[dict[str, Any]]
+    # Which partitions this read actually covered; None means every group.
+    # Present so an empty result reports its scope instead of reading as
+    # "there is nothing" when it really means "nothing in that one group".
+    searched_group_ids: list[str] | None
 
 
 class EpisodeSearchResponse(TypedDict):
     message: str
     episodes: list[dict[str, Any]]
+    # Which partitions this read actually covered; None means every group.
+    # Present so an empty result reports its scope instead of reading as
+    # "there is nothing" when it really means "nothing in that one group".
+    searched_group_ids: list[str] | None
 
 
 class StatusResponse(TypedDict):

--- a/mcp_server/src/utils/type_config.py
+++ b/mcp_server/src/utils/type_config.py
@@ -64,6 +64,36 @@ def coerce_group_ids(group_ids: str | list[str] | None) -> list[str] | None:
     return group_ids
 
 
+#: Sentinel a caller passes as ``group_ids`` to read across every partition.
+#: ``validate_group_id`` rejects ``*`` (only ``[a-zA-Z0-9_-]`` is legal), so no
+#: real group can ever collide with it.
+ALL_GROUPS = '*'
+
+
+def resolve_read_group_ids(
+    group_ids: list[str] | None, default_group_id: str | None
+) -> list[str] | None:
+    """Resolve the group scope for a read tool.
+
+    Returns ``None`` to mean "every group", which is what graphiti-core's search
+    path already does with an absent group filter.
+
+    - ``[ALL_GROUPS]`` -> ``None``: the caller explicitly asked for the whole graph.
+    - ``None`` -> the configured default group, or ``None`` if none is configured.
+      Reads stay scoped to the deployment's group unless asked otherwise, so a
+      server configured for one tenant never widens its scope by accident.
+    - anything else passes through.
+
+    ``ALL_GROUPS`` is honored anywhere in the list, so ``['a', '*']`` is the whole
+    graph rather than a group literally named ``*`` (which cannot exist).
+    """
+    if group_ids is not None and ALL_GROUPS in group_ids:
+        return None
+    if group_ids is not None:
+        return group_ids
+    return [default_group_id] if default_group_id else None
+
+
 def _doc_only_model(name: str, description: str) -> type[BaseModel]:
     """Build a documentation-only Pydantic model with no fields.
 

--- a/mcp_server/tests/test_read_group_scope.py
+++ b/mcp_server/tests/test_read_group_scope.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Unit tests for read-tool group scoping.
+
+Covers the `'*'` (ALL_GROUPS) sentinel, the `searched_group_ids` echo on every
+read response, and the invariant that widening the scope never happens by
+omission. These drive the tool functions against a mocked Graphiti client, so
+they need no database and run in the default (non-integration) suite.
+"""
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from graphiti_core import Graphiti
+from graphiti_core.errors import GroupIdValidationError
+from graphiti_core.helpers import validate_group_id
+from graphiti_core.nodes import EpisodeType, EpisodicNode
+from graphiti_core.search.search_config import SearchResults
+
+# Add the src directory to the path (mirrors the other unit tests)
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+import graphiti_mcp_server as server  # noqa: E402
+from config.schema import GraphitiConfig  # noqa: E402
+from utils.type_config import ALL_GROUPS, resolve_read_group_ids  # noqa: E402
+
+NOW = datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def fake_service(monkeypatch):
+    client = AsyncMock(spec=Graphiti)
+    client.driver = object()
+    service = AsyncMock()
+    service.get_client = AsyncMock(return_value=client)
+    monkeypatch.setattr(server, 'graphiti_service', service)
+    return client
+
+
+def _install_config(monkeypatch, group_id: str) -> None:
+    """`config` is a module global bound in main(), so tests must supply it."""
+    cfg = GraphitiConfig()
+    cfg.graphiti.group_id = group_id
+    monkeypatch.setattr(server, 'config', cfg, raising=False)
+
+
+@pytest.fixture
+def configured_group(monkeypatch):
+    """Server configured with a default group, as a single-tenant deployment is."""
+    _install_config(monkeypatch, 'tenant-a')
+
+
+class TestResolveReadGroupIds:
+    def test_omitted_uses_configured_default(self):
+        assert resolve_read_group_ids(None, 'tenant-a') == ['tenant-a']
+
+    def test_omitted_with_no_default_is_all_groups(self):
+        assert resolve_read_group_ids(None, None) is None
+        assert resolve_read_group_ids(None, '') is None
+
+    def test_explicit_groups_pass_through(self):
+        assert resolve_read_group_ids(['x', 'y'], 'tenant-a') == ['x', 'y']
+
+    def test_star_widens_to_all_groups(self):
+        assert resolve_read_group_ids([ALL_GROUPS], 'tenant-a') is None
+
+    def test_star_wins_anywhere_in_the_list(self):
+        # A group literally named '*' cannot exist, so this is unambiguous.
+        assert resolve_read_group_ids(['x', ALL_GROUPS], 'tenant-a') is None
+
+    def test_star_is_not_a_legal_group_id(self):
+        """The sentinel is safe precisely because no real group can be named it."""
+        with pytest.raises(GroupIdValidationError):
+            validate_group_id(ALL_GROUPS)
+
+
+class TestNoAccidentalWidening:
+    """Omitting group_ids must never broaden a configured deployment's scope."""
+
+    @pytest.mark.asyncio
+    async def test_facts_stay_on_configured_group(self, fake_service, configured_group):
+        fake_service.search.return_value = []
+
+        result = await server.search_memory_facts(query='q')
+
+        assert fake_service.search.call_args.kwargs['group_ids'] == ['tenant-a']
+        assert result['searched_group_ids'] == ['tenant-a']
+
+    @pytest.mark.asyncio
+    async def test_nodes_stay_on_configured_group(self, fake_service, configured_group):
+        fake_service.search_.return_value = SearchResults(nodes=[])
+
+        result = await server.search_nodes(query='q')
+
+        assert fake_service.search_.call_args.kwargs['group_ids'] == ['tenant-a']
+        assert result['searched_group_ids'] == ['tenant-a']
+
+
+class TestStarReadsEverything:
+    @pytest.mark.asyncio
+    async def test_facts_star_passes_none_to_core(self, fake_service, configured_group):
+        """None is what graphiti-core's search path reads as 'no group filter'."""
+        fake_service.search.return_value = []
+
+        result = await server.search_memory_facts(query='q', group_ids='*')
+
+        assert fake_service.search.call_args.kwargs['group_ids'] is None
+        assert result['searched_group_ids'] is None
+
+    @pytest.mark.asyncio
+    async def test_nodes_star_passes_none_to_core(self, fake_service, configured_group):
+        fake_service.search_.return_value = SearchResults(nodes=[])
+
+        result = await server.search_nodes(query='q', group_ids='*')
+
+        assert fake_service.search_.call_args.kwargs['group_ids'] is None
+        assert result['searched_group_ids'] is None
+
+
+class TestEmptyResultReportsItsScope:
+    """The bug this closes: an empty result that reads as absence of memory."""
+
+    @pytest.mark.asyncio
+    async def test_empty_facts_carry_scope(self, fake_service, configured_group):
+        fake_service.search.return_value = []
+
+        result = await server.search_memory_facts(query='q')
+
+        assert result['facts'] == []
+        assert result['searched_group_ids'] == ['tenant-a']
+
+    @pytest.mark.asyncio
+    async def test_empty_nodes_carry_scope(self, fake_service, configured_group):
+        fake_service.search_.return_value = SearchResults(nodes=[])
+
+        result = await server.search_nodes(query='q')
+
+        assert result['nodes'] == []
+        assert result['searched_group_ids'] == ['tenant-a']
+
+
+class TestGetEpisodes:
+    @pytest.mark.asyncio
+    async def test_scope_echoed_on_results(self, fake_service, configured_group):
+        episode = EpisodicNode(
+            uuid='e1',
+            name='ep',
+            group_id='tenant-a',
+            source=EpisodeType.text,
+            source_description='',
+            content='body',
+            valid_at=NOW,
+            created_at=NOW,
+        )
+        with patch.object(EpisodicNode, 'get_by_group_ids', AsyncMock(return_value=[episode])):
+            result = await server.get_episodes()
+
+        assert result['searched_group_ids'] == ['tenant-a']
+        assert len(result['episodes']) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_resolvable_group_errors_instead_of_empty(self, fake_service, monkeypatch):
+        """Returning [] here would read as 'this graph has no episodes'."""
+        _install_config(monkeypatch, '')
+
+        result = await server.get_episodes()
+
+        assert 'error' in result
+        assert 'concrete group' in result['error']
+
+    @pytest.mark.asyncio
+    async def test_star_is_rejected_not_silently_empty(self, fake_service, configured_group):
+        result = await server.get_episodes(group_ids='*')
+
+        assert 'error' in result
+        assert "'*' is not supported" in result['error']
+
+
+class TestClearGraphUnchanged:
+    """The destructive tool must not inherit read semantics."""
+
+    @pytest.mark.asyncio
+    async def test_star_does_not_wipe_the_whole_graph(self, fake_service, configured_group):
+        with patch.object(server, 'clear_data', AsyncMock()) as cleared:
+            result = await server.clear_graph(group_ids='*')
+
+        # '*' must not reach clear_data: it would match no group and still report
+        # success, which is the worst possible answer from a destructive tool.
+        assert 'error' in result
+        assert 'not accepted by clear_graph' in result['error']
+        cleared.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_omitted_still_uses_configured_group(self, fake_service, configured_group):
+        with patch.object(server, 'clear_data', AsyncMock()) as cleared:
+            await server.clear_graph()
+
+        assert cleared.call_args.kwargs['group_ids'] == ['tenant-a']


### PR DESCRIPTION
## Problem

An MCP server holding several partitions has no way to read across them. `search_memory_facts`, `search_nodes` and `get_episodes` take `group_ids`, and omitting it falls back to `config.graphiti.group_id` — so a caller that does not know the partition names cannot ask the whole graph anything.

The silence is the worse half. On a deployment whose configured default names a group holding no data — easy to reach, since the shipped config defaults to a placeholder — **every search that omits `group_ids` returns `"No relevant facts found"`**. That is indistinguishable from "this graph knows nothing about your question", and an agent consuming it will conclude exactly that.

Measured on a production graph with 7 populated partitions and a stale configured default: two searches, one Portuguese and one English, both with clear answers in the graph, both empty. Adding `group_ids` explicitly returned the right facts immediately.

## What this adds

- **`'*'` as a `group_ids` sentinel** meaning "every group", on the two search tools.
- **`searched_group_ids` on every read response** (`None` = all groups), so an empty result reports the scope that produced it.

## Why not just make the default "all groups"

That fixes the same symptom and I started there, but it converts a fail-closed scope into a fail-open one: a server configured for one tenant would begin answering across every tenant because a caller left an argument off. Given #1716, that is not a direction to take by accident.

The sentinel makes widening an explicit act. `searched_group_ids` makes the narrow case legible instead of silent. Together they close the reported failure without changing what any existing deployment returns.

`'*'` is safe as a sentinel because `validate_group_id` accepts only `[a-zA-Z0-9_-]+`, so no real group can collide with it — there is a test pinning that, so the guarantee breaks loudly if the validation ever loosens.

## Per tool

| Tool | `'*'` | `searched_group_ids` | Note |
| --- | --- | --- | --- |
| `search_memory_facts` | yes | yes | passes `None` to core, which already reads an absent group filter as all groups |
| `search_nodes` | yes | yes | same |
| `get_episodes` | **no** | yes | see below |
| `clear_graph` | **rejected** | — | see below |
| `add_memory`, `build_communities` | no | — | untouched; a write has to land somewhere concrete |

**`get_episodes`** goes through `EpisodicNode.get_by_group_ids`, which needs a concrete list. Serving the whole graph there would mean switching to `retrieve_episodes`, which also changes ordering and belongs with #1724 — deliberately out of scope. What it does get: instead of returning an empty list when no group resolves (the same lie in a different tool), it returns an error naming the problem.

**`clear_graph`** explicitly rejects `'*'`. This one is worth calling out because I only found it by testing the assumption. Without the guard the sentinel reaches `clear_data` as a literal group name, matches nothing, and the tool reports:

```
Graph data cleared successfully for group IDs: *
```

A success message from a destructive tool that did nothing — on the one tool where being wrong about scope is unrecoverable. A user who learns `'*' = everything` from the search tools would reasonably try it here. Clearing every group has to be spelled out one group at a time.

## Testing

- 17 new unit tests (`mcp_server/tests/test_read_group_scope.py`) driving the tools against a mocked client — no database, no LLM, default suite.
- Existing non-integration suite: 78 passed, 1 skipped.
- `ruff check`, `ruff format --check`, `pyright` clean.

Three modules fail collection both before and after this change (`test_async_operations.py`, `test_cross_encoder_factory.py`, `test_stress_load.py`) — missing optional deps and a test-path import, unrelated.

## Relation to #1790

Textual overlap only: #1790 adds other fields to the same response TypedDicts. The two are behaviorally independent and can land in either order.

— 🤖 Claude Opus 5
