### PR TITLE
Reframe README as a temporal knowledge graph framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">
 Graphiti
 </h1>
-<h2 align="center">Build Temporal Context Graphs for AI Agents</h2>
+<h2 align="center">A Framework for Building Temporal Knowledge Graphs</h2>
 
 <div align="center">
 
@@ -34,13 +34,9 @@ Graphiti
 
 &nbsp;
 
-> [!TIP]
-> Check out the new [MCP server for Graphiti](mcp_server/README.md)! Give Claude, Cursor, and other MCP clients powerful
-> context graph-based memory with temporal awareness.
-
-Graphiti is a framework for building and querying temporal context graphs for AI agents. Unlike static knowledge graphs,
-Graphiti's context graphs track how facts change over time, maintain provenance to source data, and support both
-prescribed and learned ontology — making them purpose-built for agents operating on evolving, real-world data.
+Graphiti is a framework for building temporal knowledge graphs. Unlike static knowledge graphs, Graphiti tracks how
+facts change over time, maintains provenance to source data, and supports both prescribed and learned ontology — making
+it suitable for applications that operate on evolving, real-world data.
 
 Unlike traditional retrieval-augmented generation (RAG) methods, Graphiti continuously integrates user interactions,
 structured and unstructured enterprise data, and external information into a coherent, queryable graph. The framework
@@ -49,8 +45,8 @@ recomputation, making it suitable for developing interactive, context-aware AI a
 
 Use Graphiti to:
 
-- Build context graphs that evolve with every interaction — tracking what's true now and what was true before.
-- Give agents rich, structured context instead of flat document chunks or raw chat history.
+- Build temporal knowledge graphs that evolve with every interaction — tracking what's true now and what was true before.
+- Represent rich, structured context instead of flat document chunks or raw event streams.
 - Query across time, meaning, and relationships with hybrid retrieval (semantic + keyword + graph traversal).
 
 &nbsp;
@@ -82,31 +78,25 @@ A context graph contains:
 
 ## Graphiti and Zep
 
-Graphiti is the open-source temporal context graph engine at the core of
-[Zep's](https://www.getzep.com) context infrastructure for AI agents. Zep manages context graphs at scale, providing
-governed, low-latency context retrieval and assembly for production agent deployments.
+Graphiti is the open-source framework for building temporal knowledge graphs at the core of
+[Zep's](https://www.getzep.com) context infrastructure. Zep manages context graphs at scale, providing
+governed, low-latency context retrieval and assembly for production deployments.
 
 Under the hood, Zep is powered by a proprietary graph database — the
 [Context Graph Engine](https://www.getzep.com/platform/context-graph-engine/) — built for millions of context graphs
 with low-latency retrieval, so production deployments don't require a separate third-party graph database.
 
-Using Graphiti, we've demonstrated Zep is
-the [State of the Art in Agent Memory](https://blog.getzep.com/state-of-the-art-agent-memory/).
-
-Read our paper: [Zep: A Temporal Knowledge Graph Architecture for Agent Memory](https://arxiv.org/abs/2501.13956).
-
-We're excited to open-source Graphiti, believing its potential as a context graph engine reaches far beyond memory
-applications.
+Read our paper: [Zep: A Temporal Knowledge Graph Architecture](https://arxiv.org/abs/2501.13956).
 
 <p align="center">
-    <a href="https://arxiv.org/abs/2501.13956"><img src="images/arxiv-screenshot.png" alt="Zep: A Temporal Knowledge Graph Architecture for Agent Memory" width="700px"></a>
+    <a href="https://arxiv.org/abs/2501.13956"><img src="images/arxiv-screenshot.png" alt="Zep: A Temporal Knowledge Graph Architecture" width="700px"></a>
 </p>
 
 ## Zep vs Graphiti
 
 | Aspect | Zep | Graphiti |
 |--------|-----|---------|
-| **What they are** | Managed context graph infrastructure for AI agents | Open-source temporal context graph engine |
+| **What they are** | Managed context graph infrastructure | Open-source framework for building temporal knowledge graphs |
 | **Context graphs** | Manages vast numbers of per-user/entity context graphs with governance | Build and query individual context graphs |
 | **Graph database** | Proprietary [Context Graph Engine](https://www.getzep.com/platform/context-graph-engine/) — built for millions of context graphs with low-latency retrieval; no third-party graph database vendor required | Bring your own third-party graph database |
 | **User & conversation management** | Built-in users, threads, and message storage | Build your own |
@@ -147,7 +137,7 @@ frequently changing data. Graphiti addresses these challenges by providing:
 
 | Aspect | GraphRAG | Graphiti |
 |--------|----------|---------|
-| **Primary Use** | Static document summarization | Dynamic, evolving context for agents |
+| **Primary Use** | Static document summarization | Dynamic, evolving temporal knowledge graphs |
 | **Data Handling** | Batch-oriented processing | Continuous, incremental updates |
 | **Knowledge Structure** | Entity clusters & community summaries | Temporal context graph — entities, facts with validity windows, episodes, communities |
 | **Retrieval Method** | Sequential LLM summarization | Hybrid semantic, keyword, and graph-based search |

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Graphiti
 
 &nbsp;
 
-Graphiti is a framework for building temporal knowledge graphs. Unlike static knowledge graphs, Graphiti tracks how
-facts change over time, maintains provenance to source data, and supports both prescribed and learned ontology — making
-it suitable for applications that operate on evolving, real-world data.
+Graphiti is a framework for building and querying temporal context graphs for AI agents. Unlike static knowledge graphs,
+Graphiti's context graphs track how facts change over time, maintain provenance to source data, and support both
+prescribed and learned ontology — making them purpose-built for agents operating on evolving, real-world data.
 
 Unlike traditional retrieval-augmented generation (RAG) methods, Graphiti continuously integrates user interactions,
 structured and unstructured enterprise data, and external information into a coherent, queryable graph. The framework


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Updates the Graphiti README positioning so Graphiti is described as a **framework for building temporal knowledge graphs**.

The original opening paragraph is unchanged.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation/Tests

## Objective
- Headline: "A Framework for Building Temporal Knowledge Graphs".
- Keep the original first paragraph (temporal context graphs for AI agents).
- Remove agent-memory marketing (SOTA agent memory blog, "beyond memory applications").
- Drop the MCP server callout at the top of the README. The later MCP Server documentation section is unchanged.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

Documentation-only change.

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afe6762e-c3fc-4cde-9e23-296f2b667fb8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afe6762e-c3fc-4cde-9e23-296f2b667fb8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

