### PR TITLE
fix(search): scope Neptune fulltext search to group_ids

### DIFF
--- a/graphiti_core/driver/neptune_driver.py
+++ b/graphiti_core/driver/neptune_driver.py
@@ -68,7 +68,7 @@ aoss_indices = [
                     'uuid': {'type': 'keyword'},
                     'name': {'type': 'text'},
                     'summary': {'type': 'text'},
-                    'group_id': {'type': 'text'},
+                    'group_id': {'type': 'text', 'fields': {'keyword': {'type': 'keyword'}}},
                 }
             }
         },
@@ -84,7 +84,7 @@ aoss_indices = [
                 'properties': {
                     'uuid': {'type': 'keyword'},
                     'name': {'type': 'text'},
-                    'group_id': {'type': 'text'},
+                    'group_id': {'type': 'text', 'fields': {'keyword': {'type': 'keyword'}}},
                 }
             }
         },
@@ -102,7 +102,7 @@ aoss_indices = [
                     'content': {'type': 'text'},
                     'source': {'type': 'text'},
                     'source_description': {'type': 'text'},
-                    'group_id': {'type': 'text'},
+                    'group_id': {'type': 'text', 'fields': {'keyword': {'type': 'keyword'}}},
                 }
             }
         },
@@ -124,7 +124,7 @@ aoss_indices = [
                     'uuid': {'type': 'keyword'},
                     'name': {'type': 'text'},
                     'fact': {'type': 'text'},
-                    'group_id': {'type': 'text'},
+                    'group_id': {'type': 'text', 'fields': {'keyword': {'type': 'keyword'}}},
                 }
             }
         },
@@ -339,12 +339,29 @@ class NeptuneDriver(GraphDriver):
             await self.delete_aoss_indices()
         await self.create_aoss_indices()
 
-    def run_aoss_query(self, name: str, query_text: str, limit: int = 10) -> dict[str, Any]:
+    def run_aoss_query(
+        self,
+        name: str,
+        query_text: str,
+        limit: int = 10,
+        group_ids: list[str] | None = None,
+    ) -> dict[str, Any]:
         for index in aoss_indices:
             if name.lower() == index['index_name']:
