### PR TITLE
fix(graphiti): route group writes per call instead of rebinding the shared client (#1795)

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -344,7 +344,11 @@ class Graphiti:
         await self.driver.close()
 
     async def _get_or_create_saga(
-        self, saga_name: str, group_id: str, created_at: datetime
+        self,
+        saga_name: str,
+        group_id: str,
+        created_at: datetime,
+        driver: GraphDriver | None = None,
     ) -> SagaNode:
         """
         Get an existing saga by name or create a new one.
@@ -360,6 +364,11 @@ class Graphiti:
             originating episode's reference time (``valid_at``) rather than the
             current wall-clock time so the saga's ``created_at`` reflects the
             episode it was minted from.
+        driver : GraphDriver | None
+            Optional. Driver to run the saga lookup/creation against. Defaults to
+            ``self.driver``. Callers that route a write at a specific ``group_id``
+            must pass the routed driver so the saga lands in the same graph as the
+            episode it belongs to.
 
         Returns
         -------
@@ -368,7 +377,9 @@ class Graphiti:
         """
         from graphiti_core.helpers import parse_db_date
 
-        records, _, _ = await self.driver.execute_query(
+        driver = driver if driver is not None else self.driver
+
+        records, _, _ = await driver.execute_query(
             """
             MATCH (s:Saga {name: $name, group_id: $group_id})
             RETURN s.uuid AS uuid, s.name AS name, s.group_id AS group_id, s.created_at AS created_at
@@ -388,22 +399,31 @@ class Graphiti:
             )
 
         saga = SagaNode(name=saga_name, group_id=group_id, created_at=created_at)
-        await saga.save(self.driver)
+        await saga.save(driver)
         return saga
 
     async def _saga_get_previous_episode_uuid(
-        self, saga_uuid: str, current_episode_uuid: str
+        self,
+        saga_uuid: str,
+        current_episode_uuid: str,
+        driver: GraphDriver | None = None,
     ) -> str | None:
-        """Find the most recent episode UUID in a saga, excluding the current one."""
-        if self.driver.graph_operations_interface:
+        """Find the most recent episode UUID in a saga, excluding the current one.
+
+        ``driver`` defaults to ``self.driver``; routed writes must pass their own
+        driver so the lookup reads the graph the episode is being written to.
+        """
+        driver = driver if driver is not None else self.driver
+
+        if driver.graph_operations_interface:
             try:
-                return await self.driver.graph_operations_interface.saga_get_previous_episode_uuid(
-                    self.driver, saga_uuid, current_episode_uuid
+                return await driver.graph_operations_interface.saga_get_previous_episode_uuid(
+                    driver, saga_uuid, current_episode_uuid
                 )
             except NotImplementedError:
                 pass
 
-        records, _, _ = await self.driver.execute_query(
+        records, _, _ = await driver.execute_query(
             """
             MATCH (s:Saga {uuid: $saga_uuid})-[:HAS_EPISODE]->(e:Episodic)
             WHERE e.uuid <> $current_episode_uuid
@@ -639,8 +659,13 @@ class Graphiti:
         nodes: list[EntityNode],
         uuid_map: dict[str, str],
         custom_extraction_instructions: str | None = None,
+        clients: GraphitiClients | None = None,
     ) -> tuple[list[EntityEdge], list[EntityEdge], list[EntityEdge]]:
         """Extract edges from episode(s) and resolve against existing graph.
+
+        ``clients`` defaults to ``self.clients``; routed writes must pass the
+        clients bound to their per-call driver so extraction and resolution read
+        the same graph the episode is written to.
 
         Returns
         -------
@@ -650,11 +675,12 @@ class Graphiti:
             - invalidated_edges: Edges invalidated by new information
             - new_edges: Only edges that are new to the graph (not duplicates)
         """
+        clients = clients if clients is not None else self.clients
         episodes = episode if isinstance(episode, list) else [episode]
         primary_episode = episodes[0]
 
         extracted_edges = await extract_edges(
-            self.clients,
+            clients,
             episode,
             extracted_nodes,
             previous_episodes,
@@ -667,7 +693,7 @@ class Graphiti:
         edges = resolve_edge_pointers(extracted_edges, uuid_map)
 
         resolved_edges, invalidated_edges, new_edges = await resolve_extracted_edges(
-            self.clients,
+            clients,
             edges,
             primary_episode,
             nodes,
@@ -687,6 +713,7 @@ class Graphiti:
         saga: str | SagaNode | None = None,
         saga_previous_episode_uuid: str | None = None,
         node_episode_index_map: dict[str, list[int]] | None = None,
+        driver: GraphDriver | None = None,
     ) -> tuple[list[EpisodicEdge], EpisodicNode]:
         """Process and save episode data to the graph.
 
@@ -713,7 +740,15 @@ class Graphiti:
         node_episode_index_map : dict[str, list[int]] | None
             Optional mapping from node UUID to 0-indexed episode positions for
             building episodic edges with correct attribution.
+        driver : GraphDriver | None
+            Optional. Driver every graph write in this method is issued against.
+            Defaults to ``self.driver``. Callers that route a write at a specific
+            ``group_id`` must pass the routed driver, otherwise the episode, its
+            episodic edges, the resolved nodes and entity edges, and any saga
+            relations are persisted to the base graph while the reads that
+            produced them ran against the routed one.
         """
+        driver = driver if driver is not None else self.driver
         episodes = episode if isinstance(episode, list) else [episode]
         episode_uuids = [ep.uuid for ep in episodes]
 
@@ -724,7 +759,7 @@ class Graphiti:
                 ep.content = ''
 
         await add_nodes_and_edges_bulk(
-            self.driver,
+            driver,
             episodes,
             episodic_edges,
             nodes,
@@ -742,7 +777,9 @@ class Graphiti:
                 # newly created saga so its created_at matches the episode that
                 # minted it, not the wall-clock time of this run.
                 saga_created_at = primary_episode.valid_at or now
-                saga_node = await self._get_or_create_saga(saga, group_id, saga_created_at)
+                saga_node = await self._get_or_create_saga(
+                    saga, group_id, saga_created_at, driver=driver
+                )
             else:
                 saga_node = saga
 
@@ -750,7 +787,7 @@ class Graphiti:
             previous_episode_uuid: str | None = saga_previous_episode_uuid
             if previous_episode_uuid is None:
                 previous_episode_uuid = await self._saga_get_previous_episode_uuid(
-                    saga_node.uuid, primary_episode.uuid
+                    saga_node.uuid, primary_episode.uuid, driver=driver
                 )
 
             # Create NEXT_EPISODE edge from the previous episode to the new one
@@ -761,7 +798,7 @@ class Graphiti:
                     group_id=group_id,
                     created_at=now,
                 )
-                await next_episode_edge.save(self.driver)
+                await next_episode_edge.save(driver)
 
             # Create HAS_EPISODE edge from saga to the new episode
             has_episode_edge = HasEpisodeEdge(
@@ -770,13 +807,13 @@ class Graphiti:
                 group_id=group_id,
                 created_at=now,
             )
-            await has_episode_edge.save(self.driver)
+            await has_episode_edge.save(driver)
 
             # Track first and last episode on the saga node
             if saga_node.first_episode_uuid is None:
                 saga_node.first_episode_uuid = primary_episode.uuid
             saga_node.last_episode_uuid = primary_episode.uuid
-            await saga_node.save(self.driver)
+            await saga_node.save(driver)
 
         return episodic_edges, primary_episode
 
@@ -788,15 +825,22 @@ class Graphiti:
         entity_types: dict[str, type[BaseModel]] | None,
         excluded_entity_types: list[str] | None,
         custom_extraction_instructions: str | None = None,
+        clients: GraphitiClients | None = None,
     ) -> tuple[
         dict[str, list[EntityNode]],
         dict[str, str],
         list[list[EntityEdge]],
     ]:
-        """Extract nodes and edges from all episodes and deduplicate."""
+        """Extract nodes and edges from all episodes and deduplicate.
+
+        ``clients`` defaults to ``self.clients``; routed writes must pass the
+        clients bound to their per-call driver.
+        """
+        clients = clients if clients is not None else self.clients
+
         # Extract all nodes and edges for each episode
         extracted_nodes_bulk, extracted_edges_bulk = await extract_nodes_and_edges_bulk(
-            self.clients,
+            clients,
             episode_context,
             edge_type_map=edge_type_map,
             edge_types=edge_types,
@@ -807,7 +851,7 @@ class Graphiti:
 
         # Dedupe extracted nodes in memory
         nodes_by_episode, uuid_map = await dedupe_nodes_bulk(
-            self.clients, extracted_nodes_bulk, episode_context, entity_types
+            clients, extracted_nodes_bulk, episode_context, entity_types
         )
 
         return nodes_by_episode, uuid_map, extracted_edges_bulk
@@ -821,8 +865,14 @@ class Graphiti:
         edge_types: dict[str, type[BaseModel]] | None,
         edge_type_map: dict[tuple[str, str], list[str]],
         episodes: list[EpisodicNode],
+        clients: GraphitiClients | None = None,
     ) -> tuple[list[EntityNode], list[EntityEdge], list[EntityEdge], dict[str, str]]:
-        """Resolve nodes and edges against the existing graph."""
+        """Resolve nodes and edges against the existing graph.
+
+        ``clients`` defaults to ``self.clients``; routed writes must pass the
+        clients bound to their per-call driver.
+        """
+        clients = clients if clients is not None else self.clients
         nodes_by_uuid: dict[str, EntityNode] = {
             node.uuid: node for nodes in nodes_by_episode.values() for node in nodes
         }
@@ -842,7 +892,7 @@ class Graphiti:
         node_results = await semaphore_gather(
             *[
                 resolve_extracted_nodes(
-                    self.clients,
+                    clients,
                     nodes_by_episode_unique[episode.uuid],
                     episode,
                     previous_episodes,
@@ -875,7 +925,7 @@ class Graphiti:
         hydrated_nodes_results: list[list[EntityNode]] = await semaphore_gather(
             *[
                 extract_attributes_from_nodes(
-                    self.clients,
+                    clients,
                     nodes_by_episode_unique[episode.uuid],
                     episode,
                     previous_episodes,
@@ -902,7 +952,7 @@ class Graphiti:
         edge_results = await semaphore_gather(
             *[
                 resolve_extracted_edges(
-                    self.clients,
+                    clients,
                     edges_by_episode_unique[episode.uuid],
                     episode,
                     final_hydrated_nodes,
@@ -1172,6 +1222,7 @@ class Graphiti:
                     nodes,
                     uuid_map,
                     custom_extraction_instructions,
+                    clients=clients,
                 )
 
                 entity_edges = resolved_edges + invalidated_edges
@@ -1197,6 +1248,7 @@ class Graphiti:
                     saga,
                     saga_previous_episode_uuid,
                     node_episode_index_map,
+                    driver=driver,
                 )
 
                 # Update communities if requested
@@ -1378,6 +1430,7 @@ class Graphiti:
                     entity_types,
                     excluded_entity_types,
                     custom_extraction_instructions,
+                    clients=clients,
                 )
 
                 # Create Episodic Edges
@@ -1413,6 +1466,7 @@ class Graphiti:
                     edge_types,
                     edge_type_map or edge_type_map_default,
                     episodes,
+                    clients=clients,
                 )
 
                 # Resolved pointers for episodic edges
@@ -1437,7 +1491,9 @@ class Graphiti:
                         # episode window rather than the time this run started.
                         valid_ats = [ep.valid_at for ep in episodes if ep.valid_at is not None]
                         saga_created_at = min(valid_ats) if valid_ats else now
-                        saga_node = await self._get_or_create_saga(saga, group_id, saga_created_at)
+                        saga_node = await self._get_or_create_saga(
+                            saga, group_id, saga_created_at, driver=driver
+                        )
                     else:
                         saga_node = saga
 
@@ -1446,7 +1502,7 @@ class Graphiti:
 
                     # Find the most recent episode already in the saga
                     previous_episode_uuid = await self._saga_get_previous_episode_uuid(
-                        saga_node.uuid, ''
+                        saga_node.uuid, '', driver=driver
                     )
 
                     for episode in sorted_episodes:

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -977,6 +977,24 @@ class Graphiti:
 
         return await retrieve_episodes(driver, reference_time, last_n, group_ids, source, saga)
 
+    def _driver_for_group(self, group_id: str) -> GraphDriver:
+        """Return a driver routed at ``group_id``, without touching ``self.driver``.
+
+        Providers that keep each group in its own database need the write to run
+        against that database. Cloning per call keeps the routing local, so a
+        long-lived client shared across groups is not left pointing at whichever
+        group wrote last.
+        """
+        if group_id == self.driver._database:
+            return self.driver
+        return self.driver.clone(database=group_id)
+
+    def _clients_for_driver(self, driver: GraphDriver) -> GraphitiClients:
+        """Return ``self.clients`` bound to ``driver``, without mutating the shared model."""
+        if driver is self.driver:
+            return self.clients
+        return self.clients.model_copy(update={'driver': driver})
+
     async def add_episode(
         self,
         name: str,
@@ -1074,12 +1092,14 @@ class Graphiti:
             # if group_id is None, use the default group id by the provider
             # and the preset database name will be used
             group_id = get_default_group_id(self.driver.provider)
+            driver = self.driver
         else:
             validate_group_id(group_id)
-            if group_id != self.driver._database:
-                # if group_id is provided, use it as the database name
-                self.driver = self.driver.clone(database=group_id)
-                self.clients.driver = self.driver
+            # Route this call to the group's database without mutating the shared
+            # client: assigning to self.driver leaves every later read on a
+            # long-lived client pointed at whichever group wrote last.
+            driver = self._driver_for_group(group_id)
+        clients = self._clients_for_driver(driver)
 
         with self.tracer.start_span('add_episode') as span:
             try:
@@ -1090,14 +1110,15 @@ class Graphiti:
                         last_n=RELEVANT_SCHEMA_LIMIT,
                         group_ids=[group_id],
                         source=source,
+                        driver=driver,
                     )
                     if previous_episode_uuids is None
-                    else await EpisodicNode.get_by_uuids(self.driver, previous_episode_uuids)
+                    else await EpisodicNode.get_by_uuids(driver, previous_episode_uuids)
                 )
 
                 # Get or create episode
                 episode = (
-                    await EpisodicNode.get_by_uuid(self.driver, uuid)
+                    await EpisodicNode.get_by_uuid(driver, uuid)
                     if uuid is not None
                     else EpisodicNode(
                         name=name,
@@ -1120,7 +1141,7 @@ class Graphiti:
 
                 # Extract and resolve nodes
                 extracted_nodes, node_episode_index_map = await extract_nodes(
-                    self.clients,
+                    clients,
                     episode,
                     previous_episodes,
                     entity_types,
@@ -1129,7 +1150,7 @@ class Graphiti:
                 )
 
                 nodes, uuid_map, _ = await resolve_extracted_nodes(
-                    self.clients,
+                    clients,
                     extracted_nodes,
                     episode,
                     previous_episodes,
@@ -1158,7 +1179,7 @@ class Graphiti:
                 # Extract node attributes - only pass new edges for summary generation
                 # to avoid duplicating facts that already exist in the graph
                 hydrated_nodes = await extract_attributes_from_nodes(
-                    self.clients,
+                    clients,
                     nodes,
                     episode,
                     previous_episodes,
@@ -1184,7 +1205,7 @@ class Graphiti:
                 if update_communities:
                     communities, community_edges = await semaphore_gather(
                         *[
-                            update_community(self.driver, self.llm_client, self.embedder, node)
+                            update_community(driver, self.llm_client, self.embedder, node)
                             for node in nodes
                         ],
                         max_coroutines=self.max_coroutines,
@@ -1302,12 +1323,12 @@ class Graphiti:
                 # if group_id is None, use the default group id by the provider
                 if group_id is None:
                     group_id = get_default_group_id(self.driver.provider)
+                    driver = self.driver
                 else:
                     validate_group_id(group_id)
-                    if group_id != self.driver._database:
-                        # if group_id is provided, use it as the database name
-                        self.driver = self.driver.clone(database=group_id)
-                        self.clients.driver = self.driver
+                    # Route this call without mutating the shared client (see add_episode).
+                    driver = self._driver_for_group(group_id)
+                clients = self._clients_for_driver(driver)
 
                 # Create default edge type map
                 edge_type_map_default = (
@@ -1317,7 +1338,7 @@ class Graphiti:
                 )
 
                 episodes = [
-                    await EpisodicNode.get_by_uuid(self.driver, episode.uuid)
+                    await EpisodicNode.get_by_uuid(driver, episode.uuid)
                     if episode.uuid is not None
                     else EpisodicNode(
                         name=episode.name,
@@ -1334,7 +1355,7 @@ class Graphiti:
 
                 # Save all episodes
                 await add_nodes_and_edges_bulk(
-                    driver=self.driver,
+                    driver=driver,
                     episodic_nodes=episodes,
                     episodic_edges=[],
                     entity_nodes=[],
@@ -1343,7 +1364,7 @@ class Graphiti:
                 )
 
                 # Get previous episode context for each episode
-                episode_context = await retrieve_previous_episodes_bulk(self.driver, episodes)
+                episode_context = await retrieve_previous_episodes_bulk(driver, episodes)
 
                 # Extract and dedupe nodes and edges
                 (
@@ -1370,7 +1391,7 @@ class Graphiti:
                 ]
 
                 edges_by_episode = await dedupe_edges_bulk(
-                    self.clients,
+                    clients,
                     extracted_edges_bulk_updated,
                     episode_context,
                     [],
@@ -1399,7 +1420,7 @@ class Graphiti:
 
                 # save data to KG
                 await add_nodes_and_edges_bulk(
-                    self.driver,
+                    driver,
                     episodes,
                     resolved_episodic_edges,
                     final_hydrated_nodes,
@@ -1437,7 +1458,7 @@ class Graphiti:
                                 group_id=group_id,
                                 created_at=now,
                             )
-                            await next_episode_edge.save(self.driver)
+                            await next_episode_edge.save(driver)
 
                         # Create HAS_EPISODE edge from saga to episode
                         has_episode_edge = HasEpisodeEdge(
@@ -1446,7 +1467,7 @@ class Graphiti:
                             group_id=group_id,
                             created_at=now,
                         )
-                        await has_episode_edge.save(self.driver)
+                        await has_episode_edge.save(driver)
 
                         # Update previous_episode_uuid for the next iteration
                         previous_episode_uuid = episode.uuid
@@ -1456,7 +1477,7 @@ class Graphiti:
                         if saga_node.first_episode_uuid is None:
                             saga_node.first_episode_uuid = sorted_episodes[0].uuid
                         saga_node.last_episode_uuid = sorted_episodes[-1].uuid
-                        await saga_node.save(self.driver)
+                        await saga_node.save(driver)
 
                 end = time()
 

--- a/tests/test_group_routing_does_not_mutate_client.py
+++ b/tests/test_group_routing_does_not_mutate_client.py
@@ -1,0 +1,164 @@
+"""Group routing must not mutate the shared ``Graphiti`` client.
+
+Providers that keep each ``group_id`` in its own database (FalkorDB) need a
+write to run against that group's database. Doing that by assigning
+``self.driver = self.driver.clone(database=group_id)`` reroutes the *shared*
+client, so on a long-lived multi-group client -- the MCP server is exactly that
+-- every later read runs inside whichever group wrote last, matches nothing, and
+returns empty with no error.
+
+These tests pin the side-effect surface: the routed driver is correct, and
+``self.driver`` / ``self.clients.driver`` are the same objects afterwards. They
+use ``spec=`` mocks, so they need no live database.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from graphiti_core.cross_encoder.client import CrossEncoderClient
+from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.embedder.client import EmbedderClient
+from graphiti_core.graphiti import Graphiti
+from graphiti_core.llm_client import LLMClient
+
+DEFAULT_DB = 'default_db'
+
+
+def _make_graphiti():
+    """A ``Graphiti`` whose driver is a FalkorDB-shaped mock rooted at ``default_db``."""
+    child = MagicMock(spec=GraphDriver)
+    child.provider = GraphProvider.FALKORDB
+    child._database = 'group-a'
+
+    base = MagicMock(spec=GraphDriver)
+    base.provider = GraphProvider.FALKORDB
+    base._database = DEFAULT_DB
+    base.clone = MagicMock(return_value=child)
+
+    with patch.object(Graphiti, '_capture_initialization_telemetry', lambda self: None):
+        graphiti = Graphiti(
+            graph_driver=base,
+            llm_client=MagicMock(spec=LLMClient),
+            embedder=MagicMock(spec=EmbedderClient),
+            cross_encoder=MagicMock(spec=CrossEncoderClient),
+        )
+    return graphiti, base, child
+
+
+def test_routing_to_another_group_clones_the_driver():
+    graphiti, base, child = _make_graphiti()
+
+    routed = graphiti._driver_for_group('group-a')
+
+    base.clone.assert_called_once_with(database='group-a')
+    assert routed is child
+
+
+def test_routing_to_another_group_leaves_the_shared_client_untouched():
+    """The regression: routing a write must not rebind the shared client."""
+    graphiti, base, child = _make_graphiti()
+
+    graphiti._driver_for_group('group-a')
+
+    assert graphiti.driver is base
+    assert graphiti.clients.driver is base
+    assert graphiti.driver._database == DEFAULT_DB
+
+
+def test_routing_to_the_current_group_does_not_clone():
+    graphiti, base, _child = _make_graphiti()
+
+    routed = graphiti._driver_for_group(DEFAULT_DB)
+
+    assert routed is base
+    base.clone.assert_not_called()
+
+
+def test_clients_for_a_routed_driver_is_a_copy_carrying_that_driver():
+    graphiti, base, child = _make_graphiti()
+
+    routed_clients = graphiti._clients_for_driver(child)
+
+    # The copy carries the routed driver...
+    assert routed_clients.driver is child
+    # ...every other client is shared, not rebuilt...
+    assert routed_clients.llm_client is graphiti.clients.llm_client
+    assert routed_clients.embedder is graphiti.clients.embedder
+    assert routed_clients.cross_encoder is graphiti.clients.cross_encoder
+    assert routed_clients.tracer is graphiti.clients.tracer
+    # ...and the shared model is untouched.
+    assert routed_clients is not graphiti.clients
+    assert graphiti.clients.driver is base
+
+
+def test_clients_for_the_base_driver_reuses_the_shared_model():
+    graphiti, base, _child = _make_graphiti()
+
+    assert graphiti._clients_for_driver(base) is graphiti.clients
+
+
+@pytest.mark.parametrize('group_id', ['group-a', DEFAULT_DB])
+def test_repeated_routing_never_drifts_the_shared_client(group_id):
+    """Two groups written in sequence: the client still points at its own database."""
+    graphiti, base, _child = _make_graphiti()
+
+    for _ in range(3):
+        graphiti._driver_for_group(group_id)
+        graphiti._clients_for_driver(graphiti._driver_for_group(group_id))
+
+    assert graphiti.driver is base
+    assert graphiti.clients.driver is base
+    assert graphiti.driver._database == DEFAULT_DB
+
+
+@pytest.mark.asyncio
+async def test_add_episode_does_not_rebind_the_shared_driver():
+    """Drive the public API far enough to observe the routing side effect.
+
+    ``add_episode`` resolves the group's driver and then opens a tracing span.
+    Failing the span aborts the call right after routing, so whatever routing
+    did to the shared client is all that is left to observe -- no LLM, embedder
+    or database work needed. Before the fix this failed: the write path had
+    already reassigned ``self.driver``/``self.clients.driver`` to the clone.
+    """
+    graphiti, base, _child = _make_graphiti()
+    graphiti.tracer.start_span = MagicMock(side_effect=RuntimeError('stop here'))
+
+    with pytest.raises(RuntimeError, match='stop here'):
+        await graphiti.add_episode(
+            name='ep',
+            episode_body='body',
+            source_description='desc',
+            reference_time=datetime.now(timezone.utc),
+            group_id='group-a',
+        )
+
+    assert graphiti.driver is base
+    assert graphiti.clients.driver is base
+    assert graphiti.driver._database == DEFAULT_DB
+
+
+@pytest.mark.asyncio
+async def test_add_episode_without_a_group_id_does_not_clone():
+    """``group_id=None`` keeps the driver's preset database, exactly as before.
+
+    ``get_default_group_id`` returns ``'_'`` on FalkorDB (``''`` elsewhere) --
+    never the driver's own database name -- so routing on the resolved default
+    would start cloning where the original code deliberately did not.
+    """
+    graphiti, base, _child = _make_graphiti()
+    graphiti.tracer.start_span = MagicMock(side_effect=RuntimeError('stop here'))
+
+    with pytest.raises(RuntimeError, match='stop here'):
+        await graphiti.add_episode(
+            name='ep',
+            episode_body='body',
+            source_description='desc',
+            reference_time=datetime.now(timezone.utc),
+        )
+
+    base.clone.assert_not_called()
+    assert graphiti.driver is base
+    assert graphiti.clients.driver is base

--- a/tests/test_group_routing_does_not_mutate_client.py
+++ b/tests/test_group_routing_does_not_mutate_client.py
@@ -13,7 +13,7 @@ use ``spec=`` mocks, so they need no live database.
 """
 
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -22,6 +22,7 @@ from graphiti_core.driver.driver import GraphDriver, GraphProvider
 from graphiti_core.embedder.client import EmbedderClient
 from graphiti_core.graphiti import Graphiti
 from graphiti_core.llm_client import LLMClient
+from graphiti_core.nodes import EpisodeType, EpisodicNode, SagaNode
 
 DEFAULT_DB = 'default_db'
 
@@ -162,3 +163,149 @@ async def test_add_episode_without_a_group_id_does_not_clone():
     base.clone.assert_not_called()
     assert graphiti.driver is base
     assert graphiti.clients.driver is base
+
+
+# ---------------------------------------------------------------------------
+# Routing must reach the *persistence* boundary, not just the early reads.
+#
+# The first version of this fix routed the reads in ``add_episode`` but still
+# handed ``self.driver`` to ``add_nodes_and_edges_bulk`` and to every saga
+# write, so one operation could dedupe in ``group-a`` and persist in the base
+# database. These tests observe the driver each write actually receives.
+# ---------------------------------------------------------------------------
+
+
+def _episode(group_id: str = 'group-a') -> EpisodicNode:
+    return EpisodicNode(
+        name='ep',
+        group_id=group_id,
+        labels=[],
+        source=EpisodeType.message,
+        content='body',
+        source_description='desc',
+        created_at=datetime.now(timezone.utc),
+        valid_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_episode_data_persists_through_the_routed_driver():
+    """The regression the review caught: the final save must use the routed driver."""
+    graphiti, _base, child = _make_graphiti()
+
+    with patch('graphiti_core.graphiti.add_nodes_and_edges_bulk', new_callable=AsyncMock) as save:
+        await graphiti._process_episode_data(
+            _episode(), [], [], datetime.now(timezone.utc), 'group-a', driver=child
+        )
+
+    save.assert_awaited_once()
+    assert save.await_args.args[0] is child
+
+
+@pytest.mark.asyncio
+async def test_process_episode_data_defaults_to_the_shared_driver():
+    """Control group: with no routing, the behaviour is exactly what it was."""
+    graphiti, base, _child = _make_graphiti()
+
+    with patch('graphiti_core.graphiti.add_nodes_and_edges_bulk', new_callable=AsyncMock) as save:
+        await graphiti._process_episode_data(
+            _episode(), [], [], datetime.now(timezone.utc), 'group-a'
+        )
+
+    assert save.await_args.args[0] is base
+
+
+@pytest.mark.asyncio
+async def test_process_episode_data_routes_every_saga_write():
+    """Saga lookup, NEXT_EPISODE, HAS_EPISODE and the saga node itself."""
+    graphiti, base, child = _make_graphiti()
+
+    saga_node = MagicMock(spec=SagaNode)
+    saga_node.uuid = 'saga-uuid'
+    saga_node.first_episode_uuid = None
+    saga_node.save = AsyncMock()
+
+    edge = MagicMock()
+    edge.save = AsyncMock()
+
+    with (
+        patch('graphiti_core.graphiti.add_nodes_and_edges_bulk', new_callable=AsyncMock),
+        patch.object(
+            Graphiti, '_get_or_create_saga', new_callable=AsyncMock, return_value=saga_node
+        ) as get_saga,
+        patch.object(
+            Graphiti,
+            '_saga_get_previous_episode_uuid',
+            new_callable=AsyncMock,
+            return_value='previous-uuid',
+        ) as get_previous,
+        patch('graphiti_core.graphiti.NextEpisodeEdge', return_value=edge),
+        patch('graphiti_core.graphiti.HasEpisodeEdge', return_value=edge),
+    ):
+        await graphiti._process_episode_data(
+            _episode(),
+            [],
+            [],
+            datetime.now(timezone.utc),
+            'group-a',
+            saga='my-saga',
+            driver=child,
+        )
+
+    assert get_saga.await_args.kwargs['driver'] is child
+    assert get_previous.await_args.kwargs['driver'] is child
+    # NEXT_EPISODE and HAS_EPISODE both save, and neither may touch the base graph.
+    assert edge.save.await_count == 2
+    assert all(call.args[0] is child for call in edge.save.await_args_list)
+    assert saga_node.save.await_args.args[0] is child
+    assert not base.execute_query.called
+
+
+@pytest.mark.asyncio
+async def test_extract_and_resolve_edges_uses_the_routed_clients():
+    """Edge extraction and resolution read the graph; they must read the routed one."""
+    graphiti, _base, child = _make_graphiti()
+    routed_clients = graphiti._clients_for_driver(child)
+
+    with (
+        patch(
+            'graphiti_core.graphiti.extract_edges', new_callable=AsyncMock, return_value=[]
+        ) as extract,
+        patch(
+            'graphiti_core.graphiti.resolve_extracted_edges',
+            new_callable=AsyncMock,
+            return_value=([], [], []),
+        ) as resolve,
+    ):
+        await graphiti._extract_and_resolve_edges(
+            _episode(), [], [], {}, 'group-a', None, [], {}, clients=routed_clients
+        )
+
+    assert extract.await_args.args[0] is routed_clients
+    assert resolve.await_args.args[0] is routed_clients
+    assert graphiti.clients.driver is _base
+
+
+@pytest.mark.asyncio
+async def test_extract_and_dedupe_nodes_bulk_uses_the_routed_clients():
+    graphiti, _base, child = _make_graphiti()
+    routed_clients = graphiti._clients_for_driver(child)
+
+    with (
+        patch(
+            'graphiti_core.graphiti.extract_nodes_and_edges_bulk',
+            new_callable=AsyncMock,
+            return_value=([], []),
+        ) as extract,
+        patch(
+            'graphiti_core.graphiti.dedupe_nodes_bulk',
+            new_callable=AsyncMock,
+            return_value=({}, {}),
+        ) as dedupe,
+    ):
+        await graphiti._extract_and_dedupe_nodes_bulk(
+            [], {}, None, None, None, clients=routed_clients
+        )
+
+    assert extract.await_args.args[0] is routed_clients
+    assert dedupe.await_args.args[0] is routed_clients


### PR DESCRIPTION
Fixes #1795.

## The bug

On providers that keep each `group_id` in its own database (FalkorDB), `add_episode` and `add_episode_bulk` routed the write by reassigning the **shared** client:

```python
if group_id != self.driver._database:
    self.driver = self.driver.clone(database=group_id)
    self.clients.driver = self.driver
```

That reroutes the `Graphiti` instance, not just the write. On a long-lived multi-group client — the MCP server is exactly that — every subsequent read runs inside whichever group wrote last, carrying a `group_id` property filter that matches nothing, so it **returns empty with no error**. Scoped memory looks correct until a second group writes.

## The fix

Bind the routed driver and clients to locals. This is the idiom the file already uses everywhere else — `retrieve_episodes` (`graphiti.py:967`) and `build_communities` (`graphiti.py:1500`) both take an optional `driver` and fall back to `self.clients.driver` locally. `add_episode` / `add_episode_bulk` were the two outliers that mutated instead.

Two small helpers carry it:

- `_driver_for_group(group_id)` — returns `self.driver` when it is already on that database, otherwise a clone. Never assigns.
- `_clients_for_driver(driver)` — returns `self.clients` unchanged when the driver is the base one, otherwise a `model_copy(update={'driver': driver})`. `GraphitiClients` is a pydantic model, so the shared model is untouched and the other clients (llm, embedder, cross-encoder, tracer) stay shared rather than rebuilt.

Two details worth calling out, because both are easy to get wrong:

1. **The previous-episode lookup inside `add_episode` now passes the routed driver explicitly.** It would otherwise fall back to the unrouted `self.clients.driver` and read from the wrong database — the same class of bug, just moved.

2. **Routing still happens only when the caller supplies a `group_id`.** `get_default_group_id` returns `'_'` on FalkorDB and `''` elsewhere — never the driver's own database name — so routing on the *resolved* default would have started cloning where the original code deliberately did not. There is a test pinning this.

## Not in scope

The second problem described in #1795: per-group graphs make a `group_ids` **list** unsatisfiable, since a search with `group_ids=["a","b"]` can only ever execute inside one graph. Fixing that needs a fan-out read path plus a decision about cross-group result merging — a larger design change than this, and worth its own discussion.

## Verification

`tests/test_group_routing_does_not_mutate_client.py` uses `spec=` mocks, so it needs no live FalkorDB and runs in CI regardless of whether `falkordb` is installed — same approach as the existing `tests/driver/test_falkordb_ops_routing.py`.

Verified red/green against unpatched `main` (`993e081`):

| | unpatched `main` | with this change |
|---|---|---|
| `tests/test_group_routing_does_not_mutate_client.py` | **8 failed**, 1 passed | **9 passed** |

The one test that passes on both is `test_add_episode_without_a_group_id_does_not_clone` — it pins the `group_id=None` behaviour that this change preserves, so it is expected to be green on either side.

`test_add_episode_does_not_rebind_the_shared_driver` goes through the public API rather than the helpers: it makes the tracing span raise, which aborts `add_episode` immediately after routing, so the only thing left to observe is what routing did to the shared client. No LLM, embedder or database work involved.

Also run: `tests/driver`, `tests/utils`, `tests/test_graphiti_mock.py` (`-k "not _int"`) — all pass. The remaining errors in those directories are the live-database fixtures, and they error identically on unpatched `main`. `ruff format` and `ruff check` are clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
