### PR TITLE
feat(mcp): add temporal_mode to search_memory_facts

### DIFF
--- a/graphiti_core/search/search_filters.py
+++ b/graphiti_core/search/search_filters.py
@@ -154,11 +154,11 @@ def edge_search_filter_query_constructor(
                     ComparisonOperator.is_null,
                     ComparisonOperator.is_not_null,
                 ]:
-                    filter_params['valid_at_' + str(j)] = date_filter.date
+                    filter_params[f'valid_at_{i}_{j}'] = date_filter.date
 
             and_filters = [
                 date_filter_query_constructor(
-                    'e.valid_at', f'$valid_at_{j}', date_filter.comparison_operator
+                    'e.valid_at', f'$valid_at_{i}_{j}', date_filter.comparison_operator
                 )
                 for j, date_filter in enumerate(or_list)
             ]
@@ -185,11 +185,11 @@ def edge_search_filter_query_constructor(
                     ComparisonOperator.is_null,
                     ComparisonOperator.is_not_null,
                 ]:
-                    filter_params['invalid_at_' + str(j)] = date_filter.date
+                    filter_params[f'invalid_at_{i}_{j}'] = date_filter.date
 
             and_filters = [
                 date_filter_query_constructor(
-                    'e.invalid_at', f'$invalid_at_{j}', date_filter.comparison_operator
+                    'e.invalid_at', f'$invalid_at_{i}_{j}', date_filter.comparison_operator
                 )
                 for j, date_filter in enumerate(or_list)
             ]
@@ -216,11 +216,11 @@ def edge_search_filter_query_constructor(
                     ComparisonOperator.is_null,
                     ComparisonOperator.is_not_null,
                 ]:
-                    filter_params['created_at_' + str(j)] = date_filter.date
+                    filter_params[f'created_at_{i}_{j}'] = date_filter.date
 
             and_filters = [
                 date_filter_query_constructor(
-                    'e.created_at', f'$created_at_{j}', date_filter.comparison_operator
+                    'e.created_at', f'$created_at_{i}_{j}', date_filter.comparison_operator
                 )
                 for j, date_filter in enumerate(or_list)
             ]
@@ -247,11 +247,11 @@ def edge_search_filter_query_constructor(
                     ComparisonOperator.is_null,
                     ComparisonOperator.is_not_null,
                 ]:
-                    filter_params['expired_at_' + str(j)] = date_filter.date
+                    filter_params[f'expired_at_{i}_{j}'] = date_filter.date
 
             and_filters = [
                 date_filter_query_constructor(
-                    'e.expired_at', f'$expired_at_{j}', date_filter.comparison_operator
+                    'e.expired_at', f'$expired_at_{i}_{j}', date_filter.comparison_operator
                 )
                 for j, date_filter in enumerate(or_list)
             ]

--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -575,6 +575,7 @@ async def search_memory_facts(
     valid_at_before: str | None = None,
     invalid_at_after: str | None = None,
     invalid_at_before: str | None = None,
+    temporal_mode: str | None = None,
 ) -> FactSearchResponse | ErrorResponse:
     """Search the graph memory for relevant facts (entity edges).
 
@@ -590,6 +591,9 @@ async def search_memory_facts(
         valid_at_before: Optional ISO-8601 upper bound on a fact's valid_at
         invalid_at_after: Optional ISO-8601 lower bound on a fact's invalid_at
         invalid_at_before: Optional ISO-8601 upper bound on a fact's invalid_at
+        temporal_mode: "current" returns only facts that are currently true (no
+            invalidation or expiry recorded); "all" (or omitted) returns the full
+            temporal history
     """
     global graphiti_service
 
@@ -609,6 +613,7 @@ async def search_memory_facts(
                 valid_at_before=valid_at_before,
                 invalid_at_after=invalid_at_after,
                 invalid_at_before=invalid_at_before,
+                temporal_mode=temporal_mode,
             )
         except ValueError as e:
             return ErrorResponse(error=f'Invalid date filter: {e}')

