### PR TITLE
Expose combined extraction for bulk episodes

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -788,6 +788,7 @@ class Graphiti:
         entity_types: dict[str, type[BaseModel]] | None,
         excluded_entity_types: list[str] | None,
         custom_extraction_instructions: str | None = None,
+        use_combined_extraction: bool = False,
     ) -> tuple[
         dict[str, list[EntityNode]],
         dict[str, str],
@@ -803,6 +804,7 @@ class Graphiti:
             entity_types=entity_types,
             excluded_entity_types=excluded_entity_types,
             custom_extraction_instructions=custom_extraction_instructions,
+            use_combined_extraction=use_combined_extraction,
         )
 
         # Dedupe extracted nodes in memory
@@ -1237,6 +1239,7 @@ class Graphiti:
         edge_type_map: dict[tuple[str, str], list[str]] | None = None,
         custom_extraction_instructions: str | None = None,
         saga: str | SagaNode | None = None,
+        use_combined_extraction: bool = False,
     ) -> AddBulkEpisodeResults:
         """
         Process multiple episodes in bulk and update the graph.
@@ -1262,6 +1265,9 @@ class Graphiti:
             Optional. Custom extraction instructions string to be included in the
             extract entities and extract edges prompts. This allows for additional
             instructions or context to guide the extraction process.
+        use_combined_extraction : bool
+            Optional. Whether to use a single combined extraction call for nodes and
+            edges instead of the legacy separate extraction calls.
         saga : str | SagaNode | None
             Optional. Either a saga name (str) or a SagaNode object to associate all episodes with.
             If a string is provided and a saga with this name already exists in the group, the episodes
@@ -1357,6 +1363,7 @@ class Graphiti:
                     entity_types,
                     excluded_entity_types,
                     custom_extraction_instructions,
+                    use_combined_extraction,
                 )
 
                 # Create Episodic Edges

--- a/tests/utils/maintenance/test_bulk_utils.py
+++ b/tests/utils/maintenance/test_bulk_utils.py
@@ -1,5 +1,5 @@
 from collections import deque
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
@@ -7,6 +7,8 @@ from graphiti_core.edges import EntityEdge
 from graphiti_core.graphiti_types import GraphitiClients
 from graphiti_core.nodes import EntityNode, EpisodeType, EpisodicNode
 from graphiti_core.utils import bulk_utils
+from graphiti_core import graphiti as graphiti_module
+from graphiti_core.graphiti import Graphiti
 from graphiti_core.utils.bulk_utils import extract_nodes_and_edges_bulk
 from graphiti_core.utils.datetime_utils import utc_now
 
@@ -563,3 +565,25 @@ async def test_extract_nodes_and_edges_bulk_custom_instructions_multiple_episode
 
     for call in extract_edges_calls:
         assert call['custom_extraction_instructions'] == custom_instructions
+@pytest.mark.asyncio
+async def test_graphiti_bulk_forwards_combined_extraction(monkeypatch):
+    graphiti = Graphiti.__new__(Graphiti)
+    graphiti.clients = Mock()
+    calls = []
+
+    async def mock_extract(*args, **kwargs):
+        calls.append(kwargs['use_combined_extraction'])
+        return [], []
+
+    async def mock_dedupe(*args):
+        return {}, {}
+
+    monkeypatch.setattr(graphiti_module, 'extract_nodes_and_edges_bulk', mock_extract)
+    monkeypatch.setattr(graphiti_module, 'dedupe_nodes_bulk', mock_dedupe)
+
+    await graphiti._extract_and_dedupe_nodes_bulk(
+        [], {}, None, None, None, use_combined_extraction=True
+    )
+    await graphiti._extract_and_dedupe_nodes_bulk([], {}, None, None, None)
+
+    assert calls == [True, False]

--- a/tests/utils/maintenance/test_bulk_utils.py
+++ b/tests/utils/maintenance/test_bulk_utils.py
@@ -3,11 +3,11 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
+from graphiti_core import graphiti as graphiti_module
 from graphiti_core.edges import EntityEdge
 from graphiti_core.graphiti_types import GraphitiClients
 from graphiti_core.nodes import EntityNode, EpisodeType, EpisodicNode
 from graphiti_core.utils import bulk_utils
-from graphiti_core import graphiti as graphiti_module
 from graphiti_core.graphiti import Graphiti
 from graphiti_core.utils.bulk_utils import extract_nodes_and_edges_bulk
 from graphiti_core.utils.datetime_utils import utc_now

--- a/tests/utils/maintenance/test_bulk_utils.py
+++ b/tests/utils/maintenance/test_bulk_utils.py
@@ -565,6 +565,8 @@ async def test_extract_nodes_and_edges_bulk_custom_instructions_multiple_episode
 
     for call in extract_edges_calls:
         assert call['custom_extraction_instructions'] == custom_instructions
+
+
 @pytest.mark.asyncio
 async def test_graphiti_bulk_forwards_combined_extraction(monkeypatch):
     graphiti = Graphiti.__new__(Graphiti)

--- a/tests/utils/maintenance/test_bulk_utils.py
+++ b/tests/utils/maintenance/test_bulk_utils.py
@@ -5,10 +5,10 @@ import pytest
 
 from graphiti_core import graphiti as graphiti_module
 from graphiti_core.edges import EntityEdge
+from graphiti_core.graphiti import Graphiti
 from graphiti_core.graphiti_types import GraphitiClients
 from graphiti_core.nodes import EntityNode, EpisodeType, EpisodicNode
 from graphiti_core.utils import bulk_utils
-from graphiti_core.graphiti import Graphiti
 from graphiti_core.utils.bulk_utils import extract_nodes_and_edges_bulk
 from graphiti_core.utils.datetime_utils import utc_now
 


### PR DESCRIPTION
## Summary

Fixes #1803.

`extract_nodes_and_edges_bulk` already supports combined node-and-edge extraction, but `Graphiti.add_episode_bulk` did not expose or forward that option. This change adds the backward-compatible `use_combined_extraction` parameter to the bulk public API and threads it through the existing deduplication helper.

## Testing

- `python -m pytest --confcutdir=tests/utils/maintenance tests/utils/maintenance/test_bulk_utils.py -q` (15 passed)
- `ruff check --isolated graphiti_core/graphiti.py tests/utils/maintenance/test_bulk_utils.py` (passed)
- `python -m compileall -q graphiti_core/graphiti.py tests/utils/maintenance/test_bulk_utils.py` (passed)
- `git diff --check` (passed)

The focused regression exercises both explicit combined extraction and the unchanged default separate extraction path.