### PR TITLE
fix: extract pronoun-referenced previous entities

### DIFF
--- a/graphiti_core/prompts/extract_nodes.py
+++ b/graphiti_core/prompts/extract_nodes.py
@@ -111,9 +111,12 @@ NEVER extract any of the following:
 - Bare generic objects that cannot be meaningfully qualified with a possessor, brand, or
   distinguishing detail (e.g., NEVER extract "supplies" from "I picked up some supplies")
 
-Your task is to extract **entity nodes** that are **explicitly** mentioned in the CURRENT MESSAGE.
+Your task is to extract **entity nodes** that are **explicitly or implicitly** mentioned in the
+CURRENT MESSAGE.
 Pronoun references such as he/she/they or this/that/those should be disambiguated to the names of the
-reference entities. Only extract distinct entities from the CURRENT MESSAGE.
+reference entities. If a pronoun or other resolved reference in the CURRENT MESSAGE refers to an
+entity from PREVIOUS MESSAGES, that entity counts as implicitly mentioned and MUST be extracted.
+Only extract distinct entities referenced by the CURRENT MESSAGE.
 
 <ENTITY TYPES>
 {context['entity_types']}
@@ -131,7 +134,8 @@ reference entities. Only extract distinct entities from the CURRENT MESSAGE.
    - If the speaker is mentioned again in the message, treat both mentions as a **single entity**.
 
 2. **Entity Identification**:
-   - Extract named entities and specific, concrete things that are **explicitly** mentioned in the CURRENT MESSAGE.
+   - Extract named entities and specific, concrete things that are **explicitly or implicitly**
+     mentioned in the CURRENT MESSAGE.
    - Only extract entities that are specific enough to be uniquely identifiable. Ask: "Could this have its own Wikipedia article or database entry, OR is it specific enough to distinguish from other items of the same category within this conversation?"
    - For objects, possessions, and physical items, extract when they are specific enough
      to distinguish from other items of the same category. SHOULD be extracted:
@@ -145,7 +149,9 @@ reference entities. Only extract distinct entities from the CURRENT MESSAGE.
    - When a speaker or named person refers to a relative, pet, or associate using a bare term
      (e.g., "my dad", "his cat"), extract the entity qualified with the possessor's name
      (e.g., "Nisha's dad", "Jordan's cat"). Do NOT extract the bare term alone.
-   - **Exclude** entities mentioned only in the PREVIOUS MESSAGES (they are for context only).
+   - **Exclude** entities mentioned only in the PREVIOUS MESSAGES when the CURRENT MESSAGE does not
+     refer to them. If the CURRENT MESSAGE refers to a previous entity with a pronoun or another
+     resolvable reference, include that entity under its disambiguated name.
 
 3. **Entity Classification**:
    - Use the descriptions in ENTITY TYPES to classify each extracted entity.