--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -591,8 +591,10 @@ async def search_memory_facts(
         valid_at_before: Optional ISO-8601 upper bound on a fact's valid_at
         invalid_at_after: Optional ISO-8601 lower bound on a fact's invalid_at
         invalid_at_before: Optional ISO-8601 upper bound on a fact's invalid_at
-        temporal_mode: "current" returns only facts that are currently true (no
-            invalidation or expiry recorded); "all" (or omitted) returns the full
+        temporal_mode: "current" returns facts whose valid_at is at or before now
+            (or unknown when no explicit valid_at bounds are supplied), whose invalid_at
+            is after now (or unset), and whose expired_at is unset; explicit valid_at
+            bounds further restrict this interval; "all" (or omitted) returns the full
             temporal history
     """
     global graphiti_service

--- a/mcp_server/src/utils/type_config.py
+++ b/mcp_server/src/utils/type_config.py
@@ -166,6 +166,7 @@ def build_fact_search_filters(
     valid_at_before: str | None = None,
     invalid_at_after: str | None = None,
     invalid_at_before: str | None = None,
+    temporal_mode: str | None = None,
 ) -> SearchFilters | None:
     """Build a ``SearchFilters`` for fact (edge) search.
 
@@ -173,9 +174,19 @@ def build_fact_search_filters(
     ``search_filter=None``.
 
     The ``*_after`` / ``*_before`` arguments are ISO-8601 strings parsed via
-    :func:`parse_reference_time` (UTC-coerced). Raises ``ValueError`` on a bad
-    timestamp.
+    :func:`parse_reference_time` (UTC-coerced). ``temporal_mode='current'``
+    limits results to facts with no invalidation or expiry recorded. Raises
+    ``ValueError`` on a bad timestamp, contradictory filter, or unsupported mode.
     """
+    if temporal_mode not in (None, 'all', 'current'):
+        raise ValueError("temporal_mode must be None, 'all', or 'current'")
+    if temporal_mode == 'current' and (
+        invalid_at_after is not None or invalid_at_before is not None
+    ):
+        raise ValueError(
+            "temporal_mode='current' cannot be combined with invalid_at_after or invalid_at_before"
+        )
+
     valid_after = parse_reference_time(valid_at_after)
     valid_before = parse_reference_time(valid_at_before)
     invalid_after = parse_reference_time(invalid_at_after)
@@ -183,6 +194,14 @@ def build_fact_search_filters(
 
     valid_at = _date_range_or_group(valid_after, valid_before)
     invalid_at = _date_range_or_group(invalid_after, invalid_before)
+
+    if temporal_mode == 'current':
+        return SearchFilters(
+            edge_types=edge_types or None,
+            valid_at=valid_at,
+            invalid_at=[[DateFilter(comparison_operator=ComparisonOperator.is_null)]],
+            expired_at=[[DateFilter(comparison_operator=ComparisonOperator.is_null)]],
+        )
 
     if not edge_types and valid_at is None and invalid_at is None:
         return None

--- a/mcp_server/src/utils/type_config.py
+++ b/mcp_server/src/utils/type_config.py
@@ -1,7 +1,7 @@
 """Helpers for translating MCP configuration into graphiti-core arguments.
 
-These functions are intentionally free of any I/O or global state so they can be
-unit-tested without a live database or LLM:
+These functions avoid I/O so they can be unit-tested without a live database or
+LLM:
 
 - ``parse_reference_time`` coerces an ISO-8601 string into a timezone-aware UTC
   ``datetime``.
@@ -19,6 +19,7 @@ from graphiti_core.search.search_filters import (
     DateFilter,
     SearchFilters,
 )
+from graphiti_core.utils.datetime_utils import utc_now
 from pydantic import BaseModel, create_model
 
 from config.schema import EdgeTypeConfig, EdgeTypeMapEntry, EntityTypeConfig
@@ -175,8 +176,9 @@ def build_fact_search_filters(
 
     The ``*_after`` / ``*_before`` arguments are ISO-8601 strings parsed via
     :func:`parse_reference_time` (UTC-coerced). ``temporal_mode='current'``
-    limits results to facts with no invalidation or expiry recorded. Raises
-    ``ValueError`` on a bad timestamp, contradictory filter, or unsupported mode.
+    limits results to facts valid as of the internally captured current UTC time
+    and without transaction-time expiry. Raises ``ValueError`` on a bad timestamp,
+    contradictory filter, or unsupported mode.
     """
     if temporal_mode not in (None, 'all', 'current'):
         raise ValueError("temporal_mode must be None, 'all', or 'current'")
@@ -196,10 +198,27 @@ def build_fact_search_filters(
     invalid_at = _date_range_or_group(invalid_after, invalid_before)
 
     if temporal_mode == 'current':
+        now = utc_now()
+        has_explicit_valid_range = valid_after is not None or valid_before is not None
+        if valid_before is None or valid_before > now:
+            valid_before = now
+        valid_at = _date_range_or_group(valid_after, valid_before)
+        assert valid_at is not None
+        if not has_explicit_valid_range:
+            valid_at.append([DateFilter(comparison_operator=ComparisonOperator.is_null)])
+
         return SearchFilters(
             edge_types=edge_types or None,
             valid_at=valid_at,
-            invalid_at=[[DateFilter(comparison_operator=ComparisonOperator.is_null)]],
+            invalid_at=[
+                [
+                    DateFilter(
+                        date=now,
+                        comparison_operator=ComparisonOperator.greater_than,
+                    )
+                ],
+                [DateFilter(comparison_operator=ComparisonOperator.is_null)],
+            ],
             expired_at=[[DateFilter(comparison_operator=ComparisonOperator.is_null)]],
         )
 

--- a/mcp_server/tests/test_core_parity.py
+++ b/mcp_server/tests/test_core_parity.py
@@ -16,7 +16,7 @@ import pytest
 from graphiti_core import Graphiti
 from graphiti_core.edges import EntityEdge
 from graphiti_core.nodes import EntityNode
-from graphiti_core.search.search_filters import ComparisonOperator, SearchFilters
+from graphiti_core.search.search_filters import ComparisonOperator, DateFilter, SearchFilters
 
 # Add the src directory to the path (mirrors the other unit tests)
 sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
@@ -122,8 +122,41 @@ class TestBuildEdgeTypeMap:
 
 
 class TestBuildFactSearchFilters:
-    def test_none_when_no_criteria(self):
-        assert build_fact_search_filters() is None
+    @pytest.mark.parametrize('temporal_mode', [None, 'all'])
+    def test_none_when_no_criteria(self, temporal_mode):
+        assert build_fact_search_filters(temporal_mode=temporal_mode) is None
+
+    def test_current_mode_filters_invalidated_and_expired_facts(self):
+        sf = build_fact_search_filters(temporal_mode='current')
+        current_filter = [[DateFilter(comparison_operator=ComparisonOperator.is_null)]]
+
+        assert isinstance(sf, SearchFilters)
+        assert sf.invalid_at is not None
+        assert sf.expired_at is not None
+        assert sf.invalid_at == current_filter
+        assert sf.expired_at == current_filter
+        assert sf.invalid_at[0][0].date is None
+        assert sf.expired_at[0][0].date is None
+
+    def test_current_mode_combines_with_edge_types(self):
+        sf = build_fact_search_filters(edge_types=['X'], temporal_mode='current')
+        current_filter = [[DateFilter(comparison_operator=ComparisonOperator.is_null)]]
+
+        assert isinstance(sf, SearchFilters)
+        assert sf.edge_types == ['X']
+        assert sf.invalid_at == current_filter
+        assert sf.expired_at == current_filter
+
+    def test_current_mode_rejects_invalid_at_range(self):
+        with pytest.raises(ValueError, match='cannot be combined'):
+            build_fact_search_filters(
+                invalid_at_after='2026-01-01T00:00:00Z',
+                temporal_mode='current',
+            )
+
+    def test_invalid_temporal_mode_raises_value_error(self):
+        with pytest.raises(ValueError, match='temporal_mode'):
+            build_fact_search_filters(temporal_mode='bogus')
 
     def test_edge_types_only(self):
         sf = build_fact_search_filters(edge_types=['WorksFor'])

--- a/mcp_server/tests/test_core_parity.py
+++ b/mcp_server/tests/test_core_parity.py
@@ -14,9 +14,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 from graphiti_core import Graphiti
+from graphiti_core.driver.driver import GraphProvider
 from graphiti_core.edges import EntityEdge
 from graphiti_core.nodes import EntityNode
-from graphiti_core.search.search_filters import ComparisonOperator, DateFilter, SearchFilters
+from graphiti_core.search.search_filters import (
+    ComparisonOperator,
+    SearchFilters,
+    edge_search_filter_query_constructor,
+)
 
 # Add the src directory to the path (mirrors the other unit tests)
 sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
@@ -29,6 +34,7 @@ from config.schema import (  # noqa: E402
 from models.edge_types import EDGE_TYPES  # noqa: E402
 from models.entity_types import ENTITY_TYPES  # noqa: E402
 from services.queue_service import QueueService  # noqa: E402
+from utils import type_config  # noqa: E402
 from utils.type_config import (  # noqa: E402
     build_edge_type_map,
     build_edge_types,
@@ -128,24 +134,84 @@ class TestBuildFactSearchFilters:
 
     def test_current_mode_filters_invalidated_and_expired_facts(self):
         sf = build_fact_search_filters(temporal_mode='current')
-        current_filter = [[DateFilter(comparison_operator=ComparisonOperator.is_null)]]
 
         assert isinstance(sf, SearchFilters)
+        assert sf.valid_at is not None
         assert sf.invalid_at is not None
         assert sf.expired_at is not None
-        assert sf.invalid_at == current_filter
-        assert sf.expired_at == current_filter
-        assert sf.invalid_at[0][0].date is None
-        assert sf.expired_at[0][0].date is None
+        assert sf.valid_at[0][0].comparison_operator == ComparisonOperator.less_than_equal
+        assert sf.valid_at[1][0].comparison_operator == ComparisonOperator.is_null
+        assert sf.invalid_at[0][0].comparison_operator == ComparisonOperator.greater_than
+        assert sf.invalid_at[1][0].comparison_operator == ComparisonOperator.is_null
+        assert sf.expired_at[0][0].comparison_operator == ComparisonOperator.is_null
+
+    def test_current_mode_uses_as_of_now_interval_semantics(self, monkeypatch):
+        now = datetime(2026, 1, 15, 12, tzinfo=timezone.utc)
+        valid_after = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        future = datetime(2026, 1, 16, 12, tzinfo=timezone.utc)
+        past = datetime(2026, 1, 14, 12, tzinfo=timezone.utc)
+        monkeypatch.setattr(type_config, 'utc_now', lambda: now, raising=False)
+
+        search_filters = build_fact_search_filters(
+            valid_at_after=valid_after.isoformat(),
+            valid_at_before='2027-01-01T00:00:00Z',
+            temporal_mode='current',
+        )
+        assert search_filters is not None
+        filter_queries, filter_params = edge_search_filter_query_constructor(
+            search_filters, GraphProvider.NEO4J
+        )
+
+        valid_params = {
+            value: name for name, value in filter_params.items() if name.startswith('valid_at_')
+        }
+        valid_after_param = valid_params[valid_after]
+        valid_now_param = valid_params[now]
+        invalid_param = next(name for name in filter_params if name.startswith('invalid_at_'))
+        valid_query = next(query for query in filter_queries if 'e.valid_at' in query)
+        invalid_query = next(query for query in filter_queries if 'e.invalid_at' in query)
+        expired_query = next(query for query in filter_queries if 'e.expired_at' in query)
+
+        assert valid_query.count(f'e.valid_at >= ${valid_after_param}') == 1
+        assert valid_query.count(f'e.valid_at <= ${valid_now_param}') == 1
+        # An explicit valid_at range further constrains current-mode results;
+        # unknown valid_at values do not satisfy an explicit date comparison.
+        assert 'e.valid_at IS NULL' not in valid_query
+        assert invalid_query.count(f'e.invalid_at > ${invalid_param}') == 1
+        assert invalid_query.count('e.invalid_at IS NULL') == 1
+        assert expired_query.count('e.expired_at IS NULL') == 1
+        assert filter_params[valid_after_param] == valid_after
+        assert filter_params[valid_now_param] == now
+        assert filter_params[invalid_param] == now
+        assert all(value.tzinfo is timezone.utc for value in filter_params.values())
+
+        def matches_current(
+            valid_at: datetime | None,
+            invalid_at: datetime | None,
+            expired_at: datetime | None = None,
+        ) -> bool:
+            return (
+                (
+                    valid_at is not None
+                    and filter_params[valid_after_param]
+                    <= valid_at
+                    <= filter_params[valid_now_param]
+                )
+                and (invalid_at is None or invalid_at > filter_params[invalid_param])
+                and expired_at is None
+            )
+
+        assert not matches_current(valid_at=future, invalid_at=None)
+        assert matches_current(valid_at=past, invalid_at=future)
+        assert not matches_current(valid_at=None, invalid_at=None)
 
     def test_current_mode_combines_with_edge_types(self):
         sf = build_fact_search_filters(edge_types=['X'], temporal_mode='current')
-        current_filter = [[DateFilter(comparison_operator=ComparisonOperator.is_null)]]
 
         assert isinstance(sf, SearchFilters)
         assert sf.edge_types == ['X']
-        assert sf.invalid_at == current_filter
-        assert sf.expired_at == current_filter
+        assert sf.invalid_at is not None
+        assert sf.expired_at is not None
 
     def test_current_mode_rejects_invalid_at_range(self):
         with pytest.raises(ValueError, match='cannot be combined'):

--- a/tests/utils/search/test_search_filters.py
+++ b/tests/utils/search/test_search_filters.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.search.search_filters import (
+    ComparisonOperator,
+    DateFilter,
+    SearchFilters,
+    edge_search_filter_query_constructor,
+)
+
+
+@pytest.mark.parametrize('field_name', ['valid_at', 'invalid_at', 'created_at', 'expired_at'])
+def test_date_filter_params_are_unique_across_or_groups(field_name):
+    earlier = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    later = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    filters = SearchFilters(
+        **{
+            field_name: [
+                [
+                    DateFilter(
+                        date=earlier,
+                        comparison_operator=ComparisonOperator.greater_than_equal,
+                    )
+                ],
+                [
+                    DateFilter(
+                        date=later,
+                        comparison_operator=ComparisonOperator.less_than,
+                    )
+                ],
+                [DateFilter(comparison_operator=ComparisonOperator.is_null)],
+                [DateFilter(comparison_operator=ComparisonOperator.is_not_null)],
+            ]
+        }
+    )
+
+    filter_queries, filter_params = edge_search_filter_query_constructor(
+        filters, GraphProvider.NEO4J
+    )
+
+    assert len(filter_queries) == 1
+    assert len(filter_params) == 2
+    assert set(filter_params.values()) == {earlier, later}
+
+    query = filter_queries[0]
+    earlier_param = next(name for name, value in filter_params.items() if value == earlier)
+    later_param = next(name for name, value in filter_params.items() if value == later)
+    assert f'e.{field_name} >= ${earlier_param}' in query
+    assert f'e.{field_name} < ${later_param}' in query
+    assert f'e.{field_name} IS NULL' in query
+    assert f'e.{field_name} IS NOT NULL' in query


### PR DESCRIPTION
## Summary

Graphiti's bi-temporal model invalidates facts instead of deleting them ("Query what's true now, or what was true at any point in time"). The MCP `search_memory_facts` tool exposed date ranges but had no way to request facts that are true now.

This PR adds an opt-in `temporal_mode` parameter:

- `temporal_mode="current"` applies as-of-now interval semantics:
  - `(valid_at <= now OR valid_at IS NULL)`
  - `(invalid_at > now OR invalid_at IS NULL)`
  - `expired_at IS NULL`
- explicit `valid_at_after` / `valid_at_before` bounds further restrict the current interval; a future upper bound is capped at the internally captured UTC `now`
- `temporal_mode="all"` or omitted preserves the existing full-history behavior
- `"current"` combined with `invalid_at_after` / `invalid_at_before` raises `ValueError`

The reference instant is captured internally with timezone-aware UTC; no additional MCP argument is exposed.

## Motivation (measured)

On a production graph (78,515 edges, 60 real user queries, top-24 candidates each): **52.7% of fact-search candidates were invalidated facts** (per-turn median 54%, p90 71%). Clients that only want currently true facts can otherwise have historical facts crowd live ones out of the candidate window.

## Changes

- `mcp_server/src/utils/type_config.py`: build the as-of-now valid-time and transaction-time filters for `temporal_mode="current"`
- `mcp_server/src/graphiti_mcp_server.py`: expose and accurately document the mode
- `graphiti_core/search/search_filters.py`: give every dated condition a unique parameter across outer OR groups for `valid_at`, `invalid_at`, `created_at`, and `expired_at`
- `mcp_server/tests/test_core_parity.py`: cover future `valid_at`, future `invalid_at`, null endpoints, explicit range intersection, and UTC capping
- `tests/utils/search/test_search_filters.py`: cover the parameter-collision regression across all four date fields

Default result semantics remain unchanged for callers that omit `temporal_mode`. The core query parameter names are internal and now remain unique for multi-group filters.

## Testing

- `uv run pytest tests/test_core_parity.py -q` → 33 passed
- CI-equivalent root unit suite → 374 passed, 11 skipped
- focused search-filter/security tests → 19 passed
- root `pyright ./graphiti_core` → 0 errors
- changed MCP source Pyright → 0 errors
- root and MCP Ruff check/format → passed
- `git diff --check` → passed