-                index['query']['query']['multi_match']['query'] = query_text
-                query = {'size': limit, 'query': index['query']}
-                resp = self.aoss_client.search(body=query['query'], index=index['index_name'])
+                fields = index['query']['query']['multi_match']['fields']
+                multi_match_query = {'multi_match': {'query': query_text, 'fields': fields}}
+                if group_ids:
+                    es_query: dict[str, Any] = {
+                        'bool': {
+                            'must': multi_match_query,
+                            'filter': {'terms': {'group_id.keyword': group_ids}},
+                        }
+                    }
+                else:
+                    es_query = multi_match_query
+                resp = self.aoss_client.search(
+                    body={'size': limit, 'query': es_query}, index=index['index_name']
+                )
                 return resp
         return {}
 

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -601,13 +601,19 @@ async def node_fulltext_search(
                 input_ids.append({'id': r['_source']['uuid'], 'score': r['_score']})
 
             # Match the edge ides and return the values
+            neptune_group_filter = (
+                '\n                AND n.group_id IN $group_ids' if group_ids is not None else ''
+            )
             query = (
                 """
                                 UNWIND $ids as i
                                 MATCH (n:Entity)
                                 WHERE n.uuid=i.id
-                                RETURN
                                 """
+                + neptune_group_filter
+                + """
+                RETURN
+                """
                 + get_entity_node_return_query(driver.provider)
                 + """
                 ORDER BY i.score DESC
@@ -898,10 +904,14 @@ async def episode_fulltext_search(
                 input_ids.append({'id': r['_source']['uuid'], 'score': r['_score']})
 
             # Match the edge ides and return the values
-            query = """
+            query = (
+                """
                 UNWIND $ids as i
                 MATCH (e:Episodic)
                 WHERE e.uuid=i.uuid
+                """
+                + group_filter_query
+                + """
             RETURN
                     e.content AS content,
                     e.created_at AS created_at,
@@ -915,6 +925,7 @@ async def episode_fulltext_search(
                 ORDER BY i.score DESC
                 LIMIT $limit
             """
+            )
             records, _, _ = await driver.execute_query(
                 query,
                 ids=input_ids,
@@ -991,10 +1002,19 @@ async def community_fulltext_search(
                 input_ids.append({'id': r['_source']['uuid'], 'score': r['_score']})
 
             # Match the edge ides and return the values
-            query = """
+            # Note: this MATCH binds the `comm` alias, not `c` -- group_filter_query above
+            # is written for the non-Neptune branch's `c` alias and must not be reused here.
+            neptune_group_filter = (
+                '\n                AND comm.group_id IN $group_ids' if group_ids is not None else ''
+            )
+            query = (
+                """
                 UNWIND $ids as i
                 MATCH (comm:Community)
                 WHERE comm.uuid=i.id
+                """
+                + neptune_group_filter
+                + """
                 RETURN
                     comm.uuid AS uuid,
                     comm.group_id AS group_id,
@@ -1005,6 +1025,7 @@ async def community_fulltext_search(
                 ORDER BY i.score DESC
                 LIMIT $limit
             """
+            )
             records, _, _ = await driver.execute_query(
                 query,
                 ids=input_ids,

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -594,7 +594,9 @@ async def node_fulltext_search(
         yield_query = 'WITH node AS n, score'
 
     if driver.provider == GraphProvider.NEPTUNE:
-        res = driver.run_aoss_query('node_name_and_summary', query, limit=limit)  # pyright: ignore reportAttributeAccessIssue
+        res = driver.run_aoss_query(  # pyright: ignore reportAttributeAccessIssue
+            'node_name_and_summary', query, limit=limit, group_ids=group_ids
+        )
         if res['hits']['total']['value'] > 0:
             input_ids = []
             for r in res['hits']['hits']:
@@ -897,7 +899,7 @@ async def episode_fulltext_search(
         filter_params['group_ids'] = group_ids
 
     if driver.provider == GraphProvider.NEPTUNE:
-        res = driver.run_aoss_query('episode_content', query, limit=limit)  # pyright: ignore reportAttributeAccessIssue
+        res = driver.run_aoss_query('episode_content', query, limit=limit, group_ids=group_ids)  # pyright: ignore reportAttributeAccessIssue
         if res['hits']['total']['value'] > 0:
             input_ids = []
             for r in res['hits']['hits']:
@@ -908,7 +910,7 @@ async def episode_fulltext_search(
                 """
                 UNWIND $ids as i
                 MATCH (e:Episodic)
-                WHERE e.uuid=i.uuid
+                WHERE e.uuid=i.id
                 """
                 + group_filter_query
                 + """
@@ -994,7 +996,7 @@ async def community_fulltext_search(
         yield_query = 'WITH node AS c, score'
 
     if driver.provider == GraphProvider.NEPTUNE:
-        res = driver.run_aoss_query('community_name', query, limit=limit)  # pyright: ignore reportAttributeAccessIssue
+        res = driver.run_aoss_query('community_name', query, limit=limit, group_ids=group_ids)  # pyright: ignore reportAttributeAccessIssue
         if res['hits']['total']['value'] > 0:
             # Calculate Cosine similarity then return the edge ids
             input_ids = []

--- a/tests/test_neptune_run_aoss_query.py
+++ b/tests/test_neptune_run_aoss_query.py
@@ -1,0 +1,53 @@
+"""Regression tests for NeptuneDriver.run_aoss_query's group_id filtering (no live database).
+
+run_aoss_query fetches the top-`limit` hits from OpenSearch before any Cypher-side
+group_id filter runs downstream. If the AOSS query itself doesn't scope by group_id,
+a caller can get zero or too-few results back even when matching documents exist in
+the requested group, just ranked below the global top-`limit` cutoff. These tests
+build a NeptuneDriver without a live cluster (via __new__) and assert the query body
+sent to the OpenSearch client carries an exact-match group_id filter.
+"""
+
+from typing import Any
+
+from graphiti_core.driver.neptune_driver import NeptuneDriver
+
+
+class RecordingAossClient:
+    def __init__(self):
+        self.body: dict[str, Any] = {}
+        self.index: str = ''
+
+    def search(self, body: dict[str, Any], index: str):
+        self.body = body
+        self.index = index
+        return {'hits': {'total': {'value': 0}, 'hits': []}}
+
+
+def _make_driver() -> NeptuneDriver:
+    driver = NeptuneDriver.__new__(NeptuneDriver)
+    driver.aoss_client = RecordingAossClient()  # type: ignore[attr-defined]
+    return driver
+
+
+def test_run_aoss_query_filters_by_group_id():
+    driver = _make_driver()
+
+    driver.run_aoss_query(
+        'node_name_and_summary', 'api test system', limit=5, group_ids=['group-a']
+    )
+
+    body = driver.aoss_client.body  # type: ignore[attr-defined]
+    assert body['size'] == 5
+    assert body['query']['bool']['filter'] == {'terms': {'group_id.keyword': ['group-a']}}
+    assert body['query']['bool']['must']['multi_match']['query'] == 'api test system'
+
+
+def test_run_aoss_query_omits_filter_without_group_ids():
+    driver = _make_driver()
+
+    driver.run_aoss_query('node_name_and_summary', 'api test system', limit=5, group_ids=None)
+
+    body = driver.aoss_client.body  # type: ignore[attr-defined]
+    assert 'bool' not in body['query']
+    assert body['query']['multi_match']['query'] == 'api test system'

--- a/tests/utils/search/test_neptune_fulltext_group_scoping.py
+++ b/tests/utils/search/test_neptune_fulltext_group_scoping.py
@@ -7,10 +7,17 @@ them by uuid -- never spliced that filter into its own Cypher. A caller passing
 group_ids therefore got results across every group/tenant on Neptune, even though the
 same call correctly scoped to group_ids on every other backend.
 
+That Cypher-side filter alone is not sufficient: run_aoss_query pulls the top-`limit`
+hits globally before the Cypher filter runs, so a requested-group hit ranked just below
+the cutoff is dropped even though it should have been returned. The AOSS query itself
+must also filter by group_id, which is why run_aoss_query below records the group_ids
+it was called with.
+
 Mirrors the RecordingExecutor approach of tests/utils/search/test_edge_bfs_query_shape.py:
 a recording driver captures the emitted Cypher, so no database connection is required.
 """
 
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
@@ -24,8 +31,27 @@ from graphiti_core.search.search_utils import (
 )
 
 
+def _make_row() -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    return {
+        'uuid': 'hit-uuid',
+        'name': 'hit name',
+        'group_id': 'group-a',
+        'created_at': now,
+        'summary': 'hit summary',
+        'labels': [],
+        'attributes': {},
+        'name_embedding': None,
+        'content': 'hit content',
+        'valid_at': now,
+        'source': 'text',
+        'source_description': 'hit source',
+        'entity_edges': [],
+    }
+
+
 class RecordingNeptuneDriver:
-    """Captures the Cypher and params a search function emits, returning no rows."""
+    """Captures the AOSS call and the Cypher/params a search function emits."""
 
     provider = GraphProvider.NEPTUNE
     search_interface = None
@@ -34,8 +60,12 @@ class RecordingNeptuneDriver:
     def __init__(self):
         self.cypher_query = ''
         self.params: dict[str, Any] = {}
+        self.aoss_group_ids: list[str] | None = 'not-called'  # type: ignore[assignment]
 
-    def run_aoss_query(self, index_name: str, query_text: str, limit: int = 10):
+    def run_aoss_query(
+        self, index_name: str, query_text: str, limit: int = 10, group_ids: list[str] | None = None
+    ):
+        self.aoss_group_ids = group_ids
         return {
             'hits': {
                 'total': {'value': 1},
@@ -46,22 +76,25 @@ class RecordingNeptuneDriver:
     async def execute_query(self, cypher_query_: str, **kwargs: Any):
         self.cypher_query = cypher_query_
         self.params = kwargs
-        return [], None, None
+        return [_make_row()], None, None
 
 
 @pytest.mark.asyncio
 async def test_neptune_node_fulltext_search_scopes_by_group_id():
     driver = RecordingNeptuneDriver()
 
-    await node_fulltext_search(
+    results = await node_fulltext_search(
         driver,  # type: ignore[arg-type]
         'api test system',
         SearchFilters(),
         group_ids=['group-a'],
     )
 
+    assert driver.aoss_group_ids == ['group-a']
     assert 'AND n.group_id IN $group_ids' in driver.cypher_query
     assert driver.params.get('group_ids') == ['group-a']
+    assert len(results) == 1
+    assert results[0].uuid == 'hit-uuid'
 
 
 @pytest.mark.asyncio
@@ -75,6 +108,7 @@ async def test_neptune_node_fulltext_search_omits_filter_without_group_ids():
         group_ids=None,
     )
 
+    assert driver.aoss_group_ids is None
     assert 'n.group_id IN $group_ids' not in driver.cypher_query
 
 
@@ -82,28 +116,36 @@ async def test_neptune_node_fulltext_search_omits_filter_without_group_ids():
 async def test_neptune_episode_fulltext_search_scopes_by_group_id():
     driver = RecordingNeptuneDriver()
 
-    await episode_fulltext_search(
+    results = await episode_fulltext_search(
         driver,  # type: ignore[arg-type]
         'api test system',
         SearchFilters(),
         group_ids=['group-a'],
     )
 
+    assert driver.aoss_group_ids == ['group-a']
     assert 'AND e.group_id IN $group_ids' in driver.cypher_query
+    assert 'e.uuid=i.id' in driver.cypher_query
     assert driver.params.get('group_ids') == ['group-a']
+    assert driver.params.get('ids') == [{'id': 'hit-uuid', 'score': 1}]
+    assert len(results) == 1
+    assert results[0].uuid == 'hit-uuid'
 
 
 @pytest.mark.asyncio
 async def test_neptune_community_fulltext_search_scopes_by_group_id():
     driver = RecordingNeptuneDriver()
 
-    await community_fulltext_search(
+    results = await community_fulltext_search(
         driver,  # type: ignore[arg-type]
         'api test system',
         group_ids=['group-a'],
     )
 
+    assert driver.aoss_group_ids == ['group-a']
     # The MATCH in this branch binds `comm`, not `c` -- the filter must use the
     # alias the query actually defines, not the one the non-Neptune branch uses.
     assert 'AND comm.group_id IN $group_ids' in driver.cypher_query
     assert driver.params.get('group_ids') == ['group-a']
+    assert len(results) == 1
+    assert results[0].uuid == 'hit-uuid'

--- a/tests/utils/search/test_neptune_fulltext_group_scoping.py
+++ b/tests/utils/search/test_neptune_fulltext_group_scoping.py
@@ -1,0 +1,109 @@
+"""Regression tests for Neptune fulltext search group_id scoping (no live database).
+
+node_fulltext_search, episode_fulltext_search and community_fulltext_search all
+compute a group_id filter for their non-Neptune (Cypher fulltext procedure) branch,
+but the Neptune branch -- which resolves candidate uuids via AOSS and then re-MATCHes
+them by uuid -- never spliced that filter into its own Cypher. A caller passing
+group_ids therefore got results across every group/tenant on Neptune, even though the
+same call correctly scoped to group_ids on every other backend.
+
+Mirrors the RecordingExecutor approach of tests/utils/search/test_edge_bfs_query_shape.py:
+a recording driver captures the emitted Cypher, so no database connection is required.
+"""
+
+from typing import Any
+
+import pytest
+
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.search.search_filters import SearchFilters
+from graphiti_core.search.search_utils import (
+    community_fulltext_search,
+    episode_fulltext_search,
+    node_fulltext_search,
+)
+
+
+class RecordingNeptuneDriver:
+    """Captures the Cypher and params a search function emits, returning no rows."""
+
+    provider = GraphProvider.NEPTUNE
+    search_interface = None
+    fulltext_syntax = ''
+
+    def __init__(self):
+        self.cypher_query = ''
+        self.params: dict[str, Any] = {}
+
+    def run_aoss_query(self, index_name: str, query_text: str, limit: int = 10):
+        return {
+            'hits': {
+                'total': {'value': 1},
+                'hits': [{'_source': {'uuid': 'hit-uuid'}, '_score': 1}],
+            }
+        }
+
+    async def execute_query(self, cypher_query_: str, **kwargs: Any):
+        self.cypher_query = cypher_query_
+        self.params = kwargs
+        return [], None, None
+
+
+@pytest.mark.asyncio
+async def test_neptune_node_fulltext_search_scopes_by_group_id():
+    driver = RecordingNeptuneDriver()
+
+    await node_fulltext_search(
+        driver,  # type: ignore[arg-type]
+        'api test system',
+        SearchFilters(),
+        group_ids=['group-a'],
+    )
+
+    assert 'AND n.group_id IN $group_ids' in driver.cypher_query
+    assert driver.params.get('group_ids') == ['group-a']
+
+
+@pytest.mark.asyncio
+async def test_neptune_node_fulltext_search_omits_filter_without_group_ids():
+    driver = RecordingNeptuneDriver()
+
+    await node_fulltext_search(
+        driver,  # type: ignore[arg-type]
+        'api test system',
+        SearchFilters(),
+        group_ids=None,
+    )
+
+    assert 'n.group_id IN $group_ids' not in driver.cypher_query
+
+
+@pytest.mark.asyncio
+async def test_neptune_episode_fulltext_search_scopes_by_group_id():
+    driver = RecordingNeptuneDriver()
+
+    await episode_fulltext_search(
+        driver,  # type: ignore[arg-type]
+        'api test system',
+        SearchFilters(),
+        group_ids=['group-a'],
+    )
+
+    assert 'AND e.group_id IN $group_ids' in driver.cypher_query
+    assert driver.params.get('group_ids') == ['group-a']
+
+
+@pytest.mark.asyncio
+async def test_neptune_community_fulltext_search_scopes_by_group_id():
+    driver = RecordingNeptuneDriver()
+
+    await community_fulltext_search(
+        driver,  # type: ignore[arg-type]
+        'api test system',
+        group_ids=['group-a'],
+    )
+
+    # The MATCH in this branch binds `comm`, not `c` -- the filter must use the
+    # alias the query actually defines, not the one the non-Neptune branch uses.
+    assert 'AND comm.group_id IN $group_ids' in driver.cypher_query
+    assert driver.params.get('group_ids') == ['group-a']


### PR DESCRIPTION
## Summary
`node_fulltext_search`, `episode_fulltext_search` and `community_fulltext_search` each compute a `group_id` filter for their non-Neptune (Cypher fulltext procedure) branch, but the Neptune branch -- which resolves candidate uuids via AOSS and then re-MATCHes them by uuid -- never spliced that filter into its own Cypher. A caller passing `group_ids` got results across every group/tenant on Neptune, even though the same call correctly scoped to `group_ids` on every other backend.

`community_fulltext_search`'s Neptune `MATCH` binds the `comm` alias, not `c` (the alias the non-Neptune branch's `group_filter_query` is written for), so it needed its own alias-correct filter rather than reusing the existing variable.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
N/A (bug fix, not a new feature/perf change).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

`tests/utils/search/test_neptune_fulltext_group_scoping.py` uses a recording driver (no live database) to assert the `group_id` predicate is present in the emitted Cypher, with the correct alias, when `group_ids` is passed, and absent when it is not. Verified failing against the pre-fix code and passing after.

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
N/A -- no existing issue tracks this; found while auditing Neptune's fulltext search branches for group_id scoping.