### PR TITLE
fix(neo4j): route queries to the configured database

### DIFF
--- a/graphiti_core/driver/neo4j_driver.py
+++ b/graphiti_core/driver/neo4j_driver.py
@@ -158,17 +158,23 @@ class Neo4jDriver(GraphDriver):
                 raise
 
     async def execute_query(self, cypher_query_: LiteralString, **kwargs: Any) -> EagerResult:
-        # Check if database_ is provided in kwargs.
-        # If not populated, set the value to retain backwards compatibility
         params = kwargs.pop('params', None)
         if params is None:
             params = {}
-        params.setdefault('database_', self._database)
+        # Route via Neo4j's database_ kwarg; an explicit override wins (including None,
+        # which lets the server resolve the home database), else the driver default.
+        database = kwargs.pop('database_') if 'database_' in kwargs else self._database
 
         try:
-            result = await self.client.execute_query(cypher_query_, parameters_=params, **kwargs)
+            result = await self.client.execute_query(
+                cypher_query_, parameters_=params, database_=database, **kwargs
+            )
         except Exception as e:
-            logger.error(f'Error executing Neo4j query: {e}\n{cypher_query_}\n{params}')
+            # Log parameter names only; values may contain sensitive data.
+            logger.error(
+                f'Error executing Neo4j query: {e}\n{cypher_query_}\n'
+                f'parameter keys: {sorted([*params, *kwargs])}'
+            )
             raise
 
         return result
@@ -189,9 +195,7 @@ class Neo4jDriver(GraphDriver):
         await self.client.close()
 
     def delete_all_indexes(self) -> Coroutine:
-        return self.client.execute_query(
-            'CALL db.indexes() YIELD name DROP INDEX name',
-        )
+        return self.execute_query('CALL db.indexes() YIELD name DROP INDEX name')
 
     async def _execute_index_query(self, query: LiteralString) -> EagerResult | None:
         """Execute an index creation query, ignoring 'index already exists' errors.

--- a/tests/driver/test_neo4j_driver_routing.py
+++ b/tests/driver/test_neo4j_driver_routing.py
@@ -1,0 +1,105 @@
+"""Unit tests for Neo4jDriver query routing to the configured database.
+
+Neo4j's client takes ``database_`` as a top-level routing keyword, distinct from
+Cypher ``parameters_``. These tests assert ``execute_query`` (and index deletion)
+pass the driver database through that routing slot rather than stuffing it into
+query parameters, so a non-default database name is actually used.
+
+No live Neo4j is required: the scheduled init task is cancelled and ``client``
+is replaced with a mock.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graphiti_core.driver.neo4j_driver import Neo4jDriver
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_driver(**init_kwargs) -> Neo4jDriver:
+    """Build a Neo4jDriver whose client is a mock and whose init task is inert."""
+    mock_client = MagicMock()
+    mock_client.execute_query = AsyncMock()
+    mock_client.close = AsyncMock()
+
+    with (
+        patch(
+            'graphiti_core.driver.neo4j_driver.AsyncGraphDatabase.driver',
+            return_value=mock_client,
+        ),
+        patch.object(Neo4jDriver, 'build_indices_and_constraints', new_callable=AsyncMock),
+    ):
+        driver = Neo4jDriver(uri='bolt://x', user='u', password='p', **init_kwargs)
+
+    if driver._init_task is not None:
+        driver._init_task.cancel()
+
+    assert driver.client is mock_client
+    return driver
+
+
+async def test_execute_query_routes_to_configured_database():
+    driver = _make_driver(database='custom')
+    try:
+        await driver.execute_query('RETURN 1')
+
+        driver.client.execute_query.assert_awaited_once()
+        call_kwargs = driver.client.execute_query.await_args.kwargs
+        assert call_kwargs['database_'] == 'custom'
+        assert 'database_' not in call_kwargs['parameters_']
+    finally:
+        await driver.close()
+
+
+async def test_execute_query_per_call_database_override_wins():
+    driver = _make_driver(database='custom')
+    try:
+        await driver.execute_query('RETURN 1', database_='override')
+
+        driver.client.execute_query.assert_awaited_once()
+        call_kwargs = driver.client.execute_query.await_args.kwargs
+        assert call_kwargs['database_'] == 'override'
+        assert 'database_' not in call_kwargs['parameters_']
+    finally:
+        await driver.close()
+
+
+async def test_execute_query_explicit_none_database_requests_home_database():
+    driver = _make_driver(database='custom')
+    try:
+        await driver.execute_query('RETURN 1', database_=None)
+
+        driver.client.execute_query.assert_awaited_once()
+        call_kwargs = driver.client.execute_query.await_args.kwargs
+        assert call_kwargs['database_'] is None
+        assert 'database_' not in call_kwargs['parameters_']
+    finally:
+        await driver.close()
+
+
+async def test_execute_query_defaults_to_neo4j_database():
+    driver = _make_driver()
+    try:
+        await driver.execute_query('RETURN 1')
+
+        driver.client.execute_query.assert_awaited_once()
+        call_kwargs = driver.client.execute_query.await_args.kwargs
+        assert call_kwargs['database_'] == 'neo4j'
+        assert 'database_' not in call_kwargs['parameters_']
+    finally:
+        await driver.close()
+
+
+async def test_delete_all_indexes_routes_through_execute_query():
+    driver = _make_driver(database='custom')
+    try:
+        await driver.delete_all_indexes()
+
+        driver.client.execute_query.assert_awaited_once()
+        call_kwargs = driver.client.execute_query.await_args.kwargs
+        assert call_kwargs['database_'] == 'custom'
+        assert 'database_' not in call_kwargs['parameters_']
+    finally:
+        await driver.close()


### PR DESCRIPTION
## Summary
`Neo4jDriver.execute_query` put `database_` in Cypher `parameters_`, so the Neo4j client ignored it and every query ran against the connection's home database. This passes `database_` as the client's routing keyword (per-call override, including `None` for the home database, otherwise `self._database`) and sends `delete_all_indexes` through the same path. Query error logs now record parameter names only.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation/Tests

## Objective
N/A (bug fix): honor `Neo4jDriver(..., database=...)` for reads, writes via `execute_query`, and index deletion.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

Mocked routing tests in `tests/driver/test_neo4j_driver_routing.py` cover the configured database, per-call override, explicit `None`, default `'neo4j'`, and `delete_all_indexes`. `pytest tests/driver/` passed; ruff and pyright are clean.

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Closes #1481
Related: #798, #851, #354, #875

Made with [Cursor](https://cursor.com)