### PR TITLE
feat(neo4j): route similarity search through HNSW vector indexes

### DIFF
--- a/graphiti_core/driver/neo4j/operations/search_ops.py
+++ b/graphiti_core/driver/neo4j/operations/search_ops.py
@@ -31,6 +31,8 @@ from graphiti_core.driver.record_parsers import (
 from graphiti_core.edges import EntityEdge
 from graphiti_core.graph_queries import (
     NEO4J_EDGE_VECTOR_INDEX_NAME,
+    NEO4J_ENTITY_VECTOR_INDEX_NAME,
+    VECTOR_INDEX_OVERFETCH_FACTOR,
     get_nodes_query,
     get_relationships_query,
     get_vector_cosine_func_query,
@@ -100,6 +102,43 @@ def _build_neo4j_fulltext_query(
 
 
 class Neo4jSearchOperations(SearchOperations):
+    # --- Vector index helpers ---
+
+    @staticmethod
+    def _check_vector_dimension(executor: QueryExecutor, search_vector: list[float]) -> None:
+        embedding_dim = getattr(executor, 'embedding_dim', None)
+        if embedding_dim is not None and len(search_vector) != embedding_dim:
+            raise ValueError(
+                f'query embedding dimension {len(search_vector)} does not match '
+                f'configured index dimension {embedding_dim}'
+            )
+
+    @staticmethod
+    async def _execute_with_exact_fallback(
+        executor: QueryExecutor,
+        vector_cypher: str,
+        exact_cypher: str,
+        vector_params: dict[str, Any],
+        exact_params: dict[str, Any],
+    ) -> tuple[list[Any], bool]:
+        """Run the vector-index query; on a known lifecycle failure re-run exact.
+
+        The boolean reports whether the exact query was already used. Programmer
+        errors and unrecognised ClientErrors propagate unchanged so the fallback
+        cannot hide a broken query.
+        """
+        try:
+            records, _, _ = await executor.execute_query(vector_cypher, **vector_params)
+        except ClientError as error:
+            if not _is_vector_index_lifecycle_error(error):
+                raise
+            logger.warning(
+                'Vector index unavailable; falling back to exact cosine search: %s', error
+            )
+            records, _, _ = await executor.execute_query(exact_cypher, **exact_params)
+            return records, True
+        return records, False
+
     # --- Node search ---
 
     async def node_fulltext_search(
@@ -172,7 +211,7 @@ class Neo4jSearchOperations(SearchOperations):
         if filter_queries:
             filter_query = ' WHERE ' + (' AND '.join(filter_queries))
 
-        cypher = (
+        exact_cypher = (
             'MATCH (n:Entity)'
             + filter_query
             + """
@@ -190,15 +229,54 @@ class Neo4jSearchOperations(SearchOperations):
             LIMIT $limit
             """
         )
-
-        records, _, _ = await executor.execute_query(
-            cypher,
+        exact_params: dict[str, Any] = dict(
             search_vector=search_vector,
             limit=limit,
             min_score=min_score,
             routing_='r',
             **filter_params,
         )
+
+        if not use_vector_index(executor):
+            records, _, _ = await executor.execute_query(exact_cypher, **exact_params)
+            return [entity_node_from_record(r) for r in records]
+
+        self._check_vector_dimension(executor, search_vector)
+
+        # The procedure cannot pre-filter; ask for a wider window and filter after.
+        candidates = limit * VECTOR_INDEX_OVERFETCH_FACTOR if filter_queries else limit
+        vector_cypher = (
+            get_vector_similarity_query(
+                GraphProvider.NEO4J,
+                NEO4J_ENTITY_VECTOR_INDEX_NAME,
+                'n',
+                limit,
+                relationship=False,
+                candidates=candidates,
+            )
+            + """
+            WITH n, score
+            WHERE """
+            + ' AND '.join(['score > $min_score', *filter_queries])
+            + """
+            RETURN
+            """
+            + get_entity_node_return_query(GraphProvider.NEO4J)
+            + """
+            ORDER BY score DESC
+            LIMIT $limit
+            """
+        )
+
+        records, exact_used = await self._execute_with_exact_fallback(
+            executor, vector_cypher, exact_cypher, exact_params, exact_params
+        )
+
+        # ANN post-filtering cannot prove that the candidate window contained all
+        # matching rows. Preserve the old row-count contract when the window is too
+        # sparse; do not issue a second exact query if lifecycle fallback already did.
+        if filter_queries and not exact_used and len(records) < limit:
+            records, _, _ = await executor.execute_query(exact_cypher, **exact_params)
 
         return [entity_node_from_record(r) for r in records]
 
@@ -357,69 +435,55 @@ class Neo4jSearchOperations(SearchOperations):
             """
         )
 
-        vector_index_enabled = use_vector_index(executor)
-        if vector_index_enabled:
-            embedding_dim = getattr(executor, 'embedding_dim', None)
-            if embedding_dim is not None and len(search_vector) != embedding_dim:
-                raise ValueError(
-                    f'query embedding dimension {len(search_vector)} does not match '
-                    f'configured index dimension {embedding_dim}'
-                )
+        exact_params: dict[str, Any] = dict(
+            search_vector=search_vector,
+            limit=limit,
+            min_score=min_score,
+            routing_='r',
+            **filter_params,
+        )
 
-        # Neo4j's vector procedure cannot pre-filter. Using it with any public filter
-        # would make a bounded over-fetch heuristic violate the caller's limit contract,
-        # so filtered searches retain the exact pre-filtered cosine path.
-        use_hnsw = vector_index_enabled and not filter_queries
-        if use_hnsw:
-            cypher = (
-                get_vector_similarity_query(
-                    GraphProvider.NEO4J,
-                    NEO4J_EDGE_VECTOR_INDEX_NAME,
-                    'e',
-                    limit,
-                )
-                + """
-                WITH e, startNode(e) AS n, endNode(e) AS m, score
-                WHERE n:Entity AND m:Entity AND score > $min_score
-                RETURN
-                """
-                + get_entity_edge_return_query(GraphProvider.NEO4J)
-                + """
-                ORDER BY score DESC
-                LIMIT $limit
-                """
+        if not use_vector_index(executor):
+            records, _, _ = await executor.execute_query(exact_cypher, **exact_params)
+            return [entity_edge_from_record(r) for r in records]
+
+        self._check_vector_dimension(executor, search_vector)
+
+        # The procedure cannot pre-filter; ask for a wider window and filter after.
+        # Endpoint binding (n / m) is re-established from the yielded relationship so
+        # the source/target UUID filters and the return shape are unchanged.
+        candidates = limit * VECTOR_INDEX_OVERFETCH_FACTOR if filter_queries else limit
+        vector_cypher = (
+            get_vector_similarity_query(
+                GraphProvider.NEO4J,
+                NEO4J_EDGE_VECTOR_INDEX_NAME,
+                'e',
+                limit,
+                candidates=candidates,
             )
-            try:
-                records, _, _ = await executor.execute_query(
-                    cypher,
-                    search_vector=search_vector,
-                    limit=limit,
-                    min_score=min_score,
-                    routing_='r',
-                )
-            except ClientError as error:
-                if not _is_vector_index_lifecycle_error(error):
-                    raise
-                logger.warning(
-                    'Vector index unavailable; falling back to exact cosine search: %s', error
-                )
-                records, _, _ = await executor.execute_query(
-                    exact_cypher,
-                    search_vector=search_vector,
-                    limit=limit,
-                    min_score=min_score,
-                    routing_='r',
-                    **filter_params,
-                )
-        else:
-            records, _, _ = await executor.execute_query(
-                exact_cypher,
-                search_vector=search_vector,
-                limit=limit,
-                min_score=min_score,
-                routing_='r',
-                **filter_params,
-            )
+            + """
+            WITH e, startNode(e) AS n, endNode(e) AS m, score
+            WHERE """
+            + ' AND '.join(['n:Entity', 'm:Entity', 'score > $min_score', *filter_queries])
+            + """
+            RETURN
+            """
+            + get_entity_edge_return_query(GraphProvider.NEO4J)
+            + """
+            ORDER BY score DESC
+            LIMIT $limit
+            """
+        )
+
+        records, exact_used = await self._execute_with_exact_fallback(
+            executor, vector_cypher, exact_cypher, exact_params, exact_params
+        )
+
+        # ANN post-filtering cannot prove that the candidate window contained all
+        # matching rows. Preserve the old row-count contract when the window is too
+        # sparse; do not issue a second exact query if lifecycle fallback already did.
+        if filter_queries and not exact_used and len(records) < limit:
+            records, _, _ = await executor.execute_query(exact_cypher, **exact_params)
 
         return [entity_edge_from_record(r) for r in records]
 

--- a/graphiti_core/driver/neo4j/operations/search_ops.py
+++ b/graphiti_core/driver/neo4j/operations/search_ops.py
@@ -17,6 +17,8 @@ limitations under the License.
 import logging
 from typing import Any
 
+from neo4j.exceptions import ClientError
+
 from graphiti_core.driver.driver import GraphProvider
 from graphiti_core.driver.operations.search_ops import SearchOperations
 from graphiti_core.driver.query_executor import QueryExecutor
@@ -28,9 +30,12 @@ from graphiti_core.driver.record_parsers import (
 )
 from graphiti_core.edges import EntityEdge
 from graphiti_core.graph_queries import (
+    NEO4J_EDGE_VECTOR_INDEX_NAME,
     get_nodes_query,
     get_relationships_query,
     get_vector_cosine_func_query,
+    get_vector_similarity_query,
+    use_vector_index,
 )
 from graphiti_core.helpers import lucene_sanitize, validate_group_ids
 from graphiti_core.models.edges.edge_db_queries import get_entity_edge_return_query
@@ -49,6 +54,27 @@ from graphiti_core.search.search_filters import (
 logger = logging.getLogger(__name__)
 
 MAX_QUERY_LENGTH = 128
+
+_VECTOR_INDEX_LIFECYCLE_CODES = {
+    'Neo.ClientError.Procedure.ProcedureNotFound',
+    'Neo.ClientError.Schema.IndexNotFound',
+}
+_VECTOR_INDEX_LIFECYCLE_MESSAGES = (
+    'no such vector schema index',
+    'is not online',
+    'is offline',
+    'is still populating',
+    'is in populating state',
+    'dimensions, but indexed vectors have',
+    'is not a vector index',
+)
+
+
+def _is_vector_index_lifecycle_error(error: ClientError) -> bool:
+    if getattr(error, 'code', None) in _VECTOR_INDEX_LIFECYCLE_CODES:
+        return True
+    message = str(error).lower()
+    return any(fragment in message for fragment in _VECTOR_INDEX_LIFECYCLE_MESSAGES)
 
 
 def _build_neo4j_fulltext_query(
@@ -300,19 +326,19 @@ class Neo4jSearchOperations(SearchOperations):
             filter_queries.append('e.group_id IN $group_ids')
             filter_params['group_ids'] = group_ids
 
-            if source_node_uuid is not None:
-                filter_params['source_uuid'] = source_node_uuid
-                filter_queries.append('n.uuid = $source_uuid')
+        if source_node_uuid is not None:
+            filter_params['source_uuid'] = source_node_uuid
+            filter_queries.append('n.uuid = $source_uuid')
 
-            if target_node_uuid is not None:
-                filter_params['target_uuid'] = target_node_uuid
-                filter_queries.append('m.uuid = $target_uuid')
+        if target_node_uuid is not None:
+            filter_params['target_uuid'] = target_node_uuid
+            filter_queries.append('m.uuid = $target_uuid')
 
         filter_query = ''
         if filter_queries:
             filter_query = ' WHERE ' + (' AND '.join(filter_queries))
 
-        cypher = (
+        exact_cypher = (
             'MATCH (n:Entity)-[e:RELATES_TO]->(m:Entity)'
             + filter_query
             + """
@@ -331,14 +357,69 @@ class Neo4jSearchOperations(SearchOperations):
             """
         )
 
-        records, _, _ = await executor.execute_query(
-            cypher,
-            search_vector=search_vector,
-            limit=limit,
-            min_score=min_score,
-            routing_='r',
-            **filter_params,
-        )
+        vector_index_enabled = use_vector_index(executor)
+        if vector_index_enabled:
+            embedding_dim = getattr(executor, 'embedding_dim', None)
+            if embedding_dim is not None and len(search_vector) != embedding_dim:
+                raise ValueError(
+                    f'query embedding dimension {len(search_vector)} does not match '
+                    f'configured index dimension {embedding_dim}'
+                )
+
+        # Neo4j's vector procedure cannot pre-filter. Using it with any public filter
+        # would make a bounded over-fetch heuristic violate the caller's limit contract,
+        # so filtered searches retain the exact pre-filtered cosine path.
+        use_hnsw = vector_index_enabled and not filter_queries
+        if use_hnsw:
+            cypher = (
+                get_vector_similarity_query(
+                    GraphProvider.NEO4J,
+                    NEO4J_EDGE_VECTOR_INDEX_NAME,
+                    'e',
+                    limit,
+                )
+                + """
+                WITH e, startNode(e) AS n, endNode(e) AS m, score
+                WHERE n:Entity AND m:Entity AND score > $min_score
+                RETURN
+                """
+                + get_entity_edge_return_query(GraphProvider.NEO4J)
+                + """
+                ORDER BY score DESC
+                LIMIT $limit
+                """
+            )
+            try:
+                records, _, _ = await executor.execute_query(
+                    cypher,
+                    search_vector=search_vector,
+                    limit=limit,
+                    min_score=min_score,
+                    routing_='r',
+                )
+            except ClientError as error:
+                if not _is_vector_index_lifecycle_error(error):
+                    raise
+                logger.warning(
+                    'Vector index unavailable; falling back to exact cosine search: %s', error
+                )
+                records, _, _ = await executor.execute_query(
+                    exact_cypher,
+                    search_vector=search_vector,
+                    limit=limit,
+                    min_score=min_score,
+                    routing_='r',
+                    **filter_params,
+                )
+        else:
+            records, _, _ = await executor.execute_query(
+                exact_cypher,
+                search_vector=search_vector,
+                limit=limit,
+                min_score=min_score,
+                routing_='r',
+                **filter_params,
+            )
 
         return [entity_edge_from_record(r) for r in records]
 

--- a/graphiti_core/driver/neo4j_driver.py
+++ b/graphiti_core/driver/neo4j_driver.py
@@ -52,7 +52,12 @@ from graphiti_core.driver.operations.next_episode_edge_ops import NextEpisodeEdg
 from graphiti_core.driver.operations.saga_node_ops import SagaNodeOperations
 from graphiti_core.driver.operations.search_ops import SearchOperations
 from graphiti_core.driver.query_executor import Transaction
-from graphiti_core.graph_queries import get_fulltext_indices, get_range_indices
+from graphiti_core.embedder.client import EMBEDDING_DIM
+from graphiti_core.graph_queries import (
+    get_fulltext_indices,
+    get_range_indices,
+    get_vector_indices,
+)
 from graphiti_core.helpers import semaphore_gather
 
 logger = logging.getLogger(__name__)
@@ -68,6 +73,8 @@ class Neo4jDriver(GraphDriver):
         user: str | None,
         password: str | None,
         database: str = 'neo4j',
+        embedding_dim: int = EMBEDDING_DIM,
+        use_vector_index: bool = False,
     ):
         super().__init__()
         self.client = AsyncGraphDatabase.driver(
@@ -75,6 +82,8 @@ class Neo4jDriver(GraphDriver):
             auth=(user or '', password or ''),
         )
         self._database = database
+        self.embedding_dim = embedding_dim
+        self.use_vector_index = use_vector_index
 
         # Instantiate Neo4j operations
         self._entity_node_ops = Neo4jEntityNodeOperations()
@@ -93,7 +102,9 @@ class Neo4jDriver(GraphDriver):
         # Schedule the indices and constraints to be built
         try:
             loop = asyncio.get_running_loop()
-            self._init_task = loop.create_task(self.build_indices_and_constraints())
+            self._init_task = loop.create_task(
+                self.build_indices_and_constraints(build_vector_indices=use_vector_index)
+            )
         except RuntimeError:
             pass
 
@@ -212,7 +223,9 @@ class Neo4jDriver(GraphDriver):
                 return None
             raise
 
-    async def build_indices_and_constraints(self, delete_existing: bool = False):
+    async def build_indices_and_constraints(
+        self, delete_existing: bool = False, build_vector_indices: bool = False
+    ):
         if delete_existing:
             await self.delete_all_indexes()
 
@@ -221,6 +234,11 @@ class Neo4jDriver(GraphDriver):
         fulltext_indices: list[LiteralString] = get_fulltext_indices(self.provider)
 
         index_queries: list[LiteralString] = range_indices + fulltext_indices
+
+        if build_vector_indices:
+            # Opt-in: populating a vector index over an existing large graph is a
+            # one-time expensive background build, so it is not enabled by default.
+            index_queries += get_vector_indices(self.provider, self.embedding_dim)
 
         await semaphore_gather(*[self._execute_index_query(query) for query in index_queries])
 

--- a/graphiti_core/driver/neo4j_driver.py
+++ b/graphiti_core/driver/neo4j_driver.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import asyncio
 import logging
+import os
 from collections.abc import AsyncIterator, Coroutine
 from contextlib import asynccontextmanager, suppress
 from typing import Any
@@ -62,6 +63,37 @@ from graphiti_core.helpers import semaphore_gather
 
 logger = logging.getLogger(__name__)
 
+_TRUTHY = {'1', 'true', 'yes', 'on'}
+
+USE_VECTOR_INDEX_ENV_VAR = 'GRAPHITI_NEO4J_USE_VECTOR_INDEX'
+EMBEDDING_DIM_ENV_VAR = 'GRAPHITI_NEO4J_EMBEDDING_DIM'
+
+
+def _env_use_vector_index() -> bool:
+    """Read the vector-index opt-in from the environment.
+
+    Deployments that build Graphiti indirectly (e.g. the MCP server, which passes
+    uri/user/password to Graphiti and never constructs Neo4jDriver itself) have no
+    way to supply the constructor argument, so expose the same switch as config.
+    """
+    return os.environ.get(USE_VECTOR_INDEX_ENV_VAR, '').strip().lower() in _TRUTHY
+
+
+def _env_embedding_dim() -> int | None:
+    """Read the embedding dimension override, ignoring malformed values."""
+    raw = os.environ.get(EMBEDDING_DIM_ENV_VAR, '').strip()
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            'Ignoring %s=%r: expected an integer embedding dimension',
+            EMBEDDING_DIM_ENV_VAR,
+            raw,
+        )
+        return None
+
 
 class Neo4jDriver(GraphDriver):
     provider = GraphProvider.NEO4J
@@ -73,8 +105,8 @@ class Neo4jDriver(GraphDriver):
         user: str | None,
         password: str | None,
         database: str = 'neo4j',
-        embedding_dim: int = EMBEDDING_DIM,
-        use_vector_index: bool = False,
+        embedding_dim: int | None = None,
+        use_vector_index: bool | None = None,
     ):
         super().__init__()
         self.client = AsyncGraphDatabase.driver(
@@ -82,6 +114,12 @@ class Neo4jDriver(GraphDriver):
             auth=(user or '', password or ''),
         )
         self._database = database
+        if embedding_dim is None:
+            embedding_dim = _env_embedding_dim()
+        if embedding_dim is None:
+            embedding_dim = EMBEDDING_DIM
+        if use_vector_index is None:
+            use_vector_index = _env_use_vector_index()
         self.embedding_dim = embedding_dim
         self.use_vector_index = use_vector_index
 

--- a/graphiti_core/driver/neo4j_driver.py
+++ b/graphiti_core/driver/neo4j_driver.py
@@ -66,7 +66,6 @@ logger = logging.getLogger(__name__)
 _TRUTHY = {'1', 'true', 'yes', 'on'}
 
 USE_VECTOR_INDEX_ENV_VAR = 'GRAPHITI_NEO4J_USE_VECTOR_INDEX'
-EMBEDDING_DIM_ENV_VAR = 'GRAPHITI_NEO4J_EMBEDDING_DIM'
 
 
 def _env_use_vector_index() -> bool:
@@ -77,22 +76,6 @@ def _env_use_vector_index() -> bool:
     way to supply the constructor argument, so expose the same switch as config.
     """
     return os.environ.get(USE_VECTOR_INDEX_ENV_VAR, '').strip().lower() in _TRUTHY
-
-
-def _env_embedding_dim() -> int | None:
-    """Read the embedding dimension override, ignoring malformed values."""
-    raw = os.environ.get(EMBEDDING_DIM_ENV_VAR, '').strip()
-    if not raw:
-        return None
-    try:
-        return int(raw)
-    except ValueError:
-        logger.warning(
-            'Ignoring %s=%r: expected an integer embedding dimension',
-            EMBEDDING_DIM_ENV_VAR,
-            raw,
-        )
-        return None
 
 
 class Neo4jDriver(GraphDriver):
@@ -115,9 +98,13 @@ class Neo4jDriver(GraphDriver):
         )
         self._database = database
         if embedding_dim is None:
-            embedding_dim = _env_embedding_dim()
-        if embedding_dim is None:
             embedding_dim = EMBEDDING_DIM
+        if (
+            not isinstance(embedding_dim, int)
+            or isinstance(embedding_dim, bool)
+            or not 1 <= embedding_dim <= 4096
+        ):
+            raise ValueError('embedding_dim must be an integer between 1 and 4096')
         if use_vector_index is None:
             use_vector_index = _env_use_vector_index()
         self.embedding_dim = embedding_dim
@@ -262,7 +249,7 @@ class Neo4jDriver(GraphDriver):
             raise
 
     async def build_indices_and_constraints(
-        self, delete_existing: bool = False, build_vector_indices: bool = False
+        self, delete_existing: bool = False, build_vector_indices: bool | None = None
     ):
         if delete_existing:
             await self.delete_all_indexes()
@@ -272,6 +259,9 @@ class Neo4jDriver(GraphDriver):
         fulltext_indices: list[LiteralString] = get_fulltext_indices(self.provider)
 
         index_queries: list[LiteralString] = range_indices + fulltext_indices
+
+        if build_vector_indices is None:
+            build_vector_indices = self.use_vector_index
 
         if build_vector_indices:
             # Opt-in: populating a vector index over an existing large graph is a

--- a/graphiti_core/driver/neo4j_driver.py
+++ b/graphiti_core/driver/neo4j_driver.py
@@ -99,14 +99,16 @@ class Neo4jDriver(GraphDriver):
         self._database = database
         if embedding_dim is None:
             embedding_dim = EMBEDDING_DIM
+        if use_vector_index is None:
+            use_vector_index = _env_use_vector_index()
         if (
             not isinstance(embedding_dim, int)
             or isinstance(embedding_dim, bool)
-            or not 1 <= embedding_dim <= 4096
+            or embedding_dim <= 0
         ):
-            raise ValueError('embedding_dim must be an integer between 1 and 4096')
-        if use_vector_index is None:
-            use_vector_index = _env_use_vector_index()
+            raise ValueError('embedding_dim must be a positive integer')
+        if use_vector_index and embedding_dim > 4096:
+            raise ValueError('embedding_dim must not exceed 4096 when vector indexing is enabled')
         self.embedding_dim = embedding_dim
         self.use_vector_index = use_vector_index
 

--- a/graphiti_core/graph_queries.py
+++ b/graphiti_core/graph_queries.py
@@ -180,7 +180,17 @@ NEO4J_VECTOR_INDEX_NAMES = {
     'entity_name_embedding': ('Entity', 'name_embedding'),
     'community_name_embedding': ('Community', 'name_embedding'),
 }
+NEO4J_ENTITY_VECTOR_INDEX_NAME = 'entity_name_embedding'
 NEO4J_EDGE_VECTOR_INDEX_NAME = 'edge_fact_embedding'
+
+# Neo4j's vector procedures cannot pre-filter on group_id / SearchFilters. When a
+# filter is present the procedure is asked for ``limit * VECTOR_INDEX_OVERFETCH_FACTOR``
+# candidates and the filter runs over that set. ``group_id`` is a partition key
+# (one group usually owns most of the graph), so the over-fetched window almost
+# always contains ``limit`` in-group hits; when it does not, the search returns
+# fewer rows, exactly as the exact path does when fewer than ``limit`` rows clear
+# ``min_score``. ``LIMIT`` is an upper bound in both paths.
+VECTOR_INDEX_OVERFETCH_FACTOR = 4
 
 
 def get_vector_indices(provider: GraphProvider, embedding_dim: int) -> list[LiteralString]:
@@ -219,8 +229,12 @@ def get_vector_similarity_query(
     entity_var: str,
     limit: int,
     relationship: bool = True,
+    candidates: int | None = None,
 ) -> str:
     """Return a Cypher fragment that yields (entity, score) from a vector index.
+
+    ``candidates`` is the k handed to the procedure. It defaults to ``limit``;
+    filtered callers pass a wider window so post-filtering has room to work.
 
     Returns an empty string for providers without vector index support, letting
     callers fall back to the brute-force cosine path.
@@ -230,8 +244,9 @@ def get_vector_similarity_query(
 
     procedure = 'queryRelationships' if relationship else 'queryNodes'
     yielded = 'relationship' if relationship else 'node'
+    k = limit if candidates is None else candidates
     return (
-        f"CALL db.index.vector.{procedure}('{index_name}', {limit}, $search_vector) "
+        f"CALL db.index.vector.{procedure}('{index_name}', {k}, $search_vector) "
         f'YIELD {yielded} AS {entity_var}, score '
     )
 

--- a/graphiti_core/graph_queries.py
+++ b/graphiti_core/graph_queries.py
@@ -182,10 +182,6 @@ NEO4J_VECTOR_INDEX_NAMES = {
 }
 NEO4J_EDGE_VECTOR_INDEX_NAME = 'edge_fact_embedding'
 
-# HNSW cannot pre-filter on group_id or SearchFilters, so the procedure is asked
-# for more candidates than the caller's LIMIT and the surplus absorbs post-filtering.
-VECTOR_INDEX_OVERFETCH_FACTOR = 3
-
 
 def get_vector_indices(provider: GraphProvider, embedding_dim: int) -> list[LiteralString]:
     """Return vector index DDL for the given provider.
@@ -234,10 +230,8 @@ def get_vector_similarity_query(
 
     procedure = 'queryRelationships' if relationship else 'queryNodes'
     yielded = 'relationship' if relationship else 'node'
-    k = limit * VECTOR_INDEX_OVERFETCH_FACTOR
-
     return (
-        f"CALL db.index.vector.{procedure}('{index_name}', {k}, $search_vector) "
+        f"CALL db.index.vector.{procedure}('{index_name}', {limit}, $search_vector) "
         f'YIELD {yielded} AS {entity_var}, score '
     )
 
@@ -249,4 +243,7 @@ def use_vector_index(driver) -> bool:
     deployments keep the exact-recall brute-force path until they opt in and have
     built the indices.
     """
-    return getattr(driver, 'use_vector_index', False)
+    return (
+        getattr(driver, 'provider', None) == GraphProvider.NEO4J
+        and getattr(driver, 'use_vector_index', False) is True
+    )

--- a/graphiti_core/graph_queries.py
+++ b/graphiti_core/graph_queries.py
@@ -185,11 +185,10 @@ NEO4J_EDGE_VECTOR_INDEX_NAME = 'edge_fact_embedding'
 
 # Neo4j's vector procedures cannot pre-filter on group_id / SearchFilters. When a
 # filter is present the procedure is asked for ``limit * VECTOR_INDEX_OVERFETCH_FACTOR``
-# candidates and the filter runs over that set. ``group_id`` is a partition key
-# (one group usually owns most of the graph), so the over-fetched window almost
-# always contains ``limit`` in-group hits; when it does not, the search returns
-# fewer rows, exactly as the exact path does when fewer than ``limit`` rows clear
-# ``min_score``. ``LIMIT`` is an upper bound in both paths.
+# candidates and the filter runs over that set. The candidate window is a bounded
+# fast path rather than an exact guarantee: callers rerun the exact cosine query
+# when post-filtering produces fewer than ``limit`` rows, preserving the old row
+# count/recall contract while keeping the common case off the full scan.
 VECTOR_INDEX_OVERFETCH_FACTOR = 4
 
 

--- a/graphiti_core/graph_queries.py
+++ b/graphiti_core/graph_queries.py
@@ -173,3 +173,80 @@ def get_relationships_query(name: str, limit: int, provider: GraphProvider) -> s
         return f"CALL QUERY_FTS_INDEX('{label}', '{name}', cast($query AS STRING), TOP := $limit)"
 
     return f'CALL db.index.fulltext.queryRelationships("{name}", $query, {{limit: $limit}})'
+
+
+# Neo4j vector index names, keyed by the embedded property they cover.
+NEO4J_VECTOR_INDEX_NAMES = {
+    'entity_name_embedding': ('Entity', 'name_embedding'),
+    'community_name_embedding': ('Community', 'name_embedding'),
+}
+NEO4J_EDGE_VECTOR_INDEX_NAME = 'edge_fact_embedding'
+
+# HNSW cannot pre-filter on group_id or SearchFilters, so the procedure is asked
+# for more candidates than the caller's LIMIT and the surplus absorbs post-filtering.
+VECTOR_INDEX_OVERFETCH_FACTOR = 3
+
+
+def get_vector_indices(provider: GraphProvider, embedding_dim: int) -> list[LiteralString]:
+    """Return vector index DDL for the given provider.
+
+    Only Neo4j is supported today. FalkorDB HNSW support is proposed separately
+    in getzep/graphiti#1335; Kuzu and Neptune have no equivalent procedure here.
+    """
+    if provider != GraphProvider.NEO4J:
+        return []
+
+    from typing import cast
+
+    options = (
+        f'OPTIONS {{indexConfig: {{'
+        f'`vector.dimensions`: {embedding_dim}, '
+        f"`vector.similarity_function`: 'cosine'"
+        f'}}}}'
+    )
+
+    queries = [
+        f'CREATE VECTOR INDEX {name} IF NOT EXISTS FOR (n:{label}) ON (n.{prop}) {options}'
+        for name, (label, prop) in NEO4J_VECTOR_INDEX_NAMES.items()
+    ]
+    queries.append(
+        f'CREATE VECTOR INDEX {NEO4J_EDGE_VECTOR_INDEX_NAME} IF NOT EXISTS '
+        f'FOR ()-[e:RELATES_TO]-() ON (e.fact_embedding) {options}'
+    )
+
+    return cast(list[LiteralString], queries)
+
+
+def get_vector_similarity_query(
+    provider: GraphProvider,
+    index_name: str,
+    entity_var: str,
+    limit: int,
+    relationship: bool = True,
+) -> str:
+    """Return a Cypher fragment that yields (entity, score) from a vector index.
+
+    Returns an empty string for providers without vector index support, letting
+    callers fall back to the brute-force cosine path.
+    """
+    if provider != GraphProvider.NEO4J:
+        return ''
+
+    procedure = 'queryRelationships' if relationship else 'queryNodes'
+    yielded = 'relationship' if relationship else 'node'
+    k = limit * VECTOR_INDEX_OVERFETCH_FACTOR
+
+    return (
+        f"CALL db.index.vector.{procedure}('{index_name}', {k}, $search_vector) "
+        f'YIELD {yielded} AS {entity_var}, score '
+    )
+
+
+def use_vector_index(driver) -> bool:
+    """Whether similarity search should route through a vector index.
+
+    Enabled per-driver via ``Neo4jDriver(..., use_vector_index=True)`` so existing
+    deployments keep the exact-recall brute-force path until they opt in and have
+    built the indices.
+    """
+    return getattr(driver, 'use_vector_index', False)

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -38,6 +38,7 @@ from graphiti_core.edges import (
     create_entity_edge_embeddings,
 )
 from graphiti_core.embedder import EmbedderClient, OpenAIEmbedder
+from graphiti_core.embedder.client import EMBEDDING_DIM
 from graphiti_core.errors import EdgeNotFoundError, NodeNotFoundError
 from graphiti_core.graphiti_types import GraphitiClients
 from graphiti_core.helpers import (
@@ -148,6 +149,7 @@ class Graphiti:
         max_coroutines: int | None = None,
         tracer: Tracer | None = None,
         trace_span_prefix: str = 'graphiti',
+        use_vector_index: bool | None = None,
     ):
         """
         Initialize a Graphiti instance.
@@ -184,6 +186,9 @@ class Graphiti:
             An OpenTelemetry tracer instance for distributed tracing. If not provided, tracing is disabled (no-op).
         trace_span_prefix : str, optional
             Prefix to prepend to all span names. Defaults to 'graphiti'.
+        use_vector_index : bool | None, optional
+            Enable Neo4j vector-index search when Graphiti constructs its default
+            Neo4j driver. If omitted, the Neo4j environment fallback is used.
 
         Returns
         -------
@@ -204,12 +209,27 @@ class Graphiti:
         Graphiti if you're using the default OpenAIClient.
         """
 
-        if graph_driver:
+        if graph_driver is None and uri is None:
+            raise ValueError('uri must be provided when graph_driver is None')
+
+        if embedder:
+            self.embedder = embedder
+        else:
+            self.embedder = OpenAIEmbedder()
+
+        if graph_driver is not None:
             self.driver = graph_driver
         else:
-            if uri is None:
-                raise ValueError('uri must be provided when graph_driver is None')
-            self.driver = Neo4jDriver(uri, user, password)
+            assert uri is not None  # Narrowed by the validation above.
+            embedder_config = getattr(self.embedder, 'config', None)
+            embedding_dim = getattr(embedder_config, 'embedding_dim', EMBEDDING_DIM)
+            self.driver = Neo4jDriver(
+                uri,
+                user,
+                password,
+                embedding_dim=embedding_dim,
+                use_vector_index=use_vector_index,
+            )
 
         self.store_raw_episode_content = store_raw_episode_content
         self.max_coroutines = max_coroutines
@@ -217,10 +237,6 @@ class Graphiti:
             self.llm_client = llm_client
         else:
             self.llm_client = OpenAIClient()
-        if embedder:
-            self.embedder = embedder
-        else:
-            self.embedder = OpenAIEmbedder()
         if cross_encoder:
             self.cross_encoder = cross_encoder
         else:

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -679,6 +679,11 @@ async def node_similarity_search(
             driver, search_vector, search_filter, group_ids, limit, min_score
         )
 
+    if use_vector_index(driver) and driver.search_ops is not None:
+        return await driver.search_ops.node_similarity_search(
+            driver, search_vector, search_filter, group_ids, limit, min_score
+        )
+
     filter_queries, filter_params = node_search_filter_query_constructor(
         search_filter, driver.provider
     )

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -29,9 +29,12 @@ from graphiti_core.driver.driver import (
 )
 from graphiti_core.edges import EntityEdge, get_entity_edge_from_record
 from graphiti_core.graph_queries import (
+    NEO4J_EDGE_VECTOR_INDEX_NAME,
     get_nodes_query,
     get_relationships_query,
     get_vector_cosine_func_query,
+    get_vector_similarity_query,
+    use_vector_index,
 )
 from graphiti_core.helpers import (
     lucene_sanitize,
@@ -405,22 +408,59 @@ async def edge_similarity_search(
         else:
             return []
     else:
-        query = (
-            match_query
-            + filter_query
-            + """
-            WITH DISTINCT e, n, m, """
-            + get_vector_cosine_func_query('e.fact_embedding', search_vector_var, driver.provider)
-            + """ AS score
-            WHERE score > $min_score
+        vector_index_query = ''
+        if use_vector_index(driver):
+            vector_index_query = get_vector_similarity_query(
+                driver.provider,
+                index_name=NEO4J_EDGE_VECTOR_INDEX_NAME,
+                entity_var='e',
+                limit=limit,
+            )
+
+        if vector_index_query:
+            # HNSW yields (e, score) directly. Endpoints are still bound so filters
+            # and the return shape are unchanged; post-filtering runs over the
+            # over-fetched candidate set.
+            candidate_filters = ['score > $min_score']
+            if filter_queries:
+                candidate_filters.extend(filter_queries)
+
+            query = (
+                vector_index_query
+                + """
+            MATCH (n:Entity)-[e2:RELATES_TO]->(m:Entity)
+            WHERE e2.uuid = e.uuid
+            WITH DISTINCT e, n, m, score
+            WHERE """
+                + ' AND '.join(candidate_filters)
+                + """
             RETURN
             """
-            + get_entity_edge_return_query(driver.provider)
-            + """
+                + get_entity_edge_return_query(driver.provider)
+                + """
             ORDER BY score DESC
             LIMIT $limit
             """
-        )
+            )
+        else:
+            query = (
+                match_query
+                + filter_query
+                + """
+            WITH DISTINCT e, n, m, """
+                + get_vector_cosine_func_query(
+                    'e.fact_embedding', search_vector_var, driver.provider
+                )
+                + """ AS score
+            WHERE score > $min_score
+            RETURN
+            """
+                + get_entity_edge_return_query(driver.provider)
+                + """
+            ORDER BY score DESC
+            LIMIT $limit
+            """
+            )
 
         records, _, _ = await driver.execute_query(
             query,

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -29,11 +29,9 @@ from graphiti_core.driver.driver import (
 )
 from graphiti_core.edges import EntityEdge, get_entity_edge_from_record
 from graphiti_core.graph_queries import (
-    NEO4J_EDGE_VECTOR_INDEX_NAME,
     get_nodes_query,
     get_relationships_query,
     get_vector_cosine_func_query,
-    get_vector_similarity_query,
     use_vector_index,
 )
 from graphiti_core.helpers import (
@@ -313,6 +311,18 @@ async def edge_similarity_search(
             min_score,
         )
 
+    if use_vector_index(driver) and driver.search_ops is not None:
+        return await driver.search_ops.edge_similarity_search(
+            driver,
+            search_vector,
+            source_node_uuid,
+            target_node_uuid,
+            search_filter,
+            group_ids,
+            limit,
+            min_score,
+        )
+
     match_query = """
         MATCH (n:Entity)-[e:RELATES_TO]->(m:Entity)
     """
@@ -329,13 +339,13 @@ async def edge_similarity_search(
         filter_queries.append('e.group_id IN $group_ids')
         filter_params['group_ids'] = group_ids
 
-        if source_node_uuid is not None:
-            filter_params['source_uuid'] = source_node_uuid
-            filter_queries.append('n.uuid = $source_uuid')
+    if source_node_uuid is not None:
+        filter_params['source_uuid'] = source_node_uuid
+        filter_queries.append('n.uuid = $source_uuid')
 
-        if target_node_uuid is not None:
-            filter_params['target_uuid'] = target_node_uuid
-            filter_queries.append('m.uuid = $target_uuid')
+    if target_node_uuid is not None:
+        filter_params['target_uuid'] = target_node_uuid
+        filter_queries.append('m.uuid = $target_uuid')
 
     filter_query = ''
     if filter_queries:
@@ -408,59 +418,22 @@ async def edge_similarity_search(
         else:
             return []
     else:
-        vector_index_query = ''
-        if use_vector_index(driver):
-            vector_index_query = get_vector_similarity_query(
-                driver.provider,
-                index_name=NEO4J_EDGE_VECTOR_INDEX_NAME,
-                entity_var='e',
-                limit=limit,
-            )
-
-        if vector_index_query:
-            # HNSW yields (e, score) directly. Endpoints are still bound so filters
-            # and the return shape are unchanged; post-filtering runs over the
-            # over-fetched candidate set.
-            candidate_filters = ['score > $min_score']
-            if filter_queries:
-                candidate_filters.extend(filter_queries)
-
-            query = (
-                vector_index_query
-                + """
-            MATCH (n:Entity)-[e2:RELATES_TO]->(m:Entity)
-            WHERE e2.uuid = e.uuid
-            WITH DISTINCT e, n, m, score
-            WHERE """
-                + ' AND '.join(candidate_filters)
-                + """
-            RETURN
-            """
-                + get_entity_edge_return_query(driver.provider)
-                + """
-            ORDER BY score DESC
-            LIMIT $limit
-            """
-            )
-        else:
-            query = (
-                match_query
-                + filter_query
-                + """
+        query = (
+            match_query
+            + filter_query
+            + """
             WITH DISTINCT e, n, m, """
-                + get_vector_cosine_func_query(
-                    'e.fact_embedding', search_vector_var, driver.provider
-                )
-                + """ AS score
+            + get_vector_cosine_func_query('e.fact_embedding', search_vector_var, driver.provider)
+            + """ AS score
             WHERE score > $min_score
             RETURN
             """
-                + get_entity_edge_return_query(driver.provider)
-                + """
+            + get_entity_edge_return_query(driver.provider)
+            + """
             ORDER BY score DESC
             LIMIT $limit
             """
-            )
+        )
 
         records, _, _ = await driver.execute_query(
             query,

--- a/tests/driver/test_neo4j_vector_search_contract.py
+++ b/tests/driver/test_neo4j_vector_search_contract.py
@@ -7,9 +7,10 @@ from neo4j.exceptions import ClientError
 
 from graphiti_core.driver.driver import GraphProvider
 from graphiti_core.driver.neo4j.operations.search_ops import Neo4jSearchOperations
+from graphiti_core.graph_queries import VECTOR_INDEX_OVERFETCH_FACTOR
 from graphiti_core.graphiti import Graphiti
 from graphiti_core.search.search_filters import SearchFilters
-from graphiti_core.search.search_utils import edge_similarity_search
+from graphiti_core.search.search_utils import edge_similarity_search, node_similarity_search
 
 
 def _record(uuid: str, source: str, target: str, group_id: str = 'group') -> dict:
@@ -26,6 +27,18 @@ def _record(uuid: str, source: str, target: str, group_id: str = 'group') -> dic
         'valid_at': None,
         'invalid_at': None,
         'reference_time': None,
+        'attributes': {'uuid': uuid, 'custom': f'attribute-{uuid}'},
+    }
+
+
+def _node_record(uuid: str, group_id: str = 'group') -> dict:
+    return {
+        'uuid': uuid,
+        'name': uuid,
+        'group_id': group_id,
+        'created_at': datetime(2024, 1, 1, tzinfo=timezone.utc),
+        'summary': '',
+        'labels': ['Entity'],
         'attributes': {'uuid': uuid, 'custom': f'attribute-{uuid}'},
     }
 
@@ -120,7 +133,7 @@ async def test_public_search_does_not_leak_vector_opt_in_to_other_providers():
 
 
 @pytest.mark.asyncio
-async def test_node_and_community_similarity_paths_remain_exact_when_edge_hnsw_is_enabled():
+async def test_node_opt_in_uses_hnsw_and_community_remains_exact():
     executor = _executor(([], None, None), ([], None, None))
     operations = Neo4jSearchOperations()
 
@@ -129,52 +142,213 @@ async def test_node_and_community_similarity_paths_remain_exact_when_edge_hnsw_i
 
     node_query = executor.execute_query.await_args_list[0].args[0]
     community_query = executor.execute_query.await_args_list[1].args[0]
-    assert 'vector.similarity.cosine(n.name_embedding' in node_query
+    assert "db.index.vector.queryNodes('entity_name_embedding', 2, $search_vector)" in node_query
+    assert 'YIELD node AS n' in node_query
+    assert 'vector.similarity.cosine' not in node_query
+    assert 'ORDER BY score DESC' in node_query
+    assert 'LIMIT $limit' in node_query
+    # Community search has no HNSW path in this PR and must be untouched.
     assert 'vector.similarity.cosine(c.name_embedding' in community_query
-    assert 'db.index.vector' not in node_query + community_query
+    assert 'db.index.vector' not in community_query
 
 
 @pytest.mark.asyncio
-async def test_filtered_search_uses_exact_prefilter_path_not_fixed_overfetch():
-    limit = 2
-    # Six globally closer results are outside the accepted group. The two valid
-    # results begin at ranks 7 and 8, beyond a fixed 3x candidate window.
-    globally_ranked_groups = ['other-group'] * (limit * 3) + ['sparse-group'] * limit
-    acceptable_records = [
-        _record(f'accepted-{i}', 'source', 'target', group_id='sparse-group') for i in range(limit)
-    ]
+async def test_node_hnsw_preserves_record_shape():
+    records = [_node_record('higher'), _node_record('lower')]
+    executor = _executor((records, None, None))
 
-    async def execute_query(query, **kwargs):
-        if 'db.index.vector.queryRelationships' in query:
-            candidate_groups = globally_ranked_groups[: limit * 3]
-            assert 'sparse-group' not in candidate_groups
-            return ([], None, None)
-        return (acceptable_records, None, None)
-
-    executor = _executor()
-    executor.execute_query.side_effect = execute_query
-
-    edges = await Neo4jSearchOperations().edge_similarity_search(
-        executor,
-        [0.1, 0.2, 0.3],
-        None,
-        None,
-        SearchFilters(edge_types=['works_at']),
-        group_ids=['sparse-group'],
-        limit=limit,
+    nodes = await Neo4jSearchOperations().node_similarity_search(
+        executor, [0.1, 0.2, 0.3], SearchFilters(), limit=2
     )
 
+    assert [node.uuid for node in nodes] == ['higher', 'lower']
+    assert [node.attributes for node in nodes] == [
+        {'custom': 'attribute-higher'},
+        {'custom': 'attribute-lower'},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_public_node_search_dispatch_reaches_neo4j_hnsw():
+    driver = SimpleNamespace(
+        provider=GraphProvider.NEO4J,
+        search_interface=None,
+        search_ops=Neo4jSearchOperations(),
+        use_vector_index=True,
+        embedding_dim=3,
+        execute_query=AsyncMock(return_value=([_node_record('node')], None, None)),
+    )
+
+    nodes = await node_similarity_search(
+        driver, [0.1, 0.2, 0.3], SearchFilters(), limit=1, min_score=0.75
+    )
+
+    query = driver.execute_query.await_args.args[0]
+    kwargs = driver.execute_query.await_args.kwargs
+    assert 'db.index.vector.queryNodes' in query
+    assert kwargs['limit'] == 1
+    assert kwargs['min_score'] == 0.75
+    assert [node.uuid for node in nodes] == ['node']
+
+
+@pytest.mark.asyncio
+async def test_public_node_search_stays_exact_without_opt_in():
+    driver = SimpleNamespace(
+        provider=GraphProvider.NEO4J,
+        search_interface=None,
+        search_ops=Neo4jSearchOperations(),
+        use_vector_index=False,
+        execute_query=AsyncMock(return_value=([], None, None)),
+    )
+
+    await node_similarity_search(driver, [0.1, 0.2, 0.3], SearchFilters(), group_ids=['g'])
+
+    query = driver.execute_query.await_args.args[0]
+    assert 'db.index.vector' not in query
+    assert 'vector.similarity.cosine(n.name_embedding' in query
+    assert 'n.group_id IN $group_ids' in query
+
+
+@pytest.mark.parametrize(
+    ('call', 'procedure', 'filter_fragment', 'response'),
+    [
+        (
+            lambda ops, ex: ops.node_similarity_search(
+                ex, [0.1, 0.2, 0.3], SearchFilters(), group_ids=['g'], limit=2
+            ),
+            'queryNodes',
+            'n.group_id IN $group_ids',
+            ([_node_record('node-1'), _node_record('node-2')], None, None),
+        ),
+        (
+            lambda ops, ex: ops.node_similarity_search(
+                ex, [0.1, 0.2, 0.3], SearchFilters(node_labels=['Person']), limit=2
+            ),
+            'queryNodes',
+            'n:Person',
+            ([_node_record('node-1'), _node_record('node-2')], None, None),
+        ),
+        (
+            lambda ops, ex: ops.edge_similarity_search(
+                ex, [0.1, 0.2, 0.3], None, None, SearchFilters(), group_ids=['g'], limit=2
+            ),
+            'queryRelationships',
+            'e.group_id IN $group_ids',
+            (
+                [_record('edge-1', 'src-1', 'dst-1'), _record('edge-2', 'src-2', 'dst-2')],
+                None,
+                None,
+            ),
+        ),
+        (
+            lambda ops, ex: ops.edge_similarity_search(
+                ex, [0.1, 0.2, 0.3], 'src', 'dst', SearchFilters(), limit=2
+            ),
+            'queryRelationships',
+            'n.uuid = $source_uuid',
+            ([_record('edge-1', 'src', 'dst'), _record('edge-2', 'src', 'dst')], None, None),
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_filtered_search_over_fetches_then_post_filters(
+    call, procedure, filter_fragment, response
+):
+    executor = _executor(response)
+
+    await call(Neo4jSearchOperations(), executor)
+
     query = executor.execute_query.await_args.args[0]
-    assert 'db.index.vector.queryRelationships' not in query
-    assert 'e.group_id IN $group_ids' in query
-    assert 'e.name in $edge_types' in query
+    kwargs = executor.execute_query.await_args.kwargs
+    # k handed to the procedure is widened; the public LIMIT is still the caller's.
+    assert f"db.index.vector.{procedure}('" in query
+    assert f', {2 * VECTOR_INDEX_OVERFETCH_FACTOR}, $search_vector' in query
     assert 'LIMIT $limit' in query
-    assert [edge.uuid for edge in edges] == ['accepted-0', 'accepted-1']
+    assert kwargs['limit'] == 2
+    # The filter is applied after the procedure, in the same WHERE as min_score.
+    assert filter_fragment in query
+    assert query.index('db.index.vector') < query.index(filter_fragment)
+    assert 'score > $min_score' in query
+
+
+@pytest.mark.asyncio
+async def test_filtered_hnsw_falls_back_to_exact_when_candidate_window_is_sparse():
+    exact_records = [_node_record('exact-1'), _node_record('exact-2')]
+    executor = _executor(([_node_record('candidate')], None, None), (exact_records, None, None))
+
+    nodes = await Neo4jSearchOperations().node_similarity_search(
+        executor,
+        [0.1, 0.2, 0.3],
+        SearchFilters(),
+        group_ids=['g'],
+        limit=2,
+    )
+
+    assert executor.execute_query.await_count == 2
+    first_query = executor.execute_query.await_args_list[0].args[0]
+    fallback_query = executor.execute_query.await_args_list[1].args[0]
+    assert "db.index.vector.queryNodes('entity_name_embedding', 8, $search_vector)" in first_query
+    assert 'vector.similarity.cosine(n.name_embedding' not in first_query
+    assert 'vector.similarity.cosine(n.name_embedding' in fallback_query
+    assert [node.uuid for node in nodes] == ['exact-1', 'exact-2']
+
+
+@pytest.mark.asyncio
+async def test_unfiltered_search_does_not_over_fetch():
+    executor = _executor(([], None, None), ([], None, None))
+    operations = Neo4jSearchOperations()
+
+    await operations.node_similarity_search(executor, [0.1, 0.2, 0.3], SearchFilters(), limit=7)
+    await operations.edge_similarity_search(
+        executor, [0.1, 0.2, 0.3], None, None, SearchFilters(), limit=7
+    )
+
+    for call in executor.execute_query.await_args_list:
+        assert ', 7, $search_vector' in call.args[0]
+
+
+@pytest.mark.asyncio
+async def test_filtered_search_forwards_filter_params_to_vector_query():
+    executor = _executor(
+        (
+            [
+                _record('edge-1', 'source-id', 'target-id'),
+                _record('edge-2', 'source-id', 'target-id'),
+            ],
+            None,
+            None,
+        )
+    )
+
+    await Neo4jSearchOperations().edge_similarity_search(
+        executor,
+        [0.1, 0.2, 0.3],
+        'source-id',
+        'target-id',
+        SearchFilters(edge_types=['works_at']),
+        group_ids=['sparse-group'],
+        limit=2,
+    )
+
+    kwargs = executor.execute_query.await_args.kwargs
+    assert kwargs['group_ids'] == ['sparse-group']
+    assert kwargs['source_uuid'] == 'source-id'
+    assert kwargs['target_uuid'] == 'target-id'
+    assert kwargs['edge_types'] == ['works_at']
 
 
 @pytest.mark.asyncio
 async def test_endpoint_filters_apply_without_group_ids():
-    executor = _executor(([], None, None))
+    executor = _executor(
+        (
+            [
+                _record('edge-1', 'source-id', 'target-id'),
+                _record('edge-2', 'source-id', 'target-id'),
+            ],
+            None,
+            None,
+        )
+    )
 
     await Neo4jSearchOperations().edge_similarity_search(
         executor,
@@ -193,8 +367,26 @@ async def test_endpoint_filters_apply_without_group_ids():
     assert kwargs['target_uuid'] == 'target-id'
 
 
+def _node_call(ops, executor, vector=(0.1, 0.2, 0.3)):
+    return ops.node_similarity_search(executor, list(vector), SearchFilters(), limit=2)
+
+
+def _edge_call(ops, executor, vector=(0.1, 0.2, 0.3)):
+    return ops.edge_similarity_search(executor, list(vector), None, None, SearchFilters(), limit=2)
+
+
+_BOTH_PATHS = pytest.mark.parametrize(
+    ('call', 'procedure'),
+    [(_node_call, 'queryNodes'), (_edge_call, 'queryRelationships')],
+    ids=['node', 'edge'],
+)
+
+
+@_BOTH_PATHS
 @pytest.mark.asyncio
-async def test_known_vector_lifecycle_failure_falls_back_to_exact_search(monkeypatch):
+async def test_known_vector_lifecycle_failure_falls_back_to_exact_search(
+    call, procedure, monkeypatch
+):
     class VectorLifecycleError(Exception):
         code = 'Neo.ClientError.Schema.IndexNotFound'
 
@@ -205,15 +397,14 @@ async def test_known_vector_lifecycle_failure_falls_back_to_exact_search(monkeyp
     )
     executor = _executor(VectorLifecycleError('index is not ONLINE'), ([], None, None))
 
-    await Neo4jSearchOperations().edge_similarity_search(
-        executor, [0.1, 0.2, 0.3], None, None, SearchFilters(), limit=2
-    )
+    await call(Neo4jSearchOperations(), executor)
 
     assert executor.execute_query.await_count == 2
     first_query = executor.execute_query.await_args_list[0].args[0]
     fallback_query = executor.execute_query.await_args_list[1].args[0]
-    assert 'db.index.vector.queryRelationships' in first_query
-    assert 'db.index.vector.queryRelationships' not in fallback_query
+    assert f'db.index.vector.{procedure}' in first_query
+    assert 'db.index.vector' not in fallback_query
+    assert 'vector.similarity.cosine' in fallback_query
 
 
 @pytest.mark.parametrize(
@@ -245,59 +436,52 @@ async def test_known_vector_lifecycle_failure_falls_back_to_exact_search(monkeyp
         ),
     ],
 )
+@_BOTH_PATHS
 @pytest.mark.asyncio
-async def test_bounded_fallback_for_known_vector_lifecycle_failures(code, message):
+async def test_bounded_fallback_for_known_vector_lifecycle_failures(call, procedure, code, message):
     executor = _executor(_client_error(code, message), ([], None, None))
 
-    await Neo4jSearchOperations().edge_similarity_search(
-        executor, [0.1, 0.2, 0.3], None, None, SearchFilters(), limit=2
-    )
+    await call(Neo4jSearchOperations(), executor)
 
     assert executor.execute_query.await_count == 2
-    assert 'db.index.vector.queryRelationships' in executor.execute_query.await_args_list[0].args[0]
-    assert (
-        'db.index.vector.queryRelationships'
-        not in executor.execute_query.await_args_list[1].args[0]
-    )
+    assert f'db.index.vector.{procedure}' in executor.execute_query.await_args_list[0].args[0]
+    assert 'db.index.vector' not in executor.execute_query.await_args_list[1].args[0]
 
 
+@_BOTH_PATHS
 @pytest.mark.asyncio
-async def test_programmer_error_is_not_hidden_by_fallback():
+async def test_programmer_error_is_not_hidden_by_fallback(call, procedure):
     executor = _executor(TypeError('bad query composition'))
 
     with pytest.raises(TypeError, match='bad query composition'):
-        await Neo4jSearchOperations().edge_similarity_search(
-            executor, [0.1, 0.2, 0.3], None, None, SearchFilters(), limit=2
-        )
+        await call(Neo4jSearchOperations(), executor)
 
     assert executor.execute_query.await_count == 1
 
 
+@_BOTH_PATHS
 @pytest.mark.asyncio
-async def test_unrecognized_client_error_is_not_hidden_by_fallback():
+async def test_unrecognized_client_error_is_not_hidden_by_fallback(call, procedure):
     error = _client_error(
         'Neo.ClientError.Statement.SyntaxError', 'Invalid input caused by a programming error'
     )
     executor = _executor(error)
 
     with pytest.raises(ClientError, match='programming error'):
-        await Neo4jSearchOperations().edge_similarity_search(
-            executor, [0.1, 0.2, 0.3], None, None, SearchFilters(), limit=2
-        )
+        await call(Neo4jSearchOperations(), executor)
 
     assert executor.execute_query.await_count == 1
 
 
+@_BOTH_PATHS
 @pytest.mark.asyncio
-async def test_vector_dimension_mismatch_is_clear_before_query_execution():
+async def test_vector_dimension_mismatch_is_clear_before_query_execution(call, procedure):
     executor = _executor(([], None, None))
 
     with pytest.raises(
         ValueError, match='query embedding dimension 2.*configured index dimension 3'
     ):
-        await Neo4jSearchOperations().edge_similarity_search(
-            executor, [0.1, 0.2], None, None, SearchFilters(), limit=2
-        )
+        await call(Neo4jSearchOperations(), executor, vector=(0.1, 0.2))
 
     executor.execute_query.assert_not_awaited()
 

--- a/tests/driver/test_neo4j_vector_search_contract.py
+++ b/tests/driver/test_neo4j_vector_search_contract.py
@@ -1,0 +1,377 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from neo4j.exceptions import ClientError
+
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.neo4j.operations.search_ops import Neo4jSearchOperations
+from graphiti_core.graphiti import Graphiti
+from graphiti_core.search.search_filters import SearchFilters
+from graphiti_core.search.search_utils import edge_similarity_search
+
+
+def _record(uuid: str, source: str, target: str, group_id: str = 'group') -> dict:
+    return {
+        'uuid': uuid,
+        'source_node_uuid': source,
+        'target_node_uuid': target,
+        'group_id': group_id,
+        'created_at': datetime(2024, 1, 1, tzinfo=timezone.utc),
+        'name': 'RELATES_TO',
+        'fact': uuid,
+        'episodes': [],
+        'expired_at': None,
+        'valid_at': None,
+        'invalid_at': None,
+        'reference_time': None,
+        'attributes': {'uuid': uuid, 'custom': f'attribute-{uuid}'},
+    }
+
+
+def _executor(*responses):
+    executor = AsyncMock()
+    executor.provider = GraphProvider.NEO4J
+    executor.use_vector_index = True
+    executor.embedding_dim = 3
+    executor.execute_query.side_effect = list(responses)
+    return executor
+
+
+def _client_error(code: str, message: str) -> ClientError:
+    error = ClientError(message)
+    error._neo4j_code = code
+    return error
+
+
+@pytest.mark.asyncio
+async def test_unfiltered_opt_in_uses_hnsw_and_preserves_shape_and_order():
+    records = [_record('higher', 'source-1', 'target-1'), _record('lower', 'source-2', 'target-2')]
+    executor = _executor((records, None, None))
+
+    edges = await Neo4jSearchOperations().edge_similarity_search(
+        executor, [0.1, 0.2, 0.3], None, None, SearchFilters(), limit=2
+    )
+
+    query = executor.execute_query.await_args.args[0]
+    assert 'db.index.vector.queryRelationships' in query
+    assert 'startNode(e) AS n' in query
+    assert 'endNode(e) AS m' in query
+    assert 'matched.uuid = e.uuid' not in query
+    assert 'ORDER BY score DESC' in query
+    assert [(edge.uuid, edge.source_node_uuid, edge.target_node_uuid) for edge in edges] == [
+        ('higher', 'source-1', 'target-1'),
+        ('lower', 'source-2', 'target-2'),
+    ]
+    assert [edge.attributes for edge in edges] == [
+        {'custom': 'attribute-higher'},
+        {'custom': 'attribute-lower'},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_public_search_dispatch_reaches_neo4j_hnsw():
+    records = [_record('edge', 'source', 'target')]
+    driver = SimpleNamespace(
+        provider=GraphProvider.NEO4J,
+        search_interface=None,
+        search_ops=Neo4jSearchOperations(),
+        use_vector_index=True,
+        embedding_dim=3,
+        execute_query=AsyncMock(return_value=(records, None, None)),
+    )
+
+    edges = await edge_similarity_search(
+        driver,
+        [0.1, 0.2, 0.3],
+        None,
+        None,
+        SearchFilters(),
+        limit=1,
+        min_score=0.75,
+    )
+
+    query = driver.execute_query.await_args.args[0]
+    kwargs = driver.execute_query.await_args.kwargs
+    assert 'db.index.vector.queryRelationships' in query
+    assert kwargs['limit'] == 1
+    assert kwargs['min_score'] == 0.75
+    assert [(edge.uuid, edge.source_node_uuid, edge.target_node_uuid) for edge in edges] == [
+        ('edge', 'source', 'target')
+    ]
+
+
+@pytest.mark.asyncio
+async def test_public_search_does_not_leak_vector_opt_in_to_other_providers():
+    provider_search = AsyncMock(side_effect=AssertionError('provider search must not be called'))
+    driver = SimpleNamespace(
+        provider=GraphProvider.FALKORDB,
+        search_interface=None,
+        search_ops=SimpleNamespace(edge_similarity_search=provider_search),
+        use_vector_index=True,
+        execute_query=AsyncMock(return_value=([], None, None)),
+    )
+
+    await edge_similarity_search(driver, [0.1, 0.2, 0.3], None, None, SearchFilters(), limit=1)
+
+    provider_search.assert_not_awaited()
+    assert 'db.index.vector' not in driver.execute_query.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_node_and_community_similarity_paths_remain_exact_when_edge_hnsw_is_enabled():
+    executor = _executor(([], None, None), ([], None, None))
+    operations = Neo4jSearchOperations()
+
+    await operations.node_similarity_search(executor, [0.1, 0.2, 0.3], SearchFilters(), limit=2)
+    await operations.community_similarity_search(executor, [0.1, 0.2, 0.3], limit=2)
+
+    node_query = executor.execute_query.await_args_list[0].args[0]
+    community_query = executor.execute_query.await_args_list[1].args[0]
+    assert 'vector.similarity.cosine(n.name_embedding' in node_query
+    assert 'vector.similarity.cosine(c.name_embedding' in community_query
+    assert 'db.index.vector' not in node_query + community_query
+
+
+@pytest.mark.asyncio
+async def test_filtered_search_uses_exact_prefilter_path_not_fixed_overfetch():
+    limit = 2
+    # Six globally closer results are outside the accepted group. The two valid
+    # results begin at ranks 7 and 8, beyond a fixed 3x candidate window.
+    globally_ranked_groups = ['other-group'] * (limit * 3) + ['sparse-group'] * limit
+    acceptable_records = [
+        _record(f'accepted-{i}', 'source', 'target', group_id='sparse-group') for i in range(limit)
+    ]
+
+    async def execute_query(query, **kwargs):
+        if 'db.index.vector.queryRelationships' in query:
+            candidate_groups = globally_ranked_groups[: limit * 3]
+            assert 'sparse-group' not in candidate_groups
+            return ([], None, None)
+        return (acceptable_records, None, None)
+
+    executor = _executor()
+    executor.execute_query.side_effect = execute_query
+
+    edges = await Neo4jSearchOperations().edge_similarity_search(
+        executor,
+        [0.1, 0.2, 0.3],
+        None,
+        None,
+        SearchFilters(edge_types=['works_at']),
+        group_ids=['sparse-group'],
+        limit=limit,
+    )
+
+    query = executor.execute_query.await_args.args[0]
+    assert 'db.index.vector.queryRelationships' not in query
+    assert 'e.group_id IN $group_ids' in query
+    assert 'e.name in $edge_types' in query
+    assert 'LIMIT $limit' in query
+    assert [edge.uuid for edge in edges] == ['accepted-0', 'accepted-1']
+
+
+@pytest.mark.asyncio
+async def test_endpoint_filters_apply_without_group_ids():
+    executor = _executor(([], None, None))
+
+    await Neo4jSearchOperations().edge_similarity_search(
+        executor,
+        [0.1, 0.2, 0.3],
+        'source-id',
+        'target-id',
+        SearchFilters(),
+        limit=2,
+    )
+
+    query = executor.execute_query.await_args.args[0]
+    kwargs = executor.execute_query.await_args.kwargs
+    assert 'n.uuid = $source_uuid' in query
+    assert 'm.uuid = $target_uuid' in query
+    assert kwargs['source_uuid'] == 'source-id'
+    assert kwargs['target_uuid'] == 'target-id'
+
+
+@pytest.mark.asyncio
+async def test_known_vector_lifecycle_failure_falls_back_to_exact_search(monkeypatch):
+    class VectorLifecycleError(Exception):
+        code = 'Neo.ClientError.Schema.IndexNotFound'
+
+    monkeypatch.setattr(
+        'graphiti_core.driver.neo4j.operations.search_ops.ClientError',
+        VectorLifecycleError,
+        raising=False,
+    )
+    executor = _executor(VectorLifecycleError('index is not ONLINE'), ([], None, None))
+
+    await Neo4jSearchOperations().edge_similarity_search(
+        executor, [0.1, 0.2, 0.3], None, None, SearchFilters(), limit=2
+    )
+
+    assert executor.execute_query.await_count == 2
+    first_query = executor.execute_query.await_args_list[0].args[0]
+    fallback_query = executor.execute_query.await_args_list[1].args[0]
+    assert 'db.index.vector.queryRelationships' in first_query
+    assert 'db.index.vector.queryRelationships' not in fallback_query
+
+
+@pytest.mark.parametrize(
+    ('code', 'message'),
+    [
+        (
+            'Neo.ClientError.Procedure.ProcedureNotFound',
+            'There is no procedure with the name db.index.vector.queryRelationships',
+        ),
+        (
+            'Neo.ClientError.Procedure.ProcedureCallFailed',
+            "The index 'edge_fact_embedding' is not ONLINE.",
+        ),
+        (
+            'Neo.ClientError.Procedure.ProcedureCallFailed',
+            "The index 'edge_fact_embedding' is still POPULATING.",
+        ),
+        (
+            'Neo.ClientError.Procedure.ProcedureCallFailed',
+            "The index 'edge_fact_embedding' is OFFLINE.",
+        ),
+        (
+            'Neo.ClientError.Procedure.ProcedureCallFailed',
+            'Index query vector has 3 dimensions, but indexed vectors have 2.',
+        ),
+        (
+            'Neo.ClientError.Procedure.ProcedureCallFailed',
+            "The index 'edge_fact_embedding' is not a vector index.",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_bounded_fallback_for_known_vector_lifecycle_failures(code, message):
+    executor = _executor(_client_error(code, message), ([], None, None))
+
+    await Neo4jSearchOperations().edge_similarity_search(
+        executor, [0.1, 0.2, 0.3], None, None, SearchFilters(), limit=2
+    )
+
+    assert executor.execute_query.await_count == 2
+    assert 'db.index.vector.queryRelationships' in executor.execute_query.await_args_list[0].args[0]
+    assert (
+        'db.index.vector.queryRelationships'
+        not in executor.execute_query.await_args_list[1].args[0]
+    )
+
+
+@pytest.mark.asyncio
+async def test_programmer_error_is_not_hidden_by_fallback():
+    executor = _executor(TypeError('bad query composition'))
+
+    with pytest.raises(TypeError, match='bad query composition'):
+        await Neo4jSearchOperations().edge_similarity_search(
+            executor, [0.1, 0.2, 0.3], None, None, SearchFilters(), limit=2
+        )
+
+    assert executor.execute_query.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_client_error_is_not_hidden_by_fallback():
+    error = _client_error(
+        'Neo.ClientError.Statement.SyntaxError', 'Invalid input caused by a programming error'
+    )
+    executor = _executor(error)
+
+    with pytest.raises(ClientError, match='programming error'):
+        await Neo4jSearchOperations().edge_similarity_search(
+            executor, [0.1, 0.2, 0.3], None, None, SearchFilters(), limit=2
+        )
+
+    assert executor.execute_query.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_vector_dimension_mismatch_is_clear_before_query_execution():
+    executor = _executor(([], None, None))
+
+    with pytest.raises(
+        ValueError, match='query embedding dimension 2.*configured index dimension 3'
+    ):
+        await Neo4jSearchOperations().edge_similarity_search(
+            executor, [0.1, 0.2], None, None, SearchFilters(), limit=2
+        )
+
+    executor.execute_query.assert_not_awaited()
+
+
+def test_graphiti_default_neo4j_driver_uses_actual_embedder_dimension(monkeypatch):
+    driver_factory = Mock(return_value=SimpleNamespace())
+    monkeypatch.setattr('graphiti_core.graphiti.Neo4jDriver', driver_factory)
+    monkeypatch.setattr(
+        'graphiti_core.graphiti.GraphitiClients', Mock(return_value=SimpleNamespace())
+    )
+    monkeypatch.setattr('graphiti_core.graphiti.NodeNamespace', Mock())
+    monkeypatch.setattr('graphiti_core.graphiti.EdgeNamespace', Mock())
+    embedder = SimpleNamespace(config=SimpleNamespace(embedding_dim=768))
+    llm_client = SimpleNamespace(set_tracer=Mock())
+
+    Graphiti(
+        uri='bolt://unused',
+        user='neo4j',
+        password='unused',
+        embedder=embedder,
+        llm_client=llm_client,
+        cross_encoder=SimpleNamespace(),
+        use_vector_index=True,
+    )
+
+    driver_factory.assert_called_once_with(
+        'bolt://unused',
+        'neo4j',
+        'unused',
+        embedding_dim=768,
+        use_vector_index=True,
+    )
+
+
+def test_graphiti_does_not_apply_neo4j_vector_args_to_supplied_non_neo4j_driver(monkeypatch):
+    driver = SimpleNamespace(provider=GraphProvider.FALKORDB)
+    monkeypatch.setattr(
+        'graphiti_core.graphiti.GraphitiClients', Mock(return_value=SimpleNamespace())
+    )
+    monkeypatch.setattr('graphiti_core.graphiti.NodeNamespace', Mock())
+    monkeypatch.setattr('graphiti_core.graphiti.EdgeNamespace', Mock())
+    llm_client = SimpleNamespace(set_tracer=Mock())
+
+    graphiti = Graphiti(
+        graph_driver=driver,
+        embedder=SimpleNamespace(config=SimpleNamespace(embedding_dim=768)),
+        llm_client=llm_client,
+        cross_encoder=SimpleNamespace(),
+        use_vector_index=True,
+    )
+
+    assert graphiti.driver is driver
+    assert not hasattr(driver, 'use_vector_index')
+
+
+def test_graphiti_environment_opt_in_reaches_default_neo4j_driver(monkeypatch):
+    monkeypatch.setenv('GRAPHITI_NEO4J_USE_VECTOR_INDEX', 'true')
+    monkeypatch.setattr('graphiti_core.driver.neo4j_driver.AsyncGraphDatabase.driver', Mock())
+    monkeypatch.setattr(
+        'graphiti_core.graphiti.GraphitiClients', Mock(return_value=SimpleNamespace())
+    )
+    monkeypatch.setattr('graphiti_core.graphiti.NodeNamespace', Mock())
+    monkeypatch.setattr('graphiti_core.graphiti.EdgeNamespace', Mock())
+    llm_client = SimpleNamespace(set_tracer=Mock())
+
+    graphiti = Graphiti(
+        uri='bolt://unused',
+        user='neo4j',
+        password='unused',
+        embedder=SimpleNamespace(config=SimpleNamespace(embedding_dim=768)),
+        llm_client=llm_client,
+        cross_encoder=SimpleNamespace(),
+    )
+
+    assert graphiti.driver.provider == GraphProvider.NEO4J
+    assert graphiti.driver.embedding_dim == 768
+    assert graphiti.driver.use_vector_index is True

--- a/tests/test_mcp_embedding_dimension.py
+++ b/tests/test_mcp_embedding_dimension.py
@@ -1,0 +1,54 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock
+
+from graphiti_core.graphiti import Graphiti
+
+
+def test_mcp_factory_dimension_reaches_default_driver_without_vector_index(monkeypatch):
+    schema = ModuleType('config.schema')
+    schema.DatabaseConfig = SimpleNamespace
+    schema.EmbedderConfig = SimpleNamespace
+    schema.LLMConfig = SimpleNamespace
+    config_package = ModuleType('config')
+    config_package.schema = schema
+    monkeypatch.setitem(sys.modules, 'config', config_package)
+    monkeypatch.setitem(sys.modules, 'config.schema', schema)
+
+    factory_path = Path(__file__).parents[1] / 'mcp_server/src/services/factories.py'
+    spec = importlib.util.spec_from_file_location('mcp_embedding_factories', factory_path)
+    assert spec is not None and spec.loader is not None
+    factories = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(factories)
+
+    embedder = factories.EmbedderFactory.create(
+        SimpleNamespace(
+            provider='openai',
+            model='text-embedding-3-small',
+            dimensions=8192,
+            providers=SimpleNamespace(
+                openai=SimpleNamespace(api_key='test-key', api_url='https://api.openai.com/v1')
+            ),
+        )
+    )
+    monkeypatch.setenv('GRAPHITI_NEO4J_USE_VECTOR_INDEX', 'false')
+    monkeypatch.setattr('graphiti_core.driver.neo4j_driver.AsyncGraphDatabase.driver', Mock())
+    monkeypatch.setattr(
+        'graphiti_core.graphiti.GraphitiClients', Mock(return_value=SimpleNamespace())
+    )
+    monkeypatch.setattr('graphiti_core.graphiti.NodeNamespace', Mock())
+    monkeypatch.setattr('graphiti_core.graphiti.EdgeNamespace', Mock())
+
+    graphiti = Graphiti(
+        uri='bolt://unused',
+        user='neo4j',
+        password='unused',
+        embedder=embedder,
+        llm_client=SimpleNamespace(set_tracer=Mock()),
+        cross_encoder=SimpleNamespace(),
+    )
+
+    assert graphiti.driver.embedding_dim == 8192
+    assert graphiti.driver.use_vector_index is False

--- a/tests/test_vector_index_env.py
+++ b/tests/test_vector_index_env.py
@@ -2,12 +2,14 @@
 
 Deployments that construct Graphiti indirectly (e.g. the MCP server, which calls
 Graphiti(uri=..., user=..., password=...) and never touches Neo4jDriver directly)
-cannot pass use_vector_index=True. Support GRAPHITI_NEO4J_USE_VECTOR_INDEX so the
-feature is reachable from configuration without a code change, while the explicit
-constructor argument still wins when supplied.
+can use GRAPHITI_NEO4J_USE_VECTOR_INDEX. Explicit constructor configuration still
+wins, while index dimensions come from the configured embedder rather than a second
+environment setting that can drift from it.
 """
 
 from unittest.mock import patch
+
+import pytest
 
 from graphiti_core.driver.neo4j_driver import Neo4jDriver
 
@@ -32,7 +34,7 @@ class TestUseVectorIndexEnvVar:
             assert _make_driver().use_vector_index is True, raw
 
     def test_env_accepts_common_falsy_spellings(self, monkeypatch):
-        for raw in ('0', 'false', 'False', 'no', 'off', ''):
+        for raw in ('0', 'false', 'False', 'no', 'off', '', 'malformed'):
             monkeypatch.setenv('GRAPHITI_NEO4J_USE_VECTOR_INDEX', raw)
             assert _make_driver().use_vector_index is False, raw
 
@@ -43,16 +45,30 @@ class TestUseVectorIndexEnvVar:
         monkeypatch.setenv('GRAPHITI_NEO4J_USE_VECTOR_INDEX', 'true')
         assert _make_driver(use_vector_index=False).use_vector_index is False
 
-    def test_embedding_dim_env_override(self, monkeypatch):
+    def test_embedding_dim_env_does_not_override_embedder_coupled_default(self, monkeypatch):
+        from graphiti_core.driver.neo4j_driver import EMBEDDING_DIM
+
         monkeypatch.setenv('GRAPHITI_NEO4J_EMBEDDING_DIM', '2560')
-        assert _make_driver().embedding_dim == 2560
+        assert _make_driver().embedding_dim == EMBEDDING_DIM
 
     def test_embedding_dim_explicit_argument_wins(self, monkeypatch):
         monkeypatch.setenv('GRAPHITI_NEO4J_EMBEDDING_DIM', '2560')
         assert _make_driver(embedding_dim=1024).embedding_dim == 1024
 
-    def test_embedding_dim_ignores_malformed_env(self, monkeypatch):
+    @pytest.mark.parametrize('embedding_dim', [0, -1, 4097, 1.5, True])
+    def test_embedding_dim_rejects_values_neo4j_cannot_index(self, embedding_dim):
+        with pytest.raises(ValueError, match='embedding_dim must be an integer between 1 and 4096'):
+            _make_driver(embedding_dim=embedding_dim)
+
+    def test_embedding_dim_ignores_disconnected_malformed_env(self, monkeypatch):
         from graphiti_core.driver.neo4j_driver import EMBEDDING_DIM
 
         monkeypatch.setenv('GRAPHITI_NEO4J_EMBEDDING_DIM', 'not-a-number')
         assert _make_driver().embedding_dim == EMBEDDING_DIM
+
+    def test_embedding_dim_ignores_disconnected_non_positive_env(self, monkeypatch):
+        from graphiti_core.driver.neo4j_driver import EMBEDDING_DIM
+
+        for raw in ('0', '-1'):
+            monkeypatch.setenv('GRAPHITI_NEO4J_EMBEDDING_DIM', raw)
+            assert _make_driver().embedding_dim == EMBEDDING_DIM

--- a/tests/test_vector_index_env.py
+++ b/tests/test_vector_index_env.py
@@ -7,11 +7,14 @@ wins, while index dimensions come from the configured embedder rather than a sec
 environment setting that can drift from it.
 """
 
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
 
 from graphiti_core.driver.neo4j_driver import Neo4jDriver
+from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig
+from graphiti_core.graphiti import Graphiti
 
 
 def _make_driver(**kwargs):
@@ -55,10 +58,75 @@ class TestUseVectorIndexEnvVar:
         monkeypatch.setenv('GRAPHITI_NEO4J_EMBEDDING_DIM', '2560')
         assert _make_driver(embedding_dim=1024).embedding_dim == 1024
 
-    @pytest.mark.parametrize('embedding_dim', [0, -1, 4097, 1.5, True])
-    def test_embedding_dim_rejects_values_neo4j_cannot_index(self, embedding_dim):
-        with pytest.raises(ValueError, match='embedding_dim must be an integer between 1 and 4096'):
+    @pytest.mark.parametrize('embedding_dim', [1.5, True, 0, -1])
+    def test_embedding_dim_rejects_invalid_values_without_vector_index(self, embedding_dim):
+        with pytest.raises(ValueError, match='embedding_dim must be a positive integer'):
+            _make_driver(embedding_dim=embedding_dim, use_vector_index=False)
+
+    @pytest.mark.parametrize('embedding_dim', [4097, 8192])
+    @pytest.mark.parametrize('use_vector_index', [False, None])
+    def test_large_embedding_dim_is_accepted_when_vector_index_is_disabled(
+        self, monkeypatch, embedding_dim, use_vector_index
+    ):
+        monkeypatch.setenv('GRAPHITI_NEO4J_USE_VECTOR_INDEX', 'false')
+
+        driver = _make_driver(
+            embedding_dim=embedding_dim,
+            use_vector_index=use_vector_index,
+        )
+
+        assert driver.embedding_dim == embedding_dim
+        assert driver.use_vector_index is False
+
+    def test_large_embedding_dim_is_accepted_with_default_opt_out(self, monkeypatch):
+        monkeypatch.delenv('GRAPHITI_NEO4J_USE_VECTOR_INDEX', raising=False)
+
+        driver = _make_driver(embedding_dim=8192)
+
+        assert driver.embedding_dim == 8192
+        assert driver.use_vector_index is False
+
+    @pytest.mark.parametrize('embedding_dim', [4097, 8192])
+    def test_large_embedding_dim_is_rejected_with_explicit_vector_index(self, embedding_dim):
+        with pytest.raises(ValueError, match='embedding_dim must not exceed 4096'):
+            _make_driver(embedding_dim=embedding_dim, use_vector_index=True)
+
+    @pytest.mark.parametrize('embedding_dim', [4097, 8192])
+    def test_large_embedding_dim_is_rejected_with_environment_vector_index(
+        self, monkeypatch, embedding_dim
+    ):
+        monkeypatch.setenv('GRAPHITI_NEO4J_USE_VECTOR_INDEX', 'true')
+
+        with pytest.raises(ValueError, match='embedding_dim must not exceed 4096'):
             _make_driver(embedding_dim=embedding_dim)
+
+    @pytest.mark.parametrize('use_vector_index', [None, False])
+    def test_graphiti_accepts_large_configured_dimension_without_vector_index(
+        self, monkeypatch, use_vector_index
+    ):
+        monkeypatch.delenv('GRAPHITI_NEO4J_USE_VECTOR_INDEX', raising=False)
+        monkeypatch.setattr('graphiti_core.driver.neo4j_driver.AsyncGraphDatabase.driver', Mock())
+        monkeypatch.setattr(
+            'graphiti_core.graphiti.GraphitiClients', Mock(return_value=SimpleNamespace())
+        )
+        monkeypatch.setattr('graphiti_core.graphiti.NodeNamespace', Mock())
+        monkeypatch.setattr('graphiti_core.graphiti.EdgeNamespace', Mock())
+        embedder = OpenAIEmbedder(
+            config=OpenAIEmbedderConfig(api_key='test-key', embedding_dim=8192)
+        )
+
+        graphiti = Graphiti(
+            uri='bolt://unused',
+            user='neo4j',
+            password='unused',
+            embedder=embedder,
+            llm_client=SimpleNamespace(set_tracer=Mock()),
+            cross_encoder=SimpleNamespace(),
+            use_vector_index=use_vector_index,
+        )
+
+        assert graphiti.driver.embedding_dim == 8192
+        assert graphiti.driver.use_vector_index is False
 
     def test_embedding_dim_ignores_disconnected_malformed_env(self, monkeypatch):
         from graphiti_core.driver.neo4j_driver import EMBEDDING_DIM

--- a/tests/test_vector_index_env.py
+++ b/tests/test_vector_index_env.py
@@ -1,0 +1,58 @@
+"""Env-var opt-in for the Neo4j vector index path.
+
+Deployments that construct Graphiti indirectly (e.g. the MCP server, which calls
+Graphiti(uri=..., user=..., password=...) and never touches Neo4jDriver directly)
+cannot pass use_vector_index=True. Support GRAPHITI_NEO4J_USE_VECTOR_INDEX so the
+feature is reachable from configuration without a code change, while the explicit
+constructor argument still wins when supplied.
+"""
+
+from unittest.mock import patch
+
+from graphiti_core.driver.neo4j_driver import Neo4jDriver
+
+
+def _make_driver(**kwargs):
+    with patch('graphiti_core.driver.neo4j_driver.AsyncGraphDatabase.driver'):
+        return Neo4jDriver(uri='bolt://localhost:7687', user='neo4j', password='x', **kwargs)
+
+
+class TestUseVectorIndexEnvVar:
+    def test_defaults_to_false_without_env(self, monkeypatch):
+        monkeypatch.delenv('GRAPHITI_NEO4J_USE_VECTOR_INDEX', raising=False)
+        assert _make_driver().use_vector_index is False
+
+    def test_env_true_enables(self, monkeypatch):
+        monkeypatch.setenv('GRAPHITI_NEO4J_USE_VECTOR_INDEX', 'true')
+        assert _make_driver().use_vector_index is True
+
+    def test_env_accepts_common_truthy_spellings(self, monkeypatch):
+        for raw in ('1', 'TRUE', 'True', 'yes', 'on'):
+            monkeypatch.setenv('GRAPHITI_NEO4J_USE_VECTOR_INDEX', raw)
+            assert _make_driver().use_vector_index is True, raw
+
+    def test_env_accepts_common_falsy_spellings(self, monkeypatch):
+        for raw in ('0', 'false', 'False', 'no', 'off', ''):
+            monkeypatch.setenv('GRAPHITI_NEO4J_USE_VECTOR_INDEX', raw)
+            assert _make_driver().use_vector_index is False, raw
+
+    def test_explicit_argument_overrides_env(self, monkeypatch):
+        monkeypatch.setenv('GRAPHITI_NEO4J_USE_VECTOR_INDEX', 'false')
+        assert _make_driver(use_vector_index=True).use_vector_index is True
+
+        monkeypatch.setenv('GRAPHITI_NEO4J_USE_VECTOR_INDEX', 'true')
+        assert _make_driver(use_vector_index=False).use_vector_index is False
+
+    def test_embedding_dim_env_override(self, monkeypatch):
+        monkeypatch.setenv('GRAPHITI_NEO4J_EMBEDDING_DIM', '2560')
+        assert _make_driver().embedding_dim == 2560
+
+    def test_embedding_dim_explicit_argument_wins(self, monkeypatch):
+        monkeypatch.setenv('GRAPHITI_NEO4J_EMBEDDING_DIM', '2560')
+        assert _make_driver(embedding_dim=1024).embedding_dim == 1024
+
+    def test_embedding_dim_ignores_malformed_env(self, monkeypatch):
+        from graphiti_core.driver.neo4j_driver import EMBEDDING_DIM
+
+        monkeypatch.setenv('GRAPHITI_NEO4J_EMBEDDING_DIM', 'not-a-number')
+        assert _make_driver().embedding_dim == EMBEDDING_DIM

--- a/tests/test_vector_indices.py
+++ b/tests/test_vector_indices.py
@@ -14,6 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from unittest.mock import AsyncMock
+
+import pytest
+
 from graphiti_core.driver.driver import GraphProvider
 from graphiti_core.driver.neo4j_driver import Neo4jDriver
 from graphiti_core.graph_queries import (
@@ -25,6 +29,19 @@ from graphiti_core.graph_queries import (
 
 class TestGetVectorIndices:
     """Vector index DDL emitted for each provider."""
+
+    def test_neo4j_vector_ddl_is_exact_and_stably_named(self):
+        assert get_vector_indices(GraphProvider.NEO4J, embedding_dim=1024) == [
+            'CREATE VECTOR INDEX entity_name_embedding IF NOT EXISTS FOR (n:Entity) '
+            'ON (n.name_embedding) OPTIONS {indexConfig: {`vector.dimensions`: 1024, '
+            "`vector.similarity_function`: 'cosine'}}",
+            'CREATE VECTOR INDEX community_name_embedding IF NOT EXISTS FOR (n:Community) '
+            'ON (n.name_embedding) OPTIONS {indexConfig: {`vector.dimensions`: 1024, '
+            "`vector.similarity_function`: 'cosine'}}",
+            'CREATE VECTOR INDEX edge_fact_embedding IF NOT EXISTS FOR ()-[e:RELATES_TO]-() '
+            'ON (e.fact_embedding) OPTIONS {indexConfig: {`vector.dimensions`: 1024, '
+            "`vector.similarity_function`: 'cosine'}}",
+        ]
 
     def test_neo4j_creates_hnsw_indices_for_all_embedded_properties(self):
         queries = get_vector_indices(GraphProvider.NEO4J, embedding_dim=1024)
@@ -88,8 +105,8 @@ class TestGetVectorSimilarityQuery:
 
         assert 'db.index.vector.queryNodes' in query
 
-    def test_over_fetches_candidates_for_post_filtering(self):
-        """HNSW cannot pre-filter on group_id/SearchFilters, so candidates must be over-fetched."""
+    def test_uses_public_limit_without_claiming_post_filter_guarantees(self):
+        """Filtered searches use exact cosine; this helper is only for unfiltered HNSW."""
         limit = 20
         query = get_vector_similarity_query(
             GraphProvider.NEO4J,
@@ -98,9 +115,7 @@ class TestGetVectorSimilarityQuery:
             limit=limit,
         )
 
-        # The procedure's k must exceed the caller's LIMIT so post-filtering
-        # cannot silently truncate the result set below `limit`.
-        assert str(limit * 3) in query
+        assert f', {limit}, $search_vector' in query
 
     def test_non_neo4j_providers_return_empty(self):
         for provider in (GraphProvider.FALKORDB, GraphProvider.KUZU, GraphProvider.NEPTUNE):
@@ -121,9 +136,17 @@ class TestUseVectorIndex:
 
     def test_respects_driver_opt_in(self):
         class _Driver:
+            provider = GraphProvider.NEO4J
             use_vector_index = True
 
         assert use_vector_index(_Driver()) is True
+
+    def test_non_neo4j_opt_in_does_not_leak(self):
+        class _Driver:
+            provider = GraphProvider.FALKORDB
+            use_vector_index = True
+
+        assert use_vector_index(_Driver()) is False
 
 
 class TestNeo4jDriverVectorIndexWiring:
@@ -132,16 +155,20 @@ class TestNeo4jDriverVectorIndexWiring:
         driver.use_vector_index = False
         assert use_vector_index(driver) is False
 
-    def test_build_indices_skips_vector_ddl_by_default(self):
-        """Default init must not trigger an expensive background index build."""
-        queries = get_vector_indices(GraphProvider.NEO4J, embedding_dim=1024)
-        assert queries, 'sanity: DDL exists when explicitly requested'
-        # The default path in build_indices_and_constraints() appends these only
-        # when build_vector_indices=True; covered by signature default below.
-        import inspect
+    @pytest.mark.asyncio
+    async def test_public_build_uses_driver_vector_opt_in(self):
+        """Graphiti.build_indices_and_constraints() must honor the driver opt-in."""
+        driver = Neo4jDriver.__new__(Neo4jDriver)
+        driver.embedding_dim = 768
+        driver.use_vector_index = True
+        driver._execute_index_query = AsyncMock()
 
-        sig = inspect.signature(Neo4jDriver.build_indices_and_constraints)
-        assert sig.parameters['build_vector_indices'].default is False
+        await driver.build_indices_and_constraints()
+
+        queries = [call.args[0] for call in driver._execute_index_query.await_args_list]
+        assert get_vector_indices(GraphProvider.NEO4J, embedding_dim=768) == [
+            query for query in queries if 'CREATE VECTOR INDEX' in query
+        ]
 
     def test_embedding_dim_is_configurable_not_hardcoded(self):
         import inspect

--- a/tests/test_vector_indices.py
+++ b/tests/test_vector_indices.py
@@ -21,6 +21,7 @@ import pytest
 from graphiti_core.driver.driver import GraphProvider
 from graphiti_core.driver.neo4j_driver import Neo4jDriver
 from graphiti_core.graph_queries import (
+    VECTOR_INDEX_OVERFETCH_FACTOR,
     get_vector_indices,
     get_vector_similarity_query,
     use_vector_index,
@@ -105,17 +106,26 @@ class TestGetVectorSimilarityQuery:
 
         assert 'db.index.vector.queryNodes' in query
 
-    def test_uses_public_limit_without_claiming_post_filter_guarantees(self):
-        """Filtered searches use exact cosine; this helper is only for unfiltered HNSW."""
-        limit = 20
+    def test_candidate_window_defaults_to_limit(self):
         query = get_vector_similarity_query(
-            GraphProvider.NEO4J,
-            index_name='edge_fact_embedding',
-            entity_var='e',
-            limit=limit,
+            GraphProvider.NEO4J, index_name='edge_fact_embedding', entity_var='e', limit=20
         )
 
-        assert f', {limit}, $search_vector' in query
+        assert ', 20, $search_vector' in query
+
+    def test_explicit_candidate_window_widens_procedure_k_only(self):
+        """Filtered callers over-fetch; k changes, the caller's limit does not."""
+        query = get_vector_similarity_query(
+            GraphProvider.NEO4J,
+            index_name='entity_name_embedding',
+            entity_var='n',
+            limit=10,
+            relationship=False,
+            candidates=10 * VECTOR_INDEX_OVERFETCH_FACTOR,
+        )
+
+        assert f', {10 * VECTOR_INDEX_OVERFETCH_FACTOR}, $search_vector' in query
+        assert 'YIELD node AS n' in query
 
     def test_non_neo4j_providers_return_empty(self):
         for provider in (GraphProvider.FALKORDB, GraphProvider.KUZU, GraphProvider.NEPTUNE):

--- a/tests/test_vector_indices.py
+++ b/tests/test_vector_indices.py
@@ -1,0 +1,151 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.neo4j_driver import Neo4jDriver
+from graphiti_core.graph_queries import (
+    get_vector_indices,
+    get_vector_similarity_query,
+    use_vector_index,
+)
+
+
+class TestGetVectorIndices:
+    """Vector index DDL emitted for each provider."""
+
+    def test_neo4j_creates_hnsw_indices_for_all_embedded_properties(self):
+        queries = get_vector_indices(GraphProvider.NEO4J, embedding_dim=1024)
+
+        joined = '\n'.join(queries)
+        assert 'CREATE VECTOR INDEX' in joined
+
+        # Every embedded property Graphiti searches over must be covered.
+        assert 'e.fact_embedding' in joined or 'fact_embedding' in joined
+        assert 'name_embedding' in joined
+
+    def test_neo4j_uses_supplied_embedding_dimension(self):
+        """Regression: #859 hardcoded 1024, breaking non-1024 embedders."""
+        queries = get_vector_indices(GraphProvider.NEO4J, embedding_dim=2560)
+
+        joined = '\n'.join(queries)
+        assert '2560' in joined
+        assert '1024' not in joined
+
+    def test_neo4j_uses_cosine_similarity(self):
+        queries = get_vector_indices(GraphProvider.NEO4J, embedding_dim=1024)
+
+        joined = '\n'.join(queries)
+        assert "'cosine'" in joined
+
+    def test_neo4j_indices_are_idempotent(self):
+        """build_indices_and_constraints runs on every driver init."""
+        queries = get_vector_indices(GraphProvider.NEO4J, embedding_dim=1024)
+
+        for query in queries:
+            assert 'IF NOT EXISTS' in query
+
+    def test_non_neo4j_providers_emit_no_vector_indices(self):
+        """FalkorDB/Kuzu/Neptune vector indexing is out of scope for this change."""
+        for provider in (GraphProvider.FALKORDB, GraphProvider.KUZU, GraphProvider.NEPTUNE):
+            assert get_vector_indices(provider, embedding_dim=1024) == []
+
+
+class TestGetVectorSimilarityQuery:
+    """Similarity search routed through the HNSW index when it is available."""
+
+    def test_neo4j_edge_search_uses_vector_index_procedure(self):
+        query = get_vector_similarity_query(
+            GraphProvider.NEO4J,
+            index_name='edge_fact_embedding',
+            entity_var='e',
+            limit=20,
+        )
+
+        assert 'db.index.vector.queryRelationships' in query
+        assert 'edge_fact_embedding' in query
+
+    def test_neo4j_node_search_uses_node_index_procedure(self):
+        query = get_vector_similarity_query(
+            GraphProvider.NEO4J,
+            index_name='entity_name_embedding',
+            entity_var='n',
+            limit=20,
+            relationship=False,
+        )
+
+        assert 'db.index.vector.queryNodes' in query
+
+    def test_over_fetches_candidates_for_post_filtering(self):
+        """HNSW cannot pre-filter on group_id/SearchFilters, so candidates must be over-fetched."""
+        limit = 20
+        query = get_vector_similarity_query(
+            GraphProvider.NEO4J,
+            index_name='edge_fact_embedding',
+            entity_var='e',
+            limit=limit,
+        )
+
+        # The procedure's k must exceed the caller's LIMIT so post-filtering
+        # cannot silently truncate the result set below `limit`.
+        assert str(limit * 3) in query
+
+    def test_non_neo4j_providers_return_empty(self):
+        for provider in (GraphProvider.FALKORDB, GraphProvider.KUZU, GraphProvider.NEPTUNE):
+            assert (
+                get_vector_similarity_query(provider, index_name='x', entity_var='e', limit=10)
+                == ''
+            )
+
+
+class TestUseVectorIndex:
+    """Opt-in gate: existing deployments keep brute-force until they enable it."""
+
+    def test_defaults_to_disabled_for_drivers_without_the_flag(self):
+        class _Driver:
+            pass
+
+        assert use_vector_index(_Driver()) is False
+
+    def test_respects_driver_opt_in(self):
+        class _Driver:
+            use_vector_index = True
+
+        assert use_vector_index(_Driver()) is True
+
+
+class TestNeo4jDriverVectorIndexWiring:
+    def test_driver_defaults_to_brute_force(self):
+        driver = Neo4jDriver.__new__(Neo4jDriver)
+        driver.use_vector_index = False
+        assert use_vector_index(driver) is False
+
+    def test_build_indices_skips_vector_ddl_by_default(self):
+        """Default init must not trigger an expensive background index build."""
+        queries = get_vector_indices(GraphProvider.NEO4J, embedding_dim=1024)
+        assert queries, 'sanity: DDL exists when explicitly requested'
+        # The default path in build_indices_and_constraints() appends these only
+        # when build_vector_indices=True; covered by signature default below.
+        import inspect
+
+        sig = inspect.signature(Neo4jDriver.build_indices_and_constraints)
+        assert sig.parameters['build_vector_indices'].default is False
+
+    def test_embedding_dim_is_configurable_not_hardcoded(self):
+        import inspect
+
+        sig = inspect.signature(Neo4jDriver.__init__)
+        assert 'embedding_dim' in sig.parameters
+        assert 'use_vector_index' in sig.parameters


### PR DESCRIPTION
Refs #1793.

## Problem

Neo4j similarity search computes `vector.similarity.cosine()` against every matching node/edge. On larger graphs this makes dedup/search take minutes and can leave long-running transactions behind.

## What this does

- Creates opt-in Neo4j vector indexes for `Entity.name_embedding`, `Community.name_embedding`, and `RELATES_TO.fact_embedding`, using the configured embedding dimension rather than a hard-coded dimension.
- Routes both `node_similarity_search` and `edge_similarity_search` through `db.index.vector.queryNodes` / `queryRelationships` when `use_vector_index` is enabled.
- Keeps the exact cosine path as the default and as a fallback when the index is unavailable, offline, populating, mismatched, or otherwise cannot be used.
- Applies `group_id`, search, and endpoint filters after a bounded ANN over-fetch. If the filtered candidate window is sparse, it reruns the exact query so the old result-count contract is preserved.
- Plumbs the opt-in through `Neo4jDriver` and the public `Graphiti` constructor; indirect MCP construction can use `GRAPHITI_NEO4J_USE_VECTOR_INDEX`.
- Fixes the pre-existing edge bug where source/target UUID filters were silently ignored when `group_ids` was `None`.
- Leaves `community_similarity_search` and non-Neo4j providers unchanged.

## Why this is not a blind #859 revert

#859 previously added an HNSW path but used a hard-coded dimension and a simpler opt-in. This implementation keeps indexing disabled by default, couples the index dimension to the configured embedder, preserves exact fallback, validates query dimensions, bounds lifecycle fallback to known index errors, and covers both node and edge search paths.

## Evidence

A live local Neo4j 5.26 graph with approximately 52k `Entity` nodes and 2560-dimensional embeddings was used for an independent node canary. For the same real embedding vector:

- HNSW `queryNodes` top-10: approximately 4.9 seconds under host load
- Existing brute-force cosine top-10: approximately 155 seconds
- Top-10 set and order: identical in the single-seed comparison

A second live filtered probe used 12 random `xiaoyaner-core` seeds. The HNSW candidate path returned 10 rows for every seed and reduced the measured query time from 490.5 seconds total to 6.6 seconds total. Six of twelve had identical set and order; the remaining results had the same row count but ANN ranking/set differences, which is expected from approximate search and is why exact fallback remains available for sparse windows and the feature is opt-in.

A sparse-group probe showed the bounded candidate window can produce fewer than the requested limit. The implementation detects that case and reruns the exact filtered query; a focused regression test covers this fallback.

## Testing

- `85 passed` focused tests covering node/edge routing, filters, over-fetch, sparse-window exact fallback, lifecycle fallback, dimension validation, result shape, public wiring, and provider isolation.
- `ruff check` clean.
- `ruff format --check` clean.
- `git diff --check` clean.

The repository-wide non-integration suite was attempted but cannot be used as a green gate in this environment: unrelated integration-marked tests try to connect to `localhost:7687`, while the live Neo4j instance is isolated inside Docker and is not exposed on that host port. The run reached existing database-dependent errors; no code failure from this patch was established.

## Scope / trade-off

HNSW is approximate. Results may differ from exact cosine even when the candidate window is full. Operators who require exact recall can leave the opt-in disabled. Operators enabling it should create/verify the indexes and compare their workload before making it the default in their deployment.

Index creation remains opt-in to avoid silently starting a potentially expensive index population during upgrade. The current local deployment has the indexes online and has separately verified the live node path, but this PR does not change upstream defaults.
