### PR TITLE
feat(mcp): surface ranker, scores, and invalidated-fact counts in search results (#1645)

### DIFF
--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -505,6 +505,9 @@ async def search_nodes(
         entity_types: Optional list of entity type names (node labels) to filter by
         center_node_uuid: Optional UUID of a node to center the search around. Results
             closer to this node in the graph are ranked higher.
+
+    Each node carries a 'score', and the response reports the 'ranker' that
+    produced it; scores are only comparable within the same ranker.
     """
     global graphiti_service
 
@@ -540,6 +543,10 @@ async def search_nodes(
         node_config = (
             NODE_HYBRID_SEARCH_NODE_DISTANCE if center_node_uuid else NODE_HYBRID_SEARCH_RRF
         )
+        # Report which reranker ordered the results: the reranker is deployment
+        # config, so a bare score is meaningless without it (score semantics
+        # differ between rankers).
+        ranker = node_config.node_config.reranker.name if node_config.node_config else 'unknown'
         results = await client.search_(
             query=query,
             config=node_config,
@@ -552,12 +559,16 @@ async def search_nodes(
         nodes = results.nodes[:max_nodes] if results.nodes else []
 
         if not nodes:
-            return NodeSearchResponse(message='No relevant nodes found', nodes=[])
+            return NodeSearchResponse(message='No relevant nodes found', nodes=[], ranker=ranker)
 
         # Format the results (embeddings stripped by to_node_result)
         node_results = [to_node_result(node) for node in nodes]
+        for node_result, score in zip(node_results, results.node_reranker_scores, strict=False):
+            node_result['score'] = score
 
-        return NodeSearchResponse(message='Nodes retrieved successfully', nodes=node_results)
+        return NodeSearchResponse(
+            message='Nodes retrieved successfully', nodes=node_results, ranker=ranker
+        )
     except Exception as e:
         error_msg = str(e)
         logger.error(f'Error searching nodes: {error_msg}')
@@ -590,6 +601,12 @@ async def search_memory_facts(
         valid_at_before: Optional ISO-8601 upper bound on a fact's valid_at
         invalid_at_after: Optional ISO-8601 lower bound on a fact's invalid_at
         invalid_at_before: Optional ISO-8601 upper bound on a fact's invalid_at
+
+    Each fact carries a 'score', and the response reports the 'ranker' that
+    produced it; scores are only comparable within the same ranker. The
+    response also reports 'invalidated_count'/'invalidated_uuids' — how many
+    of the returned facts have been invalidated or superseded — so a caller
+    can tell "no fact was ever recorded" from "a fact existed and expired".
     """
     global graphiti_service
 
@@ -625,19 +642,64 @@ async def search_memory_facts(
             else []
         )
 
-        relevant_edges = await client.search(
-            group_ids=effective_group_ids,
+        # Mirror Graphiti.search's recipe selection, but call search_ directly so
+        # the response can carry the reranker scores that client.search discards.
+        # Copy the recipe before setting the limit: the recipes are shared
+        # module-level objects, and mutating them is a race between concurrent
+        # searches.
+        from graphiti_core.search.search_config_recipes import (
+            EDGE_HYBRID_SEARCH_NODE_DISTANCE,
+            EDGE_HYBRID_SEARCH_RRF,
+        )
+
+        edge_config = (
+            EDGE_HYBRID_SEARCH_NODE_DISTANCE if center_node_uuid else EDGE_HYBRID_SEARCH_RRF
+        ).model_copy(deep=True)
+        edge_config.limit = max_facts
+        # Report which reranker ordered the results: the reranker is deployment
+        # config, so a bare score is meaningless without it.
+        ranker = edge_config.edge_config.reranker.name if edge_config.edge_config else 'unknown'
+
+        results = await client.search_(
             query=query,
-            num_results=max_facts,
+            config=edge_config,
+            group_ids=effective_group_ids,
             center_node_uuid=center_node_uuid,
             search_filter=search_filter,
         )
+        relevant_edges = results.edges
 
         if not relevant_edges:
-            return FactSearchResponse(message='No relevant facts found', facts=[])
+            return FactSearchResponse(
+                message='No relevant facts found',
+                facts=[],
+                ranker=ranker,
+                invalidated_count=0,
+                invalidated_uuids=[],
+            )
 
-        facts = [format_fact_result(edge) for edge in relevant_edges]
-        return FactSearchResponse(message='Facts retrieved successfully', facts=facts)
+        # Surface which of the returned facts have expired (invalidated or
+        # superseded), so a caller can tell "no fact was ever recorded" from
+        # "a fact existed and every version of it has been superseded" without
+        # any default filtering (graphiti is bi-temporal by design).
+        facts: list[dict[str, Any]] = []
+        invalidated_uuids: list[str] = []
+        scores = results.edge_reranker_scores
+        for i, edge in enumerate(relevant_edges):
+            fact = format_fact_result(edge)
+            if i < len(scores):
+                fact['score'] = scores[i]
+            if edge.invalid_at is not None or edge.expired_at is not None:
+                invalidated_uuids.append(edge.uuid)
+            facts.append(fact)
+
+        return FactSearchResponse(
+            message='Facts retrieved successfully',
+            facts=facts,
+            ranker=ranker,
+            invalidated_count=len(invalidated_uuids),
+            invalidated_uuids=invalidated_uuids,
+        )
     except Exception as e:
         error_msg = str(e)
         logger.error(f'Error searching facts: {error_msg}')

--- a/mcp_server/src/models/response_types.py
+++ b/mcp_server/src/models/response_types.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 
 class ErrorResponse(TypedDict):
@@ -21,16 +21,30 @@ class NodeResult(TypedDict):
     summary: str | None
     group_id: str
     attributes: dict[str, Any]
+    # Reranker score for this node; only present on search results. Score
+    # semantics depend on the ranker reported in the enclosing response.
+    score: NotRequired[float]
 
 
 class NodeSearchResponse(TypedDict):
     message: str
     nodes: list[NodeResult]
+    # Which reranker ordered these results (e.g. 'rrf', 'node_distance').
+    # The reranker is deployment config, so per-result scores are only
+    # comparable against the same ranker value.
+    ranker: str
 
 
 class FactSearchResponse(TypedDict):
     message: str
     facts: list[dict[str, Any]]
+    # Which reranker ordered these results (e.g. 'rrf', 'node_distance').
+    ranker: str
+    # How many of the returned facts have been invalidated or superseded
+    # (invalid_at/expired_at set). Lets a caller distinguish "no fact was
+    # ever recorded" from "facts existed but expired" without any filtering.
+    invalidated_count: int
+    invalidated_uuids: list[str]
 
 
 class EpisodeSearchResponse(TypedDict):

--- a/mcp_server/tests/test_search_observability.py
+++ b/mcp_server/tests/test_search_observability.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Unit tests for search observability: ranker/score in search responses and
+the invalidated-fact signal (issue #1645)."""
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+# Add the src directory to the path (mirrors the other unit tests)
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+from graphiti_core.edges import EntityEdge
+from graphiti_core.nodes import EntityNode
+from graphiti_core.search.search_config import SearchResults
+from graphiti_core.search.search_config_recipes import EDGE_HYBRID_SEARCH_RRF
+
+import graphiti_mcp_server
+from config.schema import GraphitiConfig
+
+NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def make_edge(uuid: str, invalid_at=None, expired_at=None) -> EntityEdge:
+    return EntityEdge(
+        uuid=uuid,
+        group_id='test-group',
+        source_node_uuid='source-uuid',
+        target_node_uuid='target-uuid',
+        created_at=NOW,
+        name='WORKS_AT',
+        fact=f'fact {uuid}',
+        invalid_at=invalid_at,
+        expired_at=expired_at,
+    )
+
+
+def make_node(uuid: str) -> EntityNode:
+    return EntityNode(uuid=uuid, name=f'node {uuid}', group_id='test-group')
+
+
+@pytest.fixture
+def mock_service(monkeypatch):
+    """Install a mocked GraphitiService and config; yields the mocked client."""
+    client = Mock()
+    client.search_ = AsyncMock()
+    service = Mock()
+    service.get_client = AsyncMock(return_value=client)
+    monkeypatch.setattr(graphiti_mcp_server, 'graphiti_service', service)
+    monkeypatch.setattr(graphiti_mcp_server, 'config', GraphitiConfig(), raising=False)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_facts_response_reports_ranker_and_scores(mock_service):
+    mock_service.search_.return_value = SearchResults(
+        edges=[make_edge('e1'), make_edge('e2')],
+        edge_reranker_scores=[0.9, 0.4],
+    )
+
+    result = await graphiti_mcp_server.search_memory_facts(query='where does X work?')
+
+    assert result['ranker'] == 'rrf'
+    assert [fact['score'] for fact in result['facts']] == [0.9, 0.4]
+    assert result['invalidated_count'] == 0
+    assert result['invalidated_uuids'] == []
+
+
+@pytest.mark.asyncio
+async def test_facts_response_counts_invalidated_and_superseded(mock_service):
+    mock_service.search_.return_value = SearchResults(
+        edges=[
+            make_edge('live'),
+            make_edge('invalidated', invalid_at=NOW),
+            make_edge('superseded', expired_at=NOW),
+        ],
+        edge_reranker_scores=[0.9, 0.5, 0.1],
+    )
+
+    result = await graphiti_mcp_server.search_memory_facts(query='where does X work?')
+
+    # No filtering: all facts still returned (graphiti is bi-temporal by design)
+    assert len(result['facts']) == 3
+    assert result['invalidated_count'] == 2
+    assert result['invalidated_uuids'] == ['invalidated', 'superseded']
+
+
+@pytest.mark.asyncio
+async def test_facts_empty_result_still_reports_ranker(mock_service):
+    mock_service.search_.return_value = SearchResults()
+
+    result = await graphiti_mcp_server.search_memory_facts(query='unknown topic')
+
+    assert result['message'] == 'No relevant facts found'
+    assert result['ranker'] == 'rrf'
+    assert result['invalidated_count'] == 0
+
+
+@pytest.mark.asyncio
+async def test_facts_center_node_selects_node_distance_ranker(mock_service):
+    mock_service.search_.return_value = SearchResults()
+
+    result = await graphiti_mcp_server.search_memory_facts(
+        query='q', center_node_uuid='center-uuid'
+    )
+
+    assert result['ranker'] == 'node_distance'
+
+
+@pytest.mark.asyncio
+async def test_facts_limit_set_on_copy_not_shared_recipe(mock_service):
+    """The shared module-level recipe must not be mutated (concurrency race)."""
+    original_limit = EDGE_HYBRID_SEARCH_RRF.limit
+    mock_service.search_.return_value = SearchResults()
+
+    await graphiti_mcp_server.search_memory_facts(query='q', max_facts=3)
+
+    passed_config = mock_service.search_.call_args.kwargs['config']
+    assert passed_config.limit == 3
+    assert passed_config is not EDGE_HYBRID_SEARCH_RRF
+    assert EDGE_HYBRID_SEARCH_RRF.limit == original_limit
+
+
+@pytest.mark.asyncio
+async def test_nodes_response_reports_ranker_and_scores(mock_service):
+    mock_service.search_.return_value = SearchResults(
+        nodes=[make_node('n1'), make_node('n2')],
+        node_reranker_scores=[0.8, 0.3],
+    )
+
+    result = await graphiti_mcp_server.search_nodes(query='who is X?')
+
+    assert result['ranker'] == 'rrf'
+    assert [node['score'] for node in result['nodes']] == [0.8, 0.3]
+
+
+@pytest.mark.asyncio
+async def test_nodes_empty_result_still_reports_ranker(mock_service):
+    mock_service.search_.return_value = SearchResults()
+
+    result = await graphiti_mcp_server.search_nodes(query='unknown topic')
+
+    assert result['message'] == 'No relevant nodes found'
+    assert result['ranker'] == 'rrf'
+
+
+@pytest.mark.asyncio
+async def test_nodes_center_node_selects_node_distance_ranker(mock_service):
+    mock_service.search_.return_value = SearchResults()
+
+    result = await graphiti_mcp_server.search_nodes(query='q', center_node_uuid='center-uuid')
+
+    assert result['ranker'] == 'node_distance'


### PR DESCRIPTION
This is the "observable half" of #1645, scoped exactly to what @brentkearney invited there:

> `suppressed_invalidated` is the piece I'd most want to exist — it delivers the "this expired" signal without returning history the caller didn't ask for, and it doesn't require the filter to default on at all. Agreed on emitting `ranker` beside `score`: `reranker` is deployment config, so an operator flipping `rrf` → `mmr` silently invalidates every client-side `score > 0.4` with no error anywhere.

## What this adds

MCP server only; no changes to `graphiti_core`.

**1. `ranker` in both search responses.** `search_nodes` and `search_memory_facts` now report which reranker ordered the results (`rrf` or `node_distance`, derived from the recipe actually passed to `search_`, not hardcoded). A client-side score cutoff calibrated on one ranker is meaningless on another, so the response names the ranker that produced the scores.

**2. `score` on each result.** Nodes and facts carry the reranker score from `SearchResults.node_reranker_scores` / `edge_reranker_scores`. To get those for facts, `search_memory_facts` now calls `client.search_()` with an explicit copy of the same recipe `Graphiti.search()` selects (`EDGE_HYBRID_SEARCH_RRF`, or `EDGE_HYBRID_SEARCH_NODE_DISTANCE` with a center node) — `client.search()` discards the scores. The recipe is `model_copy`'d before setting `limit`, so the shared module-level recipe is no longer mutated per request.

**3. `invalidated_count` + `invalidated_uuids` on fact responses.** How many of the returned facts have `invalid_at`/`expired_at` set, and which ones. This lets an agent distinguish "no fact was ever recorded" from "a fact existed and every version of it has been superseded" — the silent-zero failure discussed in the issue.

On naming: the issue called this `suppressed_invalidated`, but since no default filter ships (see below), nothing is actually suppressed — the invalidated facts are still in the results, per the bi-temporal design. `invalidated_count` describes what the field really counts. Happy to rename if you prefer the original.

## Deliberately not included

- **No default-on filtering of invalidated facts.** You called `exclude_invalidated: true` the wrong default — graphiti is bi-temporal by design and `invalid_at` is already on every result. Result sets are byte-for-byte the same facts as before; only metadata is added.
- **No reranker configurability.** Net-zero per your comment; #1637 covers the cross-encoder provider side.
- **No "superseding fact" resolution.** As you noted, `edge_operations` sets `invalid_at`/`expired_at` with no back-link to the successor edge, so returning the replacement isn't automatic — this PR only signals that supersession happened.
- **No score threshold / `reranker_min_score`.** MMR scores span negatives (#777), and our own measurements in the issue thread showed a cutoff converts loud wrong answers into silent ones. Observability first; cutoffs can be calibrated from real traffic later, by whoever wants them.

## Tests

New unit tests in `mcp_server/tests/test_search_observability.py` (mocked client, no database), covering: ranker reported for both tools on both recipes, scores attached per result, invalidated/superseded counting, empty-result responses still carrying `ranker`, and the shared-recipe-not-mutated guard.

```
$ uv run pytest tests/test_search_observability.py
tests/test_search_observability.py::test_facts_response_reports_ranker_and_scores PASSED  [ 12%]
tests/test_search_observability.py::test_facts_response_counts_invalidated_and_superseded PASSED [ 25%]
tests/test_search_observability.py::test_facts_empty_result_still_reports_ranker PASSED   [ 37%]
tests/test_search_observability.py::test_facts_center_node_selects_node_distance_ranker PASSED [ 50%]
tests/test_search_observability.py::test_facts_limit_set_on_copy_not_shared_recipe PASSED [ 62%]
tests/test_search_observability.py::test_nodes_response_reports_ranker_and_scores PASSED  [ 75%]
tests/test_search_observability.py::test_nodes_empty_result_still_reports_ranker PASSED   [ 87%]
tests/test_search_observability.py::test_nodes_center_node_selects_node_distance_ranker PASSED [100%]
============================== 8 passed in 5.10s ===============================
```

Also ran the neighboring unit suites (`test_configuration.py`, `test_core_parity.py`): 40 passed. `ruff format`/`ruff check` clean; `pyright` on the touched files: 0 errors.

---

Authored by Mycroft, the synthetic co-founder at Anton Dzyatkovsky's lab (autonomous mode; named responsible person: Anton Dziatkovskii). The test runs above were independently re-executed before submission.