### PR TITLE
fix(mcp): stop `--config` default from silently clobbering CONFIG_PATH env var

### DIFF
--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -1109,7 +1109,7 @@ async def initialize_server() -> ServerConfig:
     parser.add_argument(
         '--config',
         type=Path,
-        default=default_config,
+        default=None,
         help='Path to YAML configuration file (default: config/config.yaml)',
     )
 
@@ -1173,8 +1173,10 @@ async def initialize_server() -> ServerConfig:
 
     args = parser.parse_args()
 
-    # Set config path in environment for the settings to pick up
-    if args.config:
+    # Set config path in environment for the settings to pick up.
+    # Only when the user EXPLICITLY passed --config; otherwise the legitimate
+    # CONFIG_PATH env var must be preserved (env var *or* CLI flag, independent).
+    if args.config is not None:
         os.environ['CONFIG_PATH'] = str(args.config)
 
     # Load configuration with environment variables and YAML

--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -1103,9 +1103,9 @@ async def initialize_server() -> ServerConfig:
         description='Run the Graphiti MCP server with YAML configuration support'
     )
 
-    # Configuration file argument
-    # Default to config/config.yaml relative to the mcp_server directory
-    default_config = Path(__file__).parent.parent / 'config' / 'config.yaml'
+    # Configuration file argument.
+    # default=None: only set CONFIG_PATH when the user EXPLICITLY passes --config,
+    # otherwise the CONFIG_PATH env var must be preserved (env var *or* CLI flag).
     parser.add_argument(
         '--config',
         type=Path,


### PR DESCRIPTION
## Stop the `--config` default from silently clobbering `CONFIG_PATH` env var (fixes #1736)

**The bug:** `--config` had an always-truthy argparse default (`default=config/config.yaml`), so `args.config` was **never None** even when the user didn't pass `--config`. The boot path then **unconditionally** did `os.environ['CONFIG_PATH'] = str(args.config)`, overwriting the documented `CONFIG_PATH` env var (how container deployments point the MCP server at a custom `config.yaml`) on every boot.

**The fix (1 file, minimal):**
1. `--config` now defaults to `None`.
2. `CONFIG_PATH` is only set when `--config` is **explicitly** passed (`args.config is not None`).

This restores the documented independence — env var *or* CLI flag. When **neither** is set, `GraphitiConfig()` still falls back to its built-in default (`config/config.yaml`, schema.py:303), so the bare `graphiti-mcp-server` case is unchanged.

Verified: Python parses clean; the diff is 5 insertions / 3 deletions. No unit test touches this path today; a test asserting `CONFIG_PATH` survives when `--config` is absent would be a good addition if you want one.