--- a/graphiti_core/prompts/extract_nodes_and_edges.py
+++ b/graphiti_core/prompts/extract_nodes_and_edges.py
@@ -99,7 +99,10 @@ def extract_message(context: dict[str, Any]) -> list[Message]:
 
     user_prompt = f"""
 ENTITY RULES:
-1. Extract speakers and named entities explicitly mentioned in CURRENT MESSAGES.
+1. Extract speakers and named entities explicitly or implicitly mentioned in CURRENT MESSAGES.
+   If a pronoun or other resolved reference in a CURRENT MESSAGE refers to an entity from
+   PREVIOUS MESSAGES, that entity counts as implicitly mentioned and MUST be extracted under its
+   disambiguated name.
 2. Entity names must be at most 5 words. Use the most specific form mentioned.
 3. When someone discusses their possession, project, pet, or creation, extract it
    as a SEPARATE possessive entity — not just the person, not just the bare noun:
@@ -138,7 +141,9 @@ ENTITY RULES:
       according to his need", "the enemy of my enemy", "the perpetrator of a
       crime", "genuinely disadvantaged"). They are not retrievable referents.
 7. Each entity appears exactly ONCE. Classify using the ENTITY TYPES provided.
-8. Only extract entities from CURRENT MESSAGES — PREVIOUS MESSAGES are context only.
+8. Only extract entities referenced by CURRENT MESSAGES. PREVIOUS MESSAGES are context only, so
+   exclude entities that the current messages do not refer to. Include a previous entity when a
+   current pronoun or another resolvable reference points to it.
 9. Skip didactic / tutorial scaffolding when the assistant is teaching a topic
    (Unix commands, astronomy, cooking technique, etc.). Tutorial example values
    ("/path/to/source", "file.txt", "<username>") and explanatory primitives are

--- a/graphiti_core/prompts/extract_nodes_and_edges.py
+++ b/graphiti_core/prompts/extract_nodes_and_edges.py
@@ -209,8 +209,9 @@ FACT RULES:
    own/identify with) as source, not an observation noun.
 
 OUTPUT DISCIPLINE:
-- Entity `name` is a literal mention from CURRENT MESSAGES, ≤5 words. NEVER use a full
-  sentence, action item, goal statement, or quoted aspiration as a name.
+- Entity `name` is either a literal mention from CURRENT MESSAGES or, for a resolved reference,
+  the disambiguated name of the referenced entity from PREVIOUS MESSAGES; ≤5 words. NEVER use a
+  full sentence, action item, goal statement, or quoted aspiration as a name.
   BAD: "Establish a firm training/onboarding program",
        "Secure competitive advantage through IP",
        "Decide whether to expand into Europe next quarter".

--- a/tests/test_prompt_entity_references.py
+++ b/tests/test_prompt_entity_references.py
@@ -46,3 +46,22 @@ def test_message_prompt_extracts_pronoun_referenced_previous_entity(
     assert 'counts as implicitly mentioned' in user_prompt
     assert 'must be extracted' in user_prompt
     assert unreferenced_exclusion in user_prompt
+
+
+def test_combined_prompt_allows_disambiguated_previous_entity_name():
+    context = {
+        'entity_types': [{'entity_type_id': 0, 'entity_type_name': 'Entity'}],
+        'previous_episodes': [
+            {'content': "User: This is my friend John. He's a software engineer."}
+        ],
+        'episode_content': 'User: He also has a friend named Mike.',
+        'custom_extraction_instructions': '',
+    }
+
+    user_prompt = ' '.join(extract_nodes_and_edges_message(context)[1].content.lower().split())
+
+    assert (
+        'literal mention from current messages or, for a resolved reference, the disambiguated '
+        'name of the referenced entity from previous messages'
+    ) in user_prompt
+    assert 'entity `name` is a literal mention from current messages, ≤5 words' not in user_prompt

--- a/tests/test_prompt_entity_references.py
+++ b/tests/test_prompt_entity_references.py
@@ -1,0 +1,48 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+
+from graphiti_core.prompts.extract_nodes import extract_message as extract_nodes_message
+from graphiti_core.prompts.extract_nodes_and_edges import (
+    extract_message as extract_nodes_and_edges_message,
+)
+
+
+@pytest.mark.parametrize(
+    ('build_prompt', 'unreferenced_exclusion'),
+    [
+        (extract_nodes_message, 'current message does not refer to them'),
+        (extract_nodes_and_edges_message, 'current messages do not refer to'),
+    ],
+)
+def test_message_prompt_extracts_pronoun_referenced_previous_entity(
+    build_prompt, unreferenced_exclusion
+):
+    context = {
+        'entity_types': [{'entity_type_id': 0, 'entity_type_name': 'Entity'}],
+        'previous_episodes': [
+            {'content': "User: This is my friend John. He's a software engineer."}
+        ],
+        'episode_content': 'User: He also has a friend named Mike.',
+        'custom_extraction_instructions': '',
+    }
+
+    user_prompt = ' '.join(build_prompt(context)[1].content.lower().split())
+
+    assert 'counts as implicitly mentioned' in user_prompt
+    assert 'must be extracted' in user_prompt
+    assert unreferenced_exclusion in user_prompt


### PR DESCRIPTION
## Summary

- clarify that an entity from previous messages counts as implicitly mentioned when the current message refers to it with a pronoun or another resolvable reference
- preserve the exclusion of historical entities that the current message does not reference
- align both the default separate node-extraction prompt and the optional combined node-and-edge prompt
- add deterministic prompt-contract coverage for both extraction paths using the cross-turn John/Mike scenario

This prevents a current message such as `He also has a friend named Mike` from dropping `John` after the preceding message establishes that `He` refers to John. Keeping John in the extracted entity list allows the edge extraction stage to create `John -> FRIEND_OF -> Mike` instead of incorrectly falling back to the current speaker.

## Validation

- `uv run pytest tests/test_prompt_entity_references.py -q` (2 passed)
- `uv run pytest tests/utils/maintenance/test_entity_extraction.py -q` (30 passed)
- `uv run ruff check graphiti_core/prompts/extract_nodes.py graphiti_core/prompts/extract_nodes_and_edges.py tests/test_prompt_entity_references.py`
- `uv run ruff format --check graphiti_core/prompts/extract_nodes.py graphiti_core/prompts/extract_nodes_and_edges.py tests/test_prompt_entity_references.py`
- `git diff --check`

Fixes #1171