### PR TITLE
fix(anthropic): omit temperature instead of sending null when it is unset (#1794)

### DIFF
--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -285,15 +285,21 @@ class AnthropicClient(LLMClient):
         try:
             # Create the appropriate tool based on whether response_model is provided
             tools, tool_choice = self._create_tool(response_model)
-            result = await self.client.messages.create(
-                system=system_message.content,
-                max_tokens=max_creation_tokens,
-                temperature=self.temperature,
-                messages=user_messages_cast,
-                model=self.model,
-                tools=tools,
-                tool_choice=tool_choice,
-            )
+            create_kwargs: dict[str, typing.Any] = {
+                'system': system_message.content,
+                'max_tokens': max_creation_tokens,
+                'messages': user_messages_cast,
+                'model': self.model,
+                'tools': tools,
+                'tool_choice': tool_choice,
+            }
+            # Omit temperature entirely when it is unset — don't even send None.
+            # The Anthropic SDK serializes an explicit None as `"temperature": null`,
+            # which the API rejects with a 400 invalid_request_error.
+            if self.temperature is not None:
+                create_kwargs['temperature'] = self.temperature
+
+            result = await self.client.messages.create(**create_kwargs)
 
             # Extract token usage from the response
             input_tokens = 0

--- a/tests/llm_client/test_anthropic_client.py
+++ b/tests/llm_client/test_anthropic_client.py
@@ -251,5 +251,67 @@ class TestAnthropicClientGenerateResponse:
         assert result['test_field'] == 'correct_value'
 
 
+class TestAnthropicClientTemperature:
+    """Tests for how the temperature parameter is forwarded to the Anthropic API."""
+
+    @staticmethod
+    def _client_with_temperature(temperature):
+        """Build an AnthropicClient with a mocked messages.create returning a tool_use."""
+        config = LLMConfig(
+            api_key='test_api_key',
+            model='claude-haiku-4-5-latest',
+            temperature=temperature,
+            max_tokens=1000,
+        )
+        client = AnthropicClient(config=config, cache=False)
+
+        content_item = MagicMock()
+        content_item.type = 'tool_use'
+        content_item.input = {'test_field': 'test_value'}
+
+        mock_response = MagicMock()
+        mock_response.content = [content_item]
+
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        client.client = mock_client
+        return client, mock_client
+
+    @pytest.mark.asyncio
+    async def test_temperature_omitted_when_unset(self):
+        """An unset temperature must not be sent at all.
+
+        The Anthropic API rejects `"temperature": null` with a 400
+        invalid_request_error, and the SDK serializes an explicit ``None``
+        instead of dropping the key.
+        """
+        client, mock_client = self._client_with_temperature(None)
+
+        await client.generate_response([Message(role='user', content='Test message')])
+
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert 'temperature' not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_zero_temperature_is_still_sent(self):
+        """A temperature of 0.0 is a meaningful value and must be forwarded."""
+        client, mock_client = self._client_with_temperature(0.0)
+
+        await client.generate_response([Message(role='user', content='Test message')])
+
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert kwargs['temperature'] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_explicit_temperature_is_forwarded(self):
+        """A regular temperature is forwarded unchanged."""
+        client, mock_client = self._client_with_temperature(0.7)
+
+        await client.generate_response([Message(role='user', content='Test message')])
+
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert kwargs['temperature'] == 0.7
+
+
 if __name__ == '__main__':
     pytest.main(['-v', 'test_anthropic_client.py'])


### PR DESCRIPTION
Fixes #1794.

## Problem

`mcp_server/src/config/schema.py` defaults `llm.temperature` to `None`, and
`mcp_server/src/services/factories.py` passes it straight through to the core
`LLMConfig` — with the same comment repeated at all five provider branches:

```python
# None is intentional for reasoning models; core LLMConfig stores it
# verbatim and downstream clients omit temperature when it is None.
temperature=config.temperature,  # type: ignore[arg-type]
```

`OpenAIClient` honors that contract (`openai_client.py`):

```python
# Omit temperature entirely for reasoning models — don't even send None.
if not is_reasoning_model and temperature is not None:
    request_kwargs['temperature'] = temperature
```

`AnthropicClient` did not — it forwarded `self.temperature` to
`messages.create()` unconditionally. The Anthropic SDK serializes an explicit
`None` rather than dropping the key, so the request body carries
`"temperature": null` and the API rejects it:

```
400 - {'type': 'error', 'error': {'type': 'invalid_request_error',
       'message': 'temperature: Input should be a valid number'}}
```

Which I confirmed at the wire level against a mocked httpx transport
(anthropic 0.120.2):

| call | key on the wire | value |
|---|---|---|
| `messages.create(..., temperature=None)` | present | `null` |
| `messages.create(...)` (omitted) | **absent** | — |
| `messages.create(..., temperature=0.0)` | present | `0.0` |

Under the MCP server this is invisible to callers: the episode queue catches the
exception, logs it and marks the task done, so every `add_memory` still reports
success while nothing lands.

## Fix

Build the `messages.create()` kwargs and add `temperature` only when it is not
`None`, mirroring `OpenAIClient._create_completion`. The guard is `is not None`,
not truthiness, so an explicit `temperature=0.0` is still sent.

## Verification

Reproduction against the real `AnthropicClient` with a mocked
`messages.create`, before → after:

| config | before | after |
|---|---|---|
| `temperature` unset (`None`) | sent as `None` | **omitted** |
| `temperature=0.0` | sent as `0.0` | sent as `0.0` |
| `temperature=0.7` | sent as `0.7` | sent as `0.7` |

Tests (`tests/llm_client/test_anthropic_client.py`, new
`TestAnthropicClientTemperature`) cover all three rows.

- Full file: **11 passed** before, **14 passed** after.
- Red/green: reverting only `anthropic_client.py` while keeping the new tests
  fails **exactly** `test_temperature_omitted_when_unset` (13 passed, 1 failed).
  The two guard cases stay green on both sides, which is what they are for.
- `pytest tests/llm_client tests/test_text_utils.py tests/utils`: **297 passed,
  2 skipped** (the skips are the `_int` tests, no `ANTHROPIC_API_KEY`).
- `ruff==0.14.11` (the version pinned in `.github/workflows/lint.yml`)
  `check` and `format --check` clean on both files.

## Deliberately not in scope

The issue reports two things; this PR fixes only the first.

- **`OpenAIGenericClient`, `GeminiClient`, `GroqClient`** also pass
  `temperature=self.temperature` through unconditionally, so the factory's
  "downstream clients omit temperature when it is `None`" comment is not true
  for them either. Whether that is actually a bug depends on how each of those
  APIs treats an explicit `null`, which I have not verified the way I verified
  Anthropic's — so I left them alone rather than guess. Happy to follow up if
  you'd like them covered.
- **Surfacing per-episode queue failures** (the issue's second half — a queue
  that turns hard failures into log lines while the tool call reports success).
  That is an MCP server API-shape decision, not a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
