### PR TITLE
docs: fix backwards Ollama structured_output_mode guidance (#868)

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,9 +597,14 @@ especially on smaller or local models, so `OpenAIGenericClient` exposes a `struc
 
 - `"json_schema"` (default): requests native structured output via `response_format`. Best on capable models and
   providers that enforce the schema via constrained decoding.
-- `"json_object"`: requests plain-JSON mode and injects the schema into the prompt instead. Use this for
-  providers/models that don't reliably honor `json_schema` — including some local servers that accept the `json_schema`
-  request but don't actually constrain output to it, where `json_object` can be *more* reliable.
+- `"json_object"`: requests plain-JSON mode and injects the schema into the prompt instead. Use this only for
+  providers/models that reject or ignore the `json_schema` `response_format` parameter outright — the schema is not
+  enforced in this mode, and models frequently echo the injected Pydantic schema back verbatim instead of filling it
+  in, which surfaces as `ValidationError: ... Field required ...` with `$defs`/`$ref` in the offending value (e.g.
+  `extracted_entities` missing from `ExtractedEntities`). If you hit that error, check whether `structured_output_mode`
+  was explicitly set to `"json_object"` and switch it back to `"json_schema"` (the default) before assuming the model
+  or provider is at fault — this has resolved the issue across multiple local models on Ollama 0.32+, which supports
+  native `json_schema` constrained decoding via its OpenAI-compatible endpoint.
 
 When using smaller or local models:
 

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -183,7 +183,7 @@ llm:
   model: "gpt-oss:120b"  # or your preferred Ollama model
   api_base: "http://localhost:11434/v1"
   api_key: "ollama"  # dummy key required
-  structured_output_mode: "json_object"  # use when json_schema is accepted but not enforced
+  structured_output_mode: "json_schema"  # default; native constrained decoding on Ollama 0.32+
 
 embedder:
   provider: "sentence_transformers"  # recommended for local setup
@@ -198,9 +198,14 @@ Make sure Ollama is running locally with: `ollama serve`
 > that doesn't match the expected schema, which surfaces as ingestion failures. For background and the
 > `structured_output_mode` (`json_schema` vs `json_object`) trade-off, see the core README's
 > [Structured output and small models](../README.md#structured-output-and-small-models) section.
-> If an OpenAI-compatible endpoint accepts `json_schema` but returns objects that miss fields such as
-> `extracted_entities`, set `structured_output_mode: "json_object"` so Graphiti injects the schema into the prompt
-> instead of relying on provider-side schema enforcement.
+>
+> If ingestion fails with `ValidationError: ... extracted_entities Field required ...` and the input value contains
+> `$defs`/`$ref` keys, the model echoed the injected JSON schema back instead of filling it in. This is caused by
+> `structured_output_mode: "json_object"`, which embeds the raw Pydantic schema in the prompt — some models copy it
+> verbatim rather than extracting data. Switch to (or leave unset for the default) `structured_output_mode:
+> "json_schema"`, which uses Ollama's native constrained decoding via `response_format` instead of prompt injection
+> and has been reported to eliminate this error across multiple local models on Ollama 0.32+. Reserve `json_object`
+> for OpenAI-compatible endpoints that reject or ignore the `json_schema` `response_format` parameter outright.
 
 ### Entity Types
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

While reproducing [#868](https://github.com/getzep/graphiti/issues/868) (`ValidationError: ... extracted_entities Field required ...` with `$defs` in the offending value when using `OpenAIGenericClient` + Ollama), a commenter on the issue tracked down the root cause and confirmed it via testing across four local models:

- The error occurs when the model echoes the injected JSON schema back instead of filling it in.
- This happens specifically under `structured_output_mode="json_object"`, which embeds the raw `model_json_schema()` output (`$defs`/`$ref`) into the prompt with no server-side enforcement.
- `structured_output_mode="json_schema"` — the `OpenAIGenericClient` default since #1537 (`c537ed4`) — uses `response_format` with native constrained decoding and avoided the error entirely across `qwen2.5:7b`, `llama3.1:8b`, `qwen2.5:3b`, and `phi3.5` on Ollama 0.32.13.

I reproduced the failure locally (schema-echo response → `ExtractedEntities(**llm_response)` raising the exact same `ValidationError`) and confirmed `json_schema` mode never injects the schema into the prompt while `json_object` mode does.

## Problem

`mcp_server/README.md`'s Ollama example explicitly set `structured_output_mode: "json_object"`, and its troubleshooting note told users experiencing extraction failures to *switch to* `json_object` — which is backwards. That guidance predates the #1537 default change and steers Ollama users straight into the schema-echo failure mode described in #868.

## Changes

- `mcp_server/README.md`: Ollama example now uses `structured_output_mode: "json_schema"` (matching the library default). The troubleshooting note documents the exact error signature (`extracted_entities Field required` + `$defs`/`$ref`) and points to `json_schema` as the fix, reserving `json_object` for endpoints that reject/ignore the `json_schema` `response_format` parameter outright.
- `README.md`: "Structured output and small models" section updated with the same error signature and guidance so it's discoverable from the core docs too.

No code changes — this is a documentation-only fix based on evidence gathered while reproducing #868.

## Testing

- `DISABLE_NEO4J=1 DISABLE_FALKORDB=1 DISABLE_KUZU=1 DISABLE_NEPTUNE=1 uv run pytest tests/llm_client/test_openai_generic_client.py -q` → 9 passed (unaffected by doc-only change; confirms `json_schema` remains the default and does not inject the prompt schema).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-849917b8-ae0c-4e3f-b080-1cfb2301e974?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-849917b8-ae0c-4e3f-b080-1cfb2301e974&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

