### PR TITLE
feat(server): Zep Cloud v2 compatibility layer backed by Graphiti

### DIFF
--- a/server/graph_service/zep_compat/README.md
+++ b/server/graph_service/zep_compat/README.md
@@ -1,0 +1,121 @@
+# Zep Cloud v2 compatibility layer
+
+A drop-in replacement for the subset of the Zep Cloud API that
+[MiroFish](https://github.com/uxe-security-solutions/MiroFish) calls, implemented on
+top of `graphiti_core` — the same engine Zep Cloud is built on. It exists so
+MiroFish can run with no hosted service: Zep Community Edition is discontinued and
+there is no self-hostable Zep server.
+
+The `zep-cloud` Python SDK talks to this unmodified. MiroFish only sets
+`ZEP_BASE_URL`.
+
+## Running it
+
+```bash
+cd server
+uv sync --extra dev
+uvicorn graph_service.zep_compat.app:app --host 127.0.0.1 --port 8088
+```
+
+Deliberately a separate ASGI app from `graph_service.main`, whose settings require
+`OPENAI_API_KEY` and which builds its own Graphiti instance. Keeping them apart
+means upstream changes to `main.py` never conflict here.
+
+### Configuration
+
+| Variable | Default | Notes |
+|---|---|---|
+| `ZEP_COMPAT_API_PREFIX` | `/api/v2` | MiroFish pins the SDK `base_url` to `<host>/api/v2` |
+| `ZEP_COMPAT_DB_PATH` | `./data/zep_compat.sqlite3` | graph registry, ontologies, batch state |
+| `ZEP_COMPAT_BATCH_CONCURRENCY` | `4` | episodes ingested at once; each fans out into several LLM calls |
+| `GRAPHITI_LLM_BASE_URL` | `http://localhost:8000/v1` | any OpenAI-compatible endpoint |
+| `GRAPHITI_EMBEDDER_BASE_URL` | `http://localhost:8081/v1` | required — Zep Cloud embedded server-side, Graphiti does not |
+| `EMBEDDING_DIM` | `1024` | **one-way door**: the vector index dimension is fixed at creation |
+| `GRAPHITI_RERANKER` | `none` | `none` = RRF fusion, no reranker call. `bge` loads a local cross-encoder |
+| `GRAPHITI_DB_BACKEND` | `falkordb` | or `neo4j` |
+| `GRAPHITI_TELEMETRY_ENABLED` | forced `false` | Graphiti otherwise reports to PostHog on init |
+
+Never point `GRAPHITI_RERANKER` at Graphiti's OpenAI reranker: it scores with
+`logit_bias={'6432': 1, '7983': 1}`, hard-coded OpenAI tokenizer IDs for
+True/False that are meaningless to a Qwen or Llama tokenizer.
+
+## Layout
+
+| File | Role |
+|---|---|
+| `WIRE_SPEC.md` | The contract, derived mechanically from the `zep-cloud==3.25.0` wheel. Read this first. |
+| `models.py` | Wire-exact request/response models |
+| `router.py` | The 17 endpoints |
+| `runtime.py` | Graphiti construction, the per-graph pool, the batch worker |
+| `store.py` | SQLite: graph registry, ontologies, batch lifecycle, UUID→graph index |
+| `ontology.py` | Zep `EntityType`/`EdgeType` → Graphiti Pydantic models |
+| `paging.py` | `SKIP`/`LIMIT` paging, because `uuid_cursor` is broken on FalkorDB |
+| `app.py` | ASGI entrypoint |
+
+## Four things that will bite you
+
+Each of these was found the hard way and is covered by a test.
+
+**1. `uuid` on the wire, `uuid_` in Python.** Fern declares
+`uuid_: Annotated[str, FieldMetadata(alias="uuid")]`. Emitting `uuid_` fails
+client-side with a `ValidationError`. `models.py` uses the wire names directly so
+the mistake is unavailable.
+
+**2. `group_id` is the database name.** In `graphiti_core` 0.29.3, `add_episode`
+does:
+
+```python
+if group_id != self.driver._database:
+    self.driver = self.driver.clone(database=group_id)
+```
+
+So each graph lives in its own database, *and* that assignment mutates the shared
+instance — two concurrent `add_episode` calls for different graphs would write into
+the wrong database. Hence `GraphitiPool`: one instance per graph, driver already
+pointed at a database named exactly `graph_id`. The pool asserts that invariant,
+because if the names differ the clone fires and pre-saved episodes vanish.
+
+Consequence: a node or episode UUID is only resolvable inside its own graph, but
+`GET graph/node/{uuid}` and `GET graph/episodes/{uuid}` carry no `graph_id`. The
+store keeps a UUID→graph index, populated whenever a UUID is handed out.
+
+**3. `add_episode(uuid=...)` means "process the existing episode", not "create with
+this UUID"** — it calls `EpisodicNode.get_by_uuid` and raises if absent. But Zep's
+batch API promises the client an episode UUID at `batch.add` time. So
+`ingest_episode` persists the node first, then hands its UUID to `add_episode`,
+keeping one UUID end to end.
+
+**4. Empty results are not uniform.** `EntityNode.get_by_group_ids` returns `[]`;
+`EntityEdge.get_by_group_ids` *raises* `GroupsEdgesNotFoundError`. A fresh graph has
+no edges, so an unguarded read 500s on a completely normal state — and MiroFish
+retries a 500 three times before failing the whole drain.
+
+And one upstream bug worth knowing: on FalkorDB the `WHERE n.uuid < $uuid` cursor
+clause is silently not applied — verified against a live FalkorDB, where even a
+literal comparison returns every row while `ORDER BY` and `SKIP`/`LIMIT` are exact.
+`paging.py` uses offsets instead.
+
+## Tests
+
+```bash
+cd server
+uv run --extra dev pytest tests/ -q --asyncio-mode=auto
+```
+
+No GPU, no network, no database. `test_zep_compat_e2e.py` drives a real `AsyncZep`
+client over an ASGI transport, so paths, payloads, error mapping and the
+header-based pagination cursor are all exercised against the SDK MiroFish uses.
+
+Against a real FalkorDB:
+
+```bash
+docker run -d --name falkordb-it -p 6399:6379 falkordb/falkordb:latest
+ZEP_COMPAT_IT=1 FALKORDB_IT_PORT=6399 uv run --extra dev pytest tests/test_zep_compat_integration.py -v
+```
+
+## Scope
+
+Only the 17 endpoints MiroFish calls: graph create/get/delete/add/search,
+`entity-types`, node get / node edges / node listing, edge listing, episode get /
+mentions, and the six `batches` endpoints. Users, threads and fact-triples are not
+implemented.

--- a/server/graph_service/zep_compat/WIRE_SPEC.md
+++ b/server/graph_service/zep_compat/WIRE_SPEC.md
@@ -1,0 +1,117 @@
+# Zep Cloud v2 wire contract (the subset MiroFish uses)
+
+Derived mechanically from the `zep-cloud==3.25.0` Python SDK wheel, not from docs.
+Everything below is what the SDK actually puts on the wire and what it will accept back.
+
+Base path: the SDK is constructed with `base_url=<X>` and appends these paths, so the
+shim must be mounted such that `<X>/graph/...` resolves. MiroFish pins
+`ZEP_CLOUD_BASE_URL = "https://api.getzep.com/api/v2"`, therefore the shim serves
+under the prefix `/api/v2`.
+
+Auth: SDK sends `Authorization: Api-Key <key>`. The shim accepts any non-empty key.
+
+## Field aliasing — the single biggest trap
+
+Fern-generated models declare fields like:
+
+```python
+uuid_: Annotated[str, FieldMetadata(alias="uuid")] = pydantic.Field()
+```
+
+The wire key is **`uuid`**; `uuid_` is only the Python attribute name. Verified:
+`parse_obj_as(EntityNode, {"uuid": ...})` succeeds and `{"uuid_": ...}` raises
+`ValidationError`. **The shim must emit `uuid`, never `uuid_`.**
+
+Timestamps are plain `str` on the wire (not datetime). Emit RFC3339 / ISO-8601,
+e.g. `2024-01-01T00:00:00Z`. Unknown extra keys are tolerated by the models.
+
+## Endpoints
+
+| SDK call | Method | Path | Request body / params | Response |
+|---|---|---|---|---|
+| `graph.create` | POST | `graph/create` | `{description, graph_id, name, time_zone}` | `Graph` |
+| `graph.get` | GET | `graph/{graph_id}` | — | `Graph` |
+| `graph.delete` | DELETE | `graph/{graph_id}` | — | `SuccessResponse` |
+| `graph.add` | POST | `graph` | `{created_at, data, graph_id, metadata, source_description, strict_ontology, type, user_id}` | `Episode` |
+| `graph.search` | POST | `graph/search` | `{bfs_origin_node_uuids, center_node_uuid, graph_id, limit, max_characters, mmr_lambda, query, reranker, return_raw_results, scope, search_filters, user_id}` | `GraphSearchResults` |
+| `graph.set_ontology` | PUT | `entity-types` | `{edge_types[], entity_types[], graph_ids[], user_ids[]}` | `SuccessResponse` |
+| `graph.node.get` | GET | `graph/node/{uuid}` | — | `EntityNode` |
+| `graph.node.get_edges` | GET | `graph/node/{node_uuid}/entity-edges` | — | `EntityEdge[]` |
+| `graph.node.get_by_graph_id` | **POST** | `graph/node/graph/{graph_id}` | `{cursor, direction, filters, limit, order_by, uuid_cursor}` | `EntityNode[]` + `zep-next-cursor` header |
+| `graph.edge.get_by_graph_id` | **POST** | `graph/edge/graph/{graph_id}` | `{cursor, direction, filters, limit, order_by, uuid_cursor}` | `EntityEdge[]` + `zep-next-cursor` header |
+| `graph.episode.get` | GET | `graph/episodes/{uuid}` | — | `Episode` |
+| `batch.create` | POST | `batches` | `{ignore_roles, metadata}` | `BatchSummary` |
+| `batch.add` | POST | `batches/{batch_id}/items` | `{items: BatchAddItem[]}` | `BatchItemDetail[]` |
+| `batch.process` | POST | `batches/{batch_id}/process` | — | `BatchSummary` |
+| `batch.get` | GET | `batches/{batch_id}` | — | `BatchSummary` |
+| `batch.list` | GET | `batches` | query `{limit, cursor, status}` | `BatchListResponse` |
+| `batch.list_items` | GET | `batches/{batch_id}/items` | query params | `BatchItemListResponse` |
+
+Note the two `get_by_graph_id` calls are **POST with a JSON body**, despite reading data.
+
+## Pagination (`zep-next-cursor`)
+
+`fetch_all_nodes` / `fetch_all_edges` in MiroFish's `app/utils/zep_paging.py` drive
+pagination **entirely from a response header**, not the body:
+
+- send `{"limit": <=100, "cursor": <opaque str>}`
+- read the response header `zep-next-cursor`
+- absent header => last page, stop
+- a cursor that repeats or equals the one just sent => MiroFish raises
+  `RuntimeError("... pagination cursor did not advance ...")`
+
+So the shim MUST set `zep-next-cursor` on node/edge list responses when more rows
+remain, MUST omit it on the final page, and MUST make it strictly advance.
+
+## Response models (wire keys, from `model_fields`)
+
+```
+Graph              created_at? description? graph_id? id?(int) name? project_uuid? time_zone? uuid?
+Episode            content* created_at* uuid*  metadata? processed? relevance? role? role_type?
+                   score? selection_rank? source? source_description? task_id? thread_id?
+                   source ∈ {text, json, message, fact_triple}
+EntityNode         created_at* name* summary* uuid*  attributes? labels?[] relevance? score? selection_rank?
+EntityEdge         created_at* fact* name* source_node_uuid* target_node_uuid* uuid*
+                   attributes? episodes?[] expired_at? invalid_at? valid_at? relevance? scope? score? selection_rank?
+EpisodeResponse    episodes?[Episode]
+EpisodeMentions    edges?[EntityEdge] nodes?[EntityNode]
+GraphSearchResults context? edges?[] episodes?[] nodes?[] observations?[] response? thread_summaries?[]
+BatchSummary       batch_id? completed_at? created_at? ignore_roles?[] item_count? metadata?
+                   processed_at? progress?(BatchProgress) status? updated_at?
+                   status ∈ {draft, invalid, queued, processing, succeeded, partial, failed, canceled}
+BatchProgress      canceled_items? failed_items? percent_complete? processing_items?
+                   queued_items? skipped_items? succeeded_items? total_items?
+BatchItemDetail    created_at? episode_uuid? error? graph_id? graph_uuid? item_id? kind?
+                   sequence_index? source_uuid? status? thread_id? updated_at? user_id? user_uuid?
+                   kind ∈ {graph_episode, thread_message}
+                   status ∈ {pending, queued, processing, succeeded, failed, skipped, canceled}
+BatchItemListResponse  items?[BatchItemDetail] next_cursor?(int)
+SuccessResponse    message?
+```
+
+`*` = required by the SDK's parser (omitting it raises `ValidationError` client-side).
+`?` = optional.
+
+## Ontology request models
+
+```
+EntityType   name* description* properties?[EntityProperty] identity_properties?[str]
+EdgeType     name* description* properties?[EntityProperty] source_targets?[{source, target}]
+EntityProperty  name* description* type*   type ∈ {Text, Int, Float, Boolean}
+BatchAddItem type* (graph_episode|thread_message)  content? created_at? data? data_type?
+             graph_id? metadata? name? role? source_description? thread_id? user_id?
+             data_type ∈ {text, json, message, fact_triple}
+```
+
+## Error mapping
+
+The SDK raises typed exceptions off HTTP status, and MiroFish catches some of them
+(notably `zep_cloud.NotFoundError`). The shim must therefore use:
+
+- `404` -> `NotFoundError`  (MiroFish treats this as "graph/node absent", not a failure)
+- `400` -> `BadRequestError`
+- `500` -> `InternalServerError`
+- `408` / `429` / `5xx` -> retried by MiroFish's `is_retryable_zep_error`
+
+Returning `200` with an error body will be silently misread as success. Use real
+status codes.

--- a/server/graph_service/zep_compat/__init__.py
+++ b/server/graph_service/zep_compat/__init__.py
@@ -1,0 +1,10 @@
+"""Zep Cloud v2 compatibility layer backed by Graphiti.
+
+See WIRE_SPEC.md for the exact contract this implements and why.
+
+Nothing is imported eagerly on purpose: `models`, `ontology`, and `store` are
+pure and must stay importable (and unit-testable) without graphiti_core, a
+graph database, or an LLM. Import `graph_service.zep_compat.app:app` to serve.
+"""
+
+__all__ = ['models', 'ontology', 'store', 'runtime', 'router', 'app']

--- a/server/graph_service/zep_compat/app.py
+++ b/server/graph_service/zep_compat/app.py
@@ -1,0 +1,64 @@
+"""Standalone ASGI app for the Zep-compatible layer.
+
+Deliberately separate from graph_service.main: that app's Settings require
+OPENAI_API_KEY and it builds its own Graphiti instance. Keeping this entrypoint
+independent means upstream Graphiti changes to main.py never conflict.
+
+Serve with:
+    uvicorn graph_service.zep_compat.app:app --host 0.0.0.0 --port 8088
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from .router import router
+from .runtime import Runtime
+
+logging.basicConfig(
+    level=os.environ.get('ZEP_COMPAT_LOG_LEVEL', 'INFO').upper(),
+    format='%(asctime)s %(levelname)s %(name)s %(message)s',
+)
+logger = logging.getLogger('zep_compat')
+
+# MiroFish pins the SDK base_url to <host>/api/v2, so every route lives there.
+API_PREFIX = os.environ.get('ZEP_COMPAT_API_PREFIX', '/api/v2')
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Graphiti's telemetry ships to PostHog on init. On an offline box that is a
+    # hang risk, not just a privacy leak, so default it off unless overridden.
+    os.environ.setdefault('GRAPHITI_TELEMETRY_ENABLED', 'false')
+    logger.info('starting Zep compatibility layer on prefix %s', API_PREFIX)
+    runtime = await Runtime.create()
+    app.state.zep_runtime = runtime
+    logger.info('ready')
+    try:
+        yield
+    finally:
+        await runtime.close()
+        logger.info('shut down')
+
+
+app = FastAPI(
+    title='Zep-compatible Graph API (Graphiti-backed)',
+    description='Local drop-in for the Zep Cloud v2 endpoints MiroFish calls.',
+    lifespan=lifespan,
+)
+
+app.include_router(router, prefix=API_PREFIX)
+
+
+@app.get('/healthcheck')
+async def healthcheck():
+    ready = getattr(app.state, 'zep_runtime', None) is not None
+    return JSONResponse(
+        content={'status': 'healthy' if ready else 'starting'},
+        status_code=200 if ready else 503,
+    )

--- a/server/graph_service/zep_compat/models.py
+++ b/server/graph_service/zep_compat/models.py
@@ -1,0 +1,289 @@
+"""Wire-exact request/response models for the Zep Cloud v2 subset MiroFish uses.
+
+Field names here are the WIRE names on purpose. The zep-cloud SDK declares
+`uuid_: Annotated[str, FieldMetadata(alias="uuid")]`, so the JSON key is `uuid`;
+emitting `uuid_` makes the client raise ValidationError. Declaring plain `uuid`
+here removes any chance of that mistake. See WIRE_SPEC.md.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def iso(value: datetime | None) -> str | None:
+    """Render a datetime the way the Zep API does: RFC3339 with a Z suffix."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
+
+
+def now_iso() -> str:
+    return iso(datetime.now(timezone.utc))  # type: ignore[return-value]
+
+
+EpisodeSource = Literal['text', 'json', 'message', 'fact_triple']
+BatchStatus = Literal[
+    'draft', 'invalid', 'queued', 'processing', 'succeeded', 'partial', 'failed', 'canceled'
+]
+BatchItemStatus = Literal[
+    'pending', 'queued', 'processing', 'succeeded', 'failed', 'skipped', 'canceled'
+]
+PropertyType = Literal['Text', 'Int', 'Float', 'Boolean']
+
+
+# ---------------------------------------------------------------------------
+# responses
+# ---------------------------------------------------------------------------
+
+
+class SuccessResponse(BaseModel):
+    message: str | None = 'ok'
+
+
+class Graph(BaseModel):
+    uuid: str | None = None
+    graph_id: str | None = None
+    name: str | None = None
+    description: str | None = None
+    created_at: str | None = None
+    project_uuid: str | None = None
+    time_zone: str | None = None
+    id: int | None = None
+
+
+class Episode(BaseModel):
+    uuid: str
+    content: str
+    created_at: str
+    source: EpisodeSource | None = 'text'
+    source_description: str | None = None
+    metadata: dict[str, Any] | None = None
+    processed: bool | None = None
+    role: str | None = None
+    role_type: str | None = None
+    thread_id: str | None = None
+    task_id: str | None = None
+    score: float | None = None
+    relevance: float | None = None
+    selection_rank: int | None = None
+
+
+class EntityNode(BaseModel):
+    uuid: str
+    name: str
+    summary: str
+    created_at: str
+    labels: list[str] | None = None
+    attributes: dict[str, Any] | None = None
+    score: float | None = None
+    relevance: float | None = None
+    selection_rank: int | None = None
+
+
+class EntityEdge(BaseModel):
+    uuid: str
+    name: str
+    fact: str
+    source_node_uuid: str
+    target_node_uuid: str
+    created_at: str
+    episodes: list[str] | None = None
+    valid_at: str | None = None
+    invalid_at: str | None = None
+    expired_at: str | None = None
+    attributes: dict[str, Any] | None = None
+    scope: str | None = None
+    score: float | None = None
+    relevance: float | None = None
+    selection_rank: int | None = None
+
+
+class EpisodeResponse(BaseModel):
+    episodes: list[Episode] | None = None
+
+
+class EpisodeMentions(BaseModel):
+    nodes: list[EntityNode] | None = None
+    edges: list[EntityEdge] | None = None
+
+
+class GraphSearchResults(BaseModel):
+    nodes: list[EntityNode] | None = None
+    edges: list[EntityEdge] | None = None
+    episodes: list[Episode] | None = None
+    context: str | None = None
+
+
+class BatchProgress(BaseModel):
+    total_items: int | None = None
+    queued_items: int | None = None
+    processing_items: int | None = None
+    succeeded_items: int | None = None
+    failed_items: int | None = None
+    skipped_items: int | None = None
+    canceled_items: int | None = None
+    percent_complete: float | None = None
+
+
+class BatchSummary(BaseModel):
+    batch_id: str | None = None
+    status: BatchStatus | None = None
+    item_count: int | None = None
+    metadata: dict[str, Any] | None = None
+    progress: BatchProgress | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    processed_at: str | None = None
+    completed_at: str | None = None
+    ignore_roles: list[str] | None = None
+
+
+class BatchItemDetail(BaseModel):
+    item_id: str | None = None
+    batch_id: str | None = None
+    kind: Literal['graph_episode', 'thread_message'] | None = 'graph_episode'
+    status: BatchItemStatus | None = None
+    sequence_index: int | None = None
+    graph_id: str | None = None
+    graph_uuid: str | None = None
+    episode_uuid: str | None = None
+    source_uuid: str | None = None
+    thread_id: str | None = None
+    user_id: str | None = None
+    user_uuid: str | None = None
+    error: dict[str, Any] | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class BatchItemListResponse(BaseModel):
+    items: list[BatchItemDetail] | None = None
+    next_cursor: int | None = None
+
+
+class BatchListResponse(BaseModel):
+    batches: list[BatchSummary] | None = None
+    next_cursor: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# requests
+# ---------------------------------------------------------------------------
+
+
+class CreateGraphRequest(BaseModel):
+    graph_id: str
+    name: str | None = None
+    description: str | None = None
+    time_zone: str | None = None
+
+
+class AddDataRequest(BaseModel):
+    graph_id: str | None = None
+    user_id: str | None = None
+    data: str
+    type: EpisodeSource = 'text'
+    source_description: str | None = None
+    created_at: str | None = None
+    metadata: dict[str, Any] | None = None
+    strict_ontology: bool | None = None
+
+
+class SearchRequest(BaseModel):
+    query: str
+    graph_id: str | None = None
+    user_id: str | None = None
+    limit: int | None = 10
+    scope: str | None = 'edges'
+    reranker: str | None = None
+    center_node_uuid: str | None = None
+    bfs_origin_node_uuids: list[str] | None = None
+    mmr_lambda: float | None = None
+    max_characters: int | None = None
+    return_raw_results: bool | None = None
+    search_filters: dict[str, Any] | None = None
+
+
+class ListByGraphRequest(BaseModel):
+    """Body of POST graph/node/graph/{graph_id} and graph/edge/graph/{graph_id}."""
+
+    limit: int | None = 100
+    cursor: str | None = None
+    uuid_cursor: str | None = None
+    order_by: str | None = None
+    direction: str | None = None
+    filters: dict[str, Any] | None = None
+
+
+class EntityProperty(BaseModel):
+    name: str
+    description: str
+    type: PropertyType = 'Text'
+
+
+class EntityEdgeSourceTarget(BaseModel):
+    source: str | None = None
+    target: str | None = None
+
+
+class EntityType(BaseModel):
+    name: str
+    description: str
+    properties: list[EntityProperty] | None = None
+    identity_properties: list[str] | None = None
+
+
+class EdgeType(BaseModel):
+    name: str
+    description: str
+    properties: list[EntityProperty] | None = None
+    source_targets: list[EntityEdgeSourceTarget] | None = None
+
+
+class SetEntityTypesRequest(BaseModel):
+    entity_types: list[EntityType] = Field(default_factory=list)
+    edge_types: list[EdgeType] = Field(default_factory=list)
+    graph_ids: list[str] | None = None
+    user_ids: list[str] | None = None
+
+
+class EntityTypeResponse(BaseModel):
+    entity_types: list[EntityType] | None = None
+    edge_types: list[EdgeType] | None = None
+
+
+class CreateBatchRequest(BaseModel):
+    metadata: dict[str, Any] | None = None
+    ignore_roles: list[str] | None = None
+
+
+class BatchAddItem(BaseModel):
+    type: Literal['graph_episode', 'thread_message'] = 'graph_episode'
+    graph_id: str | None = None
+    user_id: str | None = None
+    thread_id: str | None = None
+    data: str | None = None
+    content: str | None = None
+    data_type: EpisodeSource | None = 'text'
+    name: str | None = None
+    source_description: str | None = None
+    created_at: str | None = None
+    role: str | None = None
+    metadata: dict[str, Any] | None = None
+
+    def payload(self) -> str:
+        return self.data if self.data is not None else (self.content or '')
+
+
+class AddBatchItemsRequest(BaseModel):
+    items: list[BatchAddItem] = Field(default_factory=list)

--- a/server/graph_service/zep_compat/ontology.py
+++ b/server/graph_service/zep_compat/ontology.py
@@ -1,0 +1,127 @@
+"""Translate a Zep-style ontology into Graphiti's Pydantic type maps.
+
+Zep Cloud stores the ontology server-side and applies it to every ingest.
+Graphiti instead wants `entity_types` / `edge_types` / `edge_type_map` passed
+into each `add_episode` call, as Pydantic model classes. This module builds
+those classes from the JSON MiroFish sent to `PUT entity-types`.
+"""
+
+from __future__ import annotations
+
+import keyword
+import re
+from typing import Any
+
+from pydantic import BaseModel, Field, create_model
+
+_TYPE_MAP: dict[str, type] = {
+    'Text': str,
+    'Int': int,
+    'Float': float,
+    'Boolean': bool,
+}
+
+# Graphiti raises EntityTypeValidationError when a custom attribute shadows a
+# field on its own EntityNode. Union of Node + EntityNode annotated fields in
+# graphiti_core/nodes.py. MiroFish's own reserved list misses `labels` and
+# `attributes`, so we re-check here rather than trusting the caller.
+_GRAPHITI_RESERVED = frozenset(
+    {
+        'uuid',
+        'name',
+        'group_id',
+        'labels',
+        'created_at',
+        'name_embedding',
+        'summary',
+        'attributes',
+    }
+)
+
+_IDENT_RE = re.compile(r'[^0-9a-zA-Z_]')
+
+
+def safe_field_name(raw: str) -> str:
+    """Coerce an arbitrary attribute name into a legal, non-colliding field."""
+    name = _IDENT_RE.sub('_', (raw or '').strip()).strip('_')
+    if not name:
+        name = 'value'
+    if name[0].isdigit():
+        name = f'attr_{name}'
+    if name in _GRAPHITI_RESERVED or keyword.iskeyword(name):
+        name = f'attr_{name}'
+    return name
+
+
+def _safe_model_name(raw: str, fallback: str) -> str:
+    name = _IDENT_RE.sub('', (raw or '').strip())
+    if not name or name[0].isdigit():
+        name = fallback
+    return name
+
+
+def _build_model(
+    type_name: str, description: str, properties: list[dict[str, Any]] | None
+) -> type[BaseModel]:
+    fields: dict[str, Any] = {}
+    used: set[str] = set()
+    for prop in properties or []:
+        if not isinstance(prop, dict):
+            continue
+        field_name = safe_field_name(str(prop.get('name', '')))
+        # Two distinct source names can normalize to the same field.
+        candidate, suffix = field_name, 2
+        while candidate in used:
+            candidate = f'{field_name}_{suffix}'
+            suffix += 1
+        used.add(candidate)
+        py_type = _TYPE_MAP.get(str(prop.get('type') or 'Text'), str)
+        fields[candidate] = (
+            py_type | None,
+            Field(default=None, description=str(prop.get('description') or candidate)),
+        )
+
+    model = create_model(  # type: ignore[call-overload]
+        _safe_model_name(type_name, 'OntologyType'),
+        __base__=BaseModel,
+        **fields,
+    )
+    # Graphiti feeds the class docstring to the extraction prompt as the type's
+    # definition, so this is load-bearing, not cosmetic.
+    model.__doc__ = description or f'A {type_name}.'
+    return model
+
+
+def build_entity_types(entity_types: list[dict[str, Any]]) -> dict[str, type[BaseModel]]:
+    built: dict[str, type[BaseModel]] = {}
+    for spec in entity_types or []:
+        name = str(spec.get('name') or '').strip()
+        if not name or name == 'Entity':
+            # 'Entity' is Graphiti's built-in default label; redefining it is
+            # rejected by excluded/registered-type handling upstream.
+            continue
+        built[name] = _build_model(
+            name, str(spec.get('description') or ''), spec.get('properties')
+        )
+    return built
+
+
+def build_edge_types(
+    edge_types: list[dict[str, Any]],
+) -> tuple[dict[str, type[BaseModel]], dict[tuple[str, str], list[str]]]:
+    built: dict[str, type[BaseModel]] = {}
+    type_map: dict[tuple[str, str], list[str]] = {}
+    for spec in edge_types or []:
+        name = str(spec.get('name') or '').strip()
+        if not name:
+            continue
+        built[name] = _build_model(
+            name, str(spec.get('description') or ''), spec.get('properties')
+        )
+        for pair in spec.get('source_targets') or []:
+            if not isinstance(pair, dict):
+                continue
+            source = str(pair.get('source') or 'Entity').strip() or 'Entity'
+            target = str(pair.get('target') or 'Entity').strip() or 'Entity'
+            type_map.setdefault((source, target), []).append(name)
+    return built, type_map

--- a/server/graph_service/zep_compat/paging.py
+++ b/server/graph_service/zep_compat/paging.py
@@ -1,0 +1,97 @@
+"""Offset-based paging over a graph's nodes and edges.
+
+Why this exists instead of `EntityNode/EntityEdge.get_by_group_ids(uuid_cursor=...)`:
+
+graphiti_core 0.29.3 pages with `AND n.uuid < $uuid` plus `ORDER BY n.uuid DESC`.
+On FalkorDB that WHERE clause is silently not applied — verified against a live
+FalkorDB 4.x, where even a literal `n.uuid < '0005-u'` returns every row while
+`ORDER BY` and `SKIP`/`LIMIT` behave correctly. The result is that every page
+comes back identical, so a drain never terminates and rows repeat.
+
+MiroFish's `fetch_all_nodes` / `fetch_all_edges` treat `zep-next-cursor` as an
+opaque string, so we are free to make it a row offset and page with SKIP/LIMIT,
+which the same live test showed to be exact.
+
+Caveat: offset paging is only stable if the result set does not change mid-drain.
+MiroFish reads a graph after ingestion has reached a terminal batch status, so
+that holds. Concurrent writes during a drain could shift rows across pages.
+"""
+
+from __future__ import annotations
+
+from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.edges import EntityEdge, get_entity_edge_from_record
+from graphiti_core.models.edges.edge_db_queries import get_entity_edge_return_query
+from graphiti_core.models.nodes.node_db_queries import get_entity_node_return_query
+from graphiti_core.nodes import EntityNode, get_entity_node_from_record
+
+
+def parse_cursor(cursor: str | None) -> int:
+    """Cursors are stringified row offsets; anything unparseable starts over."""
+    if not cursor:
+        return 0
+    try:
+        return max(0, int(str(cursor).strip()))
+    except (TypeError, ValueError):
+        return 0
+
+
+async def page_nodes(
+    driver: GraphDriver, group_id: str, limit: int, offset: int
+) -> tuple[list[EntityNode], int | None]:
+    """Return (nodes, next_offset). next_offset is None on the last page."""
+    records, _, _ = await driver.execute_query(
+        """
+        MATCH (n:Entity)
+        WHERE n.group_id IN $group_ids
+        RETURN
+        """
+        + get_entity_node_return_query(driver.provider)
+        + """
+        ORDER BY n.uuid DESC
+        SKIP $skip
+        LIMIT $limit
+        """,
+        group_ids=[group_id],
+        skip=offset,
+        # One extra row tells us whether another page exists without a count().
+        limit=limit + 1,
+        routing_='r',
+    )
+    nodes = [get_entity_node_from_record(record, driver.provider) for record in records]
+    has_more = len(nodes) > limit
+    return nodes[:limit], (offset + limit if has_more else None)
+
+
+async def page_edges(
+    driver: GraphDriver, group_id: str, limit: int, offset: int
+) -> tuple[list[EntityEdge], int | None]:
+    """Return (edges, next_offset). next_offset is None on the last page."""
+    match_query = """
+        MATCH (n:Entity)-[e:RELATES_TO]->(m:Entity)
+    """
+    if driver.provider == GraphProvider.KUZU:
+        match_query = """
+            MATCH (n:Entity)-[:RELATES_TO]->(e:RelatesToNode_)-[:RELATES_TO]->(m:Entity)
+        """
+
+    records, _, _ = await driver.execute_query(
+        match_query
+        + """
+        WHERE e.group_id IN $group_ids
+        RETURN
+        """
+        + get_entity_edge_return_query(driver.provider)
+        + """
+        ORDER BY e.uuid DESC
+        SKIP $skip
+        LIMIT $limit
+        """,
+        group_ids=[group_id],
+        skip=offset,
+        limit=limit + 1,
+        routing_='r',
+    )
+    edges = [get_entity_edge_from_record(record, driver.provider) for record in records]
+    has_more = len(edges) > limit
+    return edges[:limit], (offset + limit if has_more else None)

--- a/server/graph_service/zep_compat/router.py
+++ b/server/graph_service/zep_compat/router.py
@@ -1,0 +1,568 @@
+"""Zep Cloud v2 compatible routes backed by Graphiti.
+
+Mounted under /api/v2 so the zep-cloud SDK, constructed with
+base_url="http://host:port/api/v2", resolves every path it builds.
+
+Route order matters: the concrete /graph/... routes are declared before the
+/graph/{graph_id} catch-all.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from graphiti_core.edges import EntityEdge as GEntityEdge
+from graphiti_core.errors import (
+    EdgesNotFoundError,
+    GroupsEdgesNotFoundError,
+    GroupsNodesNotFoundError,
+    NodeNotFoundError,
+)
+from graphiti_core.nodes import EntityNode as GEntityNode
+from graphiti_core.nodes import EpisodicNode as GEpisodicNode
+from graphiti_core.nodes import EpisodeType
+from graphiti_core.search.search_config_recipes import (
+    COMBINED_HYBRID_SEARCH_CROSS_ENCODER,
+    COMBINED_HYBRID_SEARCH_RRF,
+    EDGE_HYBRID_SEARCH_CROSS_ENCODER,
+    EDGE_HYBRID_SEARCH_RRF,
+    NODE_HYBRID_SEARCH_CROSS_ENCODER,
+    NODE_HYBRID_SEARCH_RRF,
+)
+from graphiti_core.utils.maintenance.graph_data_operations import clear_data
+
+from . import models as m
+from .ontology import build_edge_types, build_entity_types
+from .paging import page_edges, page_nodes, parse_cursor
+from .runtime import Runtime, _parse_time, ingest_episode
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+NEXT_CURSOR_HEADER = 'zep-next-cursor'
+
+
+def get_runtime(request: Request) -> Runtime:
+    runtime = getattr(request.app.state, 'zep_runtime', None)
+    if runtime is None:
+        raise HTTPException(status_code=503, detail='Zep compatibility layer not ready')
+    return runtime
+
+
+RuntimeDep = Annotated[Runtime, Depends(get_runtime)]
+
+
+async def resolve_graph_for_uuid(runtime: Runtime, uuid: str, kind: str):
+    """Find which graph a node/episode UUID lives in.
+
+    Zep's GET graph/node/{uuid} and GET graph/episodes/{uuid} carry no graph_id,
+    but graphiti 0.29.3 puts each graph in its own database, so we need one.
+    The index is populated whenever we hand a UUID out; the scan is the fallback
+    for UUIDs this process never served (e.g. after wiping the sqlite state).
+    """
+    graph_id = runtime.store.graph_id_for_uuid(uuid)
+    if graph_id is not None:
+        return graph_id, await runtime.pool.get(graph_id)
+    return None, None
+
+
+# ---------------------------------------------------------------------------
+# converters: graphiti objects -> wire models
+# ---------------------------------------------------------------------------
+
+
+def node_out(node: GEntityNode) -> m.EntityNode:
+    return m.EntityNode(
+        uuid=node.uuid,
+        name=node.name,
+        summary=node.summary or '',
+        created_at=m.iso(node.created_at) or m.now_iso(),
+        labels=list(node.labels or []),
+        attributes=dict(node.attributes or {}),
+    )
+
+
+def edge_out(edge: GEntityEdge) -> m.EntityEdge:
+    return m.EntityEdge(
+        uuid=edge.uuid,
+        name=edge.name,
+        fact=edge.fact,
+        source_node_uuid=edge.source_node_uuid,
+        target_node_uuid=edge.target_node_uuid,
+        created_at=m.iso(edge.created_at) or m.now_iso(),
+        episodes=list(edge.episodes or []),
+        valid_at=m.iso(edge.valid_at),
+        invalid_at=m.iso(edge.invalid_at),
+        expired_at=m.iso(edge.expired_at),
+        attributes=dict(edge.attributes or {}),
+    )
+
+
+def episode_out(node: GEpisodicNode) -> m.Episode:
+    source = node.source.value if hasattr(node.source, 'value') else str(node.source)
+    return m.Episode(
+        uuid=node.uuid,
+        content=node.content or '',
+        created_at=m.iso(node.created_at) or m.now_iso(),
+        source=source if source in ('text', 'json', 'message', 'fact_triple') else 'text',
+        source_description=node.source_description or '',
+        # `processed` is what MiroFish polls in
+        # zep_graph_memory_updater._wait_for_pending_episodes. Cloud ingests
+        # asynchronously, so it can return an unprocessed episode; here
+        # add_episode runs to completion before the EpisodicNode is readable,
+        # so anything retrievable is by definition already processed. An
+        # in-flight episode is a 404, not processed=False.
+        processed=True,
+    )
+
+
+def graph_out(record: dict[str, Any]) -> m.Graph:
+    return m.Graph(
+        uuid=record['uuid'],
+        graph_id=record['graph_id'],
+        name=record.get('name'),
+        description=record.get('description'),
+        created_at=record.get('created_at'),
+        time_zone=record.get('time_zone'),
+    )
+
+
+def _progress(counts: dict[str, int]) -> m.BatchProgress:
+    total = counts.get('total', 0)
+    succeeded = counts.get('succeeded', 0)
+    failed = counts.get('failed', 0)
+    skipped = counts.get('skipped', 0)
+    settled = succeeded + failed + skipped + counts.get('canceled', 0)
+    return m.BatchProgress(
+        total_items=total,
+        queued_items=counts.get('queued', 0) + counts.get('pending', 0),
+        processing_items=counts.get('processing', 0),
+        succeeded_items=succeeded,
+        failed_items=failed,
+        skipped_items=skipped,
+        canceled_items=counts.get('canceled', 0),
+        percent_complete=(100.0 * settled / total) if total else 0.0,
+    )
+
+
+def batch_out(record: dict[str, Any], counts: dict[str, int]) -> m.BatchSummary:
+    return m.BatchSummary(
+        batch_id=record['batch_id'],
+        status=record['status'],
+        item_count=counts.get('total', 0),
+        metadata=record.get('metadata'),
+        progress=_progress(counts),
+        created_at=record.get('created_at'),
+        updated_at=record.get('updated_at'),
+        processed_at=record.get('processed_at'),
+        completed_at=record.get('completed_at'),
+        ignore_roles=record.get('ignore_roles'),
+    )
+
+
+def item_out(record: dict[str, Any]) -> m.BatchItemDetail:
+    return m.BatchItemDetail(
+        item_id=record['item_id'],
+        batch_id=record['batch_id'],
+        kind=record.get('kind') or 'graph_episode',
+        status=record['status'],
+        sequence_index=record['sequence_index'],
+        graph_id=record.get('graph_id'),
+        episode_uuid=record.get('episode_uuid'),
+        error=record.get('error'),
+        created_at=record.get('created_at'),
+        updated_at=record.get('updated_at'),
+    )
+
+
+# ---------------------------------------------------------------------------
+# ontology
+# ---------------------------------------------------------------------------
+
+
+@router.put('/entity-types', response_model=m.SuccessResponse)
+async def set_entity_types(payload: m.SetEntityTypesRequest, runtime: RuntimeDep):
+    """Zep applies an ontology to a set of graphs; we persist it per graph_id.
+
+    Graphiti needs the types passed into every add_episode call, so the stored
+    JSON is rebuilt into Pydantic models at ingest time.
+    """
+    graph_ids = payload.graph_ids or []
+    if not graph_ids:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='graph_ids is required; user-scoped ontologies are not supported',
+        )
+    entity_specs = [t.model_dump() for t in payload.entity_types]
+    edge_specs = [t.model_dump() for t in payload.edge_types]
+
+    # Fail loudly here rather than on every ingest if the ontology cannot be
+    # expressed as Pydantic models.
+    build_entity_types(entity_specs)
+    build_edge_types(edge_specs)
+
+    for graph_id in graph_ids:
+        runtime.store.set_ontology(graph_id, entity_specs, edge_specs)
+    return m.SuccessResponse(message=f'ontology set for {len(graph_ids)} graph(s)')
+
+
+@router.get('/entity-types', response_model=m.EntityTypeResponse)
+async def list_entity_types(runtime: RuntimeDep, graph_id: str | None = None):
+    if not graph_id:
+        return m.EntityTypeResponse(entity_types=[], edge_types=[])
+    entity_specs, edge_specs = runtime.store.get_ontology(graph_id)
+    return m.EntityTypeResponse(
+        entity_types=[m.EntityType(**spec) for spec in entity_specs],
+        edge_types=[m.EdgeType(**spec) for spec in edge_specs],
+    )
+
+
+# ---------------------------------------------------------------------------
+# graph lifecycle + ingest
+# ---------------------------------------------------------------------------
+
+
+@router.post('/graph/create', response_model=m.Graph)
+async def create_graph(payload: m.CreateGraphRequest, runtime: RuntimeDep):
+    record = runtime.store.create_graph(
+        payload.graph_id, payload.name, payload.description, payload.time_zone
+    )
+    return graph_out(record)
+
+
+@router.post('/graph/search', response_model=m.GraphSearchResults)
+async def search_graph(payload: m.SearchRequest, runtime: RuntimeDep):
+    if not payload.graph_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='graph_id is required; user-scoped search is not supported',
+        )
+    # MiroFish sends reranker='cross_encoder' from the report tooling and
+    # 'rrf' from the OASIS profile generator. Honour cross_encoder only when a
+    # real local reranker is configured (GRAPHITI_RERANKER=bge); with the
+    # passthrough encoder a cross_encoder recipe would just reorder by input
+    # order, which is worse than RRF's own fusion. So default to RRF.
+    scope = (payload.scope or 'edges').lower()
+    want_cross_encoder = (payload.reranker or '').lower() == 'cross_encoder' and (
+        os.environ.get('GRAPHITI_RERANKER', 'none').strip().lower() == 'bge'
+    )
+    if scope == 'nodes':
+        config = (
+            NODE_HYBRID_SEARCH_CROSS_ENCODER if want_cross_encoder else NODE_HYBRID_SEARCH_RRF
+        ).model_copy(deep=True)
+    elif scope in ('episodes', 'auto'):
+        config = (
+            COMBINED_HYBRID_SEARCH_CROSS_ENCODER
+            if want_cross_encoder
+            else COMBINED_HYBRID_SEARCH_RRF
+        ).model_copy(deep=True)
+    else:
+        config = (
+            EDGE_HYBRID_SEARCH_CROSS_ENCODER if want_cross_encoder else EDGE_HYBRID_SEARCH_RRF
+        ).model_copy(deep=True)
+    # MiroFish already clamps to 50 via normalize_zep_search_limit; clamp again
+    # so a hand-rolled client cannot ask for an unbounded scan.
+    config.limit = max(1, min(int(payload.limit or 10), 50))
+
+    graphiti = await runtime.pool.get(payload.graph_id)
+    results = await graphiti.search_(
+        query=payload.query,
+        config=config,
+        group_ids=[payload.graph_id],
+        center_node_uuid=payload.center_node_uuid,
+        bfs_origin_node_uuids=payload.bfs_origin_node_uuids,
+    )
+    runtime.store.remember_uuids(
+        payload.graph_id, 'node', [n.uuid for n in results.nodes]
+    )
+    runtime.store.remember_uuids(
+        payload.graph_id, 'episode', [e.uuid for e in results.episodes]
+    )
+    return m.GraphSearchResults(
+        nodes=[node_out(n) for n in results.nodes],
+        edges=[edge_out(e) for e in results.edges],
+        episodes=[episode_out(e) for e in results.episodes],
+    )
+
+
+@router.post('/graph/node/graph/{graph_id}', response_model=list[m.EntityNode])
+async def list_nodes_by_graph(
+    graph_id: str,
+    payload: m.ListByGraphRequest,
+    response: Response,
+    runtime: RuntimeDep,
+):
+    """MiroFish drives pagination off the zep-next-cursor RESPONSE header.
+
+    An absent header means "last page"; a non-advancing cursor makes MiroFish
+    raise. Graphiti's uuid_cursor is exactly the right primitive.
+    """
+    limit = max(1, min(int(payload.limit or 100), 100))
+    offset = parse_cursor(payload.cursor or payload.uuid_cursor)
+    graphiti = await runtime.pool.get(graph_id)
+    try:
+        nodes, next_offset = await page_nodes(graphiti.driver, graph_id, limit, offset)
+    except GroupsNodesNotFoundError:
+        nodes, next_offset = [], None
+    # Remember where these live so a later GET graph/node/{uuid} can find them.
+    runtime.store.remember_uuids(graph_id, 'node', [n.uuid for n in nodes])
+    if next_offset is not None:
+        response.headers[NEXT_CURSOR_HEADER] = str(next_offset)
+    return [node_out(n) for n in nodes]
+
+
+@router.post('/graph/edge/graph/{graph_id}', response_model=list[m.EntityEdge])
+async def list_edges_by_graph(
+    graph_id: str,
+    payload: m.ListByGraphRequest,
+    response: Response,
+    runtime: RuntimeDep,
+):
+    limit = max(1, min(int(payload.limit or 100), 100))
+    offset = parse_cursor(payload.cursor or payload.uuid_cursor)
+    graphiti = await runtime.pool.get(graph_id)
+    try:
+        edges, next_offset = await page_edges(graphiti.driver, graph_id, limit, offset)
+    except GroupsEdgesNotFoundError:
+        # graphiti_core's own edge accessor raises on an empty result where the
+        # node one returns []. Our query does not, but keep the guard: "no edges
+        # yet" is normal for a fresh graph, and a 500 here gets retried three
+        # times by MiroFish before failing the whole read.
+        edges, next_offset = [], None
+    if next_offset is not None:
+        response.headers[NEXT_CURSOR_HEADER] = str(next_offset)
+    return [edge_out(e) for e in edges]
+
+
+@router.get('/graph/node/{node_uuid}/entity-edges', response_model=list[m.EntityEdge])
+async def get_node_edges(node_uuid: str, runtime: RuntimeDep):
+    _, graphiti = await resolve_graph_for_uuid(runtime, node_uuid, 'node')
+    if graphiti is None:
+        raise HTTPException(status_code=404, detail=f'node {node_uuid} not found')
+    try:
+        edges = await GEntityEdge.get_by_node_uuid(graphiti.driver, node_uuid)
+    except (EdgesNotFoundError, GroupsEdgesNotFoundError):
+        # An isolated node has no edges; that is data, not an error.
+        edges = []
+    return [edge_out(e) for e in edges]
+
+
+@router.get('/graph/node/{node_uuid}', response_model=m.EntityNode)
+async def get_node(node_uuid: str, runtime: RuntimeDep):
+    _, graphiti = await resolve_graph_for_uuid(runtime, node_uuid, 'node')
+    if graphiti is None:
+        # MiroFish's zep_tools and zep_entity_reader both translate this 404
+        # into "entity not found" rather than an error.
+        raise HTTPException(status_code=404, detail=f'node {node_uuid} not found')
+    try:
+        node = await GEntityNode.get_by_uuid(graphiti.driver, node_uuid)
+    except NodeNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return node_out(node)
+
+
+@router.get('/graph/episodes/{episode_uuid}', response_model=m.Episode)
+async def get_episode(episode_uuid: str, runtime: RuntimeDep):
+    """Report ingestion progress for one episode.
+
+    Careful with 404 here. Unlike graph.get and graph.node.get, the zep-cloud
+    SDK's `graph.episode.get` does NOT map 404 to NotFoundError — it only
+    handles 400 and 500, so a 404 surfaces as a generic ApiError. MiroFish's
+    is_retryable_zep_error treats a 404 ApiError as non-retryable, which would
+    raise straight out of _wait_for_pending_episodes and abort the run.
+
+    Episode UUIDs are handed to MiroFish at batch.add time, before the episode
+    exists in the graph. So a UUID we know is queued must answer
+    processed=false — the same thing Cloud does — and only a genuinely unknown
+    UUID may 404.
+    """
+    # Check the batch item FIRST. The worker persists the EpisodicNode before
+    # running extraction (add_episode(uuid=...) loads an existing node rather
+    # than creating one), so the node is already readable while its item is
+    # still processing. Trusting the graph alone would report processed=true
+    # for work that has not finished.
+    item = runtime.store.find_item_by_episode_uuid(episode_uuid)
+    if item is not None and item['status'] not in ('succeeded', 'skipped'):
+        if item['status'] == 'failed':
+            # Terminal, and it will never become processed. Surfacing the
+            # failure beats letting the caller poll until its deadline.
+            raise HTTPException(
+                status_code=500,
+                detail=(item.get('error') or {}).get('message', 'ingestion failed'),
+            )
+        return m.Episode(
+            uuid=episode_uuid,
+            content=item.get('payload') or '',
+            created_at=item.get('created_at') or m.now_iso(),
+            source=item.get('data_type') or 'text',
+            source_description=item.get('source_description') or '',
+            processed=False,
+        )
+
+    graph_id = (item or {}).get('graph_id') or runtime.store.graph_id_for_uuid(episode_uuid)
+    if graph_id is None:
+        raise HTTPException(status_code=404, detail=f'episode {episode_uuid} not found')
+    graphiti = await runtime.pool.get(graph_id)
+    try:
+        episode = await GEpisodicNode.get_by_uuid(graphiti.driver, episode_uuid)
+    except NodeNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return episode_out(episode)
+
+
+@router.get('/graph/episodes/{episode_uuid}/mentions', response_model=m.EpisodeMentions)
+async def get_episode_mentions(episode_uuid: str, runtime: RuntimeDep):
+    graph_id, graphiti = await resolve_graph_for_uuid(runtime, episode_uuid, 'episode')
+    if graphiti is None:
+        raise HTTPException(status_code=404, detail=f'episode {episode_uuid} not found')
+    results = await graphiti.get_nodes_and_edges_by_episode([episode_uuid])
+    runtime.store.remember_uuids(graph_id, 'node', [n.uuid for n in results.nodes])
+    return m.EpisodeMentions(
+        nodes=[node_out(n) for n in results.nodes],
+        edges=[edge_out(e) for e in results.edges],
+    )
+
+
+@router.post('/graph', response_model=m.Episode)
+async def add_data(payload: m.AddDataRequest, runtime: RuntimeDep):
+    """Synchronous single-episode ingest. Slow with a local LLM — MiroFish's
+    bulk path goes through /batches instead."""
+    if not payload.graph_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='graph_id is required; user graphs are not supported',
+        )
+    graphiti = await runtime.pool.get(payload.graph_id)
+    # Let Graphiti mint the UUID here: unlike the batch path there is no UUID
+    # promised to the client ahead of time.
+    episode = await ingest_episode(
+        graphiti,
+        runtime.store,
+        graph_id=payload.graph_id,
+        episode_uuid=None,
+        name='mirofish-episode',
+        body=payload.data,
+        data_type=payload.type,
+        source_description=payload.source_description or '',
+        reference_time=_parse_time(payload.created_at),
+    )
+    return episode_out(episode)
+
+
+@router.get('/graph/{graph_id}', response_model=m.Graph)
+async def get_graph(graph_id: str, runtime: RuntimeDep):
+    record = runtime.store.get_graph(graph_id)
+    if record is None:
+        # MiroFish treats 404 here as "graph absent", not as a failure.
+        raise HTTPException(status_code=404, detail=f'graph {graph_id} not found')
+    return graph_out(record)
+
+
+@router.delete('/graph/{graph_id}', response_model=m.SuccessResponse)
+async def delete_graph(graph_id: str, runtime: RuntimeDep):
+    # 404 for an unknown graph matches Cloud, and MiroFish's teardown in
+    # app/api/graph.py explicitly catches NotFoundError to stay idempotent.
+    if runtime.store.get_graph(graph_id) is None:
+        raise HTTPException(status_code=404, detail=f'graph {graph_id} not found')
+    # clear_data is the purpose-built helper and scopes by group_id across
+    # Entity/Episodic/Community labels. Note EntityEdge has no
+    # delete_by_group_id classmethod, so do not reach for one.
+    graphiti = await runtime.pool.get(graph_id)
+    await clear_data(graphiti.driver, group_ids=[graph_id])
+    runtime.store.delete_graph(graph_id)
+    # Drop the cached instance so a later graph with the same id starts clean.
+    await runtime.pool.forget(graph_id)
+    return m.SuccessResponse(message=f'graph {graph_id} deleted')
+
+
+# ---------------------------------------------------------------------------
+# batches
+# ---------------------------------------------------------------------------
+
+
+@router.post('/batches', response_model=m.BatchSummary)
+async def create_batch(payload: m.CreateBatchRequest, runtime: RuntimeDep):
+    batch_id = runtime.store.create_batch(payload.metadata, payload.ignore_roles)
+    record = runtime.store.get_batch(batch_id)
+    assert record is not None
+    return batch_out(record, runtime.store.item_counts(batch_id))
+
+
+@router.get('/batches', response_model=m.BatchListResponse)
+async def list_batches(
+    runtime: RuntimeDep,
+    limit: int = 100,
+    cursor: int | None = None,
+    status_filter: str | None = None,
+):
+    limit = max(1, min(int(limit or 100), 100))
+    records, next_cursor = runtime.store.list_batches(limit, cursor, status_filter)
+    return m.BatchListResponse(
+        batches=[
+            batch_out(record, runtime.store.item_counts(record['batch_id']))
+            for record in records
+        ],
+        next_cursor=next_cursor,
+    )
+
+
+@router.post('/batches/{batch_id}/items', response_model=list[m.BatchItemDetail])
+async def add_batch_items(
+    batch_id: str, payload: m.AddBatchItemsRequest, runtime: RuntimeDep
+):
+    if runtime.store.get_batch(batch_id) is None:
+        raise HTTPException(status_code=404, detail=f'batch {batch_id} not found')
+    prepared = [
+        {
+            'graph_id': item.graph_id,
+            'payload': item.payload(),
+            'data_type': item.data_type or 'text',
+            'name': item.name,
+            'source_description': item.source_description,
+            'reference_time': item.created_at,
+            'metadata': item.metadata,
+            'kind': item.type,
+        }
+        for item in payload.items
+    ]
+    created = runtime.store.add_items(batch_id, prepared)
+    return [item_out(record) for record in created]
+
+
+@router.get('/batches/{batch_id}/items', response_model=m.BatchItemListResponse)
+async def list_batch_items(
+    batch_id: str, runtime: RuntimeDep, limit: int = 100, cursor: int | None = None
+):
+    if runtime.store.get_batch(batch_id) is None:
+        raise HTTPException(status_code=404, detail=f'batch {batch_id} not found')
+    limit = max(1, min(int(limit or 100), 100))
+    records, next_cursor = runtime.store.list_items(batch_id, limit, cursor)
+    return m.BatchItemListResponse(
+        items=[item_out(record) for record in records], next_cursor=next_cursor
+    )
+
+
+@router.post('/batches/{batch_id}/process', response_model=m.BatchSummary)
+async def process_batch(batch_id: str, runtime: RuntimeDep):
+    record = runtime.store.get_batch(batch_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f'batch {batch_id} not found')
+    if record['status'] == 'draft':
+        runtime.store.mark_items_queued(batch_id)
+        runtime.store.set_batch_status(batch_id, 'queued', processed=True)
+        runtime.worker.submit(batch_id)
+    record = runtime.store.get_batch(batch_id)
+    assert record is not None
+    return batch_out(record, runtime.store.item_counts(batch_id))
+
+
+@router.get('/batches/{batch_id}', response_model=m.BatchSummary)
+async def get_batch(batch_id: str, runtime: RuntimeDep):
+    record = runtime.store.get_batch(batch_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f'batch {batch_id} not found')
+    return batch_out(record, runtime.store.item_counts(batch_id))

--- a/server/graph_service/zep_compat/runtime.py
+++ b/server/graph_service/zep_compat/runtime.py
@@ -1,0 +1,381 @@
+"""Graphiti client construction and the async batch worker.
+
+Everything here is configured for a fully local deployment: an OpenAI-compatible
+LLM endpoint (vLLM), an OpenAI-compatible embeddings endpoint (TEI/vLLM), a local
+graph database, and no reranker that phones home.
+
+## One Graphiti instance per graph — why
+
+graphiti_core 0.29.3 treats `group_id` as the *database name*. In `add_episode`:
+
+    if group_id != self.driver._database:
+        self.driver = self.driver.clone(database=group_id)
+        self.clients.driver = self.driver
+
+Two consequences that shape this module:
+
+1. A graph's data lives in its own database, so a node/episode UUID is only
+   resolvable inside that database. Zep's `GET graph/node/{uuid}` carries no
+   graph_id, hence the uuid->graph index in `store.py`.
+2. That assignment MUTATES the shared instance. Two concurrent `add_episode`
+   calls for different graphs on one instance would clobber each other's driver
+   and write into the wrong database. So we keep one instance per graph_id,
+   already pointed at the right database — which also means `group_id ==
+   driver._database` and the clone never fires.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from graphiti_core import Graphiti
+from graphiti_core.cross_encoder.client import CrossEncoderClient
+from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig
+from graphiti_core.llm_client.config import LLMConfig
+from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
+from graphiti_core.nodes import EpisodeType, EpisodicNode
+
+from .ontology import build_edge_types, build_entity_types
+from .store import Store
+
+logger = logging.getLogger(__name__)
+
+
+def _env(name: str, default: str | None = None) -> str | None:
+    value = os.environ.get(name)
+    return value if value not in (None, '') else default
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw in (None, ''):
+        return default
+    return raw.strip().lower() in {'1', 'true', 'yes', 'on'}
+
+
+class PassthroughCrossEncoder(CrossEncoderClient):
+    """A reranker that does not rerank.
+
+    Graphiti's default is OpenAIRerankerClient, which is unusable locally for two
+    reasons: it needs an OPENAI_API_KEY at construction time, and it scores with
+    ``logit_bias={'6432': 1, '7983': 1}`` — hard-coded OpenAI tokenizer IDs for
+    True/False that mean nothing to a Qwen or Llama tokenizer, so its scores
+    would be noise. The RRF search recipes never call a cross-encoder, so this
+    exists to satisfy the constructor and to degrade gracefully if a
+    cross-encoder recipe is ever selected.
+    """
+
+    async def rank(self, query: str, passages: list[str]) -> list[tuple[str, float]]:
+        total = len(passages)
+        return [(passage, 1.0 - (i / total if total else 0)) for i, passage in enumerate(passages)]
+
+
+def _build_cross_encoder() -> CrossEncoderClient:
+    kind = (_env('GRAPHITI_RERANKER', 'none') or 'none').strip().lower()
+    if kind == 'bge':
+        # Local cross-encoder; downloads BAAI/bge-reranker-v2-m3 (~2.2GB) once.
+        from graphiti_core.cross_encoder.bge_reranker_client import BGERerankerClient
+
+        return BGERerankerClient()
+    if kind not in {'none', 'passthrough'}:
+        logger.warning('Unknown GRAPHITI_RERANKER=%r; using passthrough', kind)
+    return PassthroughCrossEncoder()
+
+
+def build_driver(database: str | None = None):
+    backend = (_env('GRAPHITI_DB_BACKEND', 'falkordb') or 'falkordb').strip().lower()
+    if backend == 'falkordb':
+        from graphiti_core.driver.falkordb_driver import FalkorDriver
+
+        return FalkorDriver(
+            host=_env('FALKORDB_HOST', 'localhost') or 'localhost',
+            port=int(_env('FALKORDB_PORT', '6379') or 6379),
+            password=_env('FALKORDB_PASSWORD'),
+            database=database or _env('FALKORDB_DATABASE', 'default_db') or 'default_db',
+        )
+    if backend == 'neo4j':
+        from graphiti_core.driver.neo4j_driver import Neo4jDriver
+
+        return Neo4jDriver(
+            uri=_env('NEO4J_URI', 'bolt://localhost:7687') or 'bolt://localhost:7687',
+            user=_env('NEO4J_USER', 'neo4j'),
+            password=_env('NEO4J_PASSWORD', 'password'),
+            database=database or _env('NEO4J_DATABASE', 'neo4j') or 'neo4j',
+        )
+    raise ValueError(f'Unsupported GRAPHITI_DB_BACKEND={backend!r} (use falkordb or neo4j)')
+
+
+def build_graphiti(database: str | None = None) -> Graphiti:
+    llm_client = OpenAIGenericClient(
+        config=LLMConfig(
+            api_key=_env('GRAPHITI_LLM_API_KEY', 'local') or 'local',
+            base_url=_env('GRAPHITI_LLM_BASE_URL', 'http://localhost:8000/v1'),
+            model=_env('GRAPHITI_LLM_MODEL', 'local-llm') or 'local-llm',
+            small_model=_env('GRAPHITI_LLM_SMALL_MODEL', _env('GRAPHITI_LLM_MODEL', 'local-llm')),
+            temperature=float(_env('GRAPHITI_LLM_TEMPERATURE', '0.0') or 0.0),
+        ),
+        max_tokens=int(_env('GRAPHITI_LLM_MAX_TOKENS', '16384') or 16384),
+        # 'json_schema' uses the server's constrained decoding (vLLM xgrammar).
+        # Switch to 'json_object' only for endpoints that reject json_schema.
+        structured_output_mode=_env('GRAPHITI_STRUCTURED_OUTPUT_MODE', 'json_schema'),  # type: ignore[arg-type]
+    )
+
+    embedder = OpenAIEmbedder(
+        config=OpenAIEmbedderConfig(
+            api_key=_env('GRAPHITI_EMBEDDER_API_KEY', 'local') or 'local',
+            base_url=_env('GRAPHITI_EMBEDDER_BASE_URL', 'http://localhost:8081/v1'),
+            embedding_model=_env('GRAPHITI_EMBEDDER_MODEL', 'BAAI/bge-m3') or 'BAAI/bge-m3',
+        )
+    )
+
+    return Graphiti(
+        graph_driver=build_driver(database),
+        llm_client=llm_client,
+        embedder=embedder,
+        cross_encoder=_build_cross_encoder(),
+        max_coroutines=int(_env('GRAPHITI_MAX_COROUTINES', '4') or 4),
+    )
+
+
+class GraphitiPool:
+    """One Graphiti per graph_id. See the module docstring for why."""
+
+    def __init__(
+        self,
+        factory: Callable[[str], Graphiti] = build_graphiti,
+        build_indices: bool = True,
+    ):
+        self._factory = factory
+        self._build_indices = build_indices
+        self._instances: dict[str, Graphiti] = {}
+        self._lock = asyncio.Lock()
+
+    async def get(self, graph_id: str) -> Graphiti:
+        instance = self._instances.get(graph_id)
+        if instance is not None:
+            return instance
+        async with self._lock:
+            # Re-check: another coroutine may have built it while we waited.
+            instance = self._instances.get(graph_id)
+            if instance is not None:
+                return instance
+            logger.info('Opening graph %s', graph_id)
+            instance = self._factory(graph_id)
+            # Hard invariant: the driver's database must BE the graph_id. If it
+            # is not, add_episode(group_id=graph_id) clones the driver to a
+            # database named graph_id and writes there instead — so anything we
+            # pre-saved through this instance lands somewhere else and the
+            # ingest fails with NodeNotFoundError. Fail loudly here rather than
+            # debug that later.
+            actual = getattr(instance.driver, '_database', None)
+            if actual is not None and actual != graph_id:
+                raise ValueError(
+                    f'Graphiti driver database {actual!r} must equal graph_id '
+                    f'{graph_id!r}; graphiti maps group_id onto the database name'
+                )
+            if self._build_indices:
+                # Indices and constraints are per-database, so every graph needs
+                # its own pass. Idempotent.
+                await instance.build_indices_and_constraints()
+            self._instances[graph_id] = instance
+            return instance
+
+    async def forget(self, graph_id: str) -> None:
+        async with self._lock:
+            instance = self._instances.pop(graph_id, None)
+        if instance is not None:
+            await instance.close()
+
+    async def close(self) -> None:
+        async with self._lock:
+            instances = list(self._instances.values())
+            self._instances.clear()
+        for instance in instances:
+            try:
+                await instance.close()
+            except Exception:  # noqa: BLE001 - shutdown must not raise
+                logger.warning('Error closing a Graphiti instance', exc_info=True)
+
+
+def _parse_time(value: str | None) -> datetime:
+    if not value:
+        return datetime.now(timezone.utc)
+    try:
+        return datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except ValueError:
+        return datetime.now(timezone.utc)
+
+
+async def ingest_episode(
+    graphiti: Graphiti,
+    store: Store,
+    *,
+    graph_id: str,
+    episode_uuid: str | None,
+    name: str,
+    body: str,
+    data_type: str,
+    source_description: str,
+    reference_time: datetime,
+) -> EpisodicNode:
+    """Ingest one episode, optionally under a caller-chosen UUID.
+
+    Zep's batch API hands the episode UUID to the client at `batch.add` time, so
+    it is fixed before ingestion starts. Graphiti's `add_episode(uuid=...)` does
+    NOT mean "create with this UUID" — it calls `EpisodicNode.get_by_uuid` and
+    raises NodeNotFoundError if absent, i.e. it means "process this existing
+    episode". So persist the node first, then hand its UUID to add_episode.
+    Keeping one UUID end to end matters: MiroFish records these and polls them.
+    """
+    entity_specs, edge_specs = store.get_ontology(graph_id)
+    entity_types = build_entity_types(entity_specs)
+    edge_types, edge_type_map = build_edge_types(edge_specs)
+    source = EpisodeType.from_str(data_type or 'text')
+
+    if episode_uuid is not None:
+        episode = EpisodicNode(
+            uuid=episode_uuid,
+            name=name,
+            group_id=graph_id,
+            labels=[],
+            source=source,
+            content=body,
+            source_description=source_description,
+            created_at=datetime.now(timezone.utc),
+            valid_at=reference_time,
+            entity_edges=[],
+        )
+        await episode.save(graphiti.driver)
+
+    result = await graphiti.add_episode(
+        uuid=episode_uuid,
+        group_id=graph_id,
+        name=name,
+        episode_body=body,
+        source=source,
+        source_description=source_description,
+        reference_time=reference_time,
+        entity_types=entity_types or None,
+        edge_types=edge_types or None,
+        edge_type_map=edge_type_map or None,
+    )
+
+    store.remember_uuids(graph_id, 'episode', [result.episode.uuid])
+    store.remember_uuids(graph_id, 'node', [n.uuid for n in result.nodes])
+    return result.episode
+
+
+@dataclass
+class BatchWorker:
+    """Processes batches out of the store, one item at a time per slot.
+
+    Zep ingestion is asynchronous: MiroFish POSTs items, POSTs /process, then
+    polls the summary until a terminal status. We reproduce that contract.
+    """
+
+    pool: GraphitiPool
+    store: Store
+    concurrency: int = 4
+    _tasks: set[asyncio.Task] = field(default_factory=set)
+    _semaphore: asyncio.Semaphore | None = None
+
+    def __post_init__(self) -> None:
+        self._semaphore = asyncio.Semaphore(self.concurrency)
+
+    def submit(self, batch_id: str) -> None:
+        task = asyncio.create_task(self._run_batch(batch_id))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def resume_incomplete(self) -> None:
+        for batch_id in self.store.claim_draft_batches():
+            logger.info('Resuming batch %s after restart', batch_id)
+            self.submit(batch_id)
+
+    async def drain(self) -> None:
+        if self._tasks:
+            await asyncio.gather(*list(self._tasks), return_exceptions=True)
+
+    async def _run_batch(self, batch_id: str) -> None:
+        self.store.set_batch_status(batch_id, 'processing')
+        items = self.store.pending_items(batch_id)
+        if not items:
+            self.store.set_batch_status(batch_id, 'succeeded', completed=True)
+            return
+
+        await asyncio.gather(*(self._run_item(item) for item in items))
+
+        counts = self.store.item_counts(batch_id)
+        failed = counts.get('failed', 0)
+        succeeded = counts.get('succeeded', 0) + counts.get('skipped', 0)
+        if failed == 0:
+            status = 'succeeded'
+        elif succeeded == 0:
+            status = 'failed'
+        else:
+            status = 'partial'
+        self.store.set_batch_status(batch_id, status, completed=True)
+        logger.info('Batch %s finished: %s (%s)', batch_id, status, counts)
+
+    async def _run_item(self, item: dict[str, Any]) -> None:
+        assert self._semaphore is not None
+        async with self._semaphore:
+            item_id = item['item_id']
+            self.store.set_item_status(item_id, 'processing')
+            graph_id = item.get('graph_id')
+            if not graph_id:
+                self.store.set_item_status(
+                    item_id, 'failed', {'message': 'item has no graph_id'}
+                )
+                return
+            try:
+                graphiti = await self.pool.get(graph_id)
+                await ingest_episode(
+                    graphiti,
+                    self.store,
+                    graph_id=graph_id,
+                    episode_uuid=item['episode_uuid'],
+                    name=item.get('name') or f'batch-{item["sequence_index"]}',
+                    body=item.get('payload') or '',
+                    data_type=item.get('data_type') or 'text',
+                    source_description=item.get('source_description') or '',
+                    reference_time=_parse_time(item.get('reference_time')),
+                )
+                self.store.set_item_status(item_id, 'succeeded')
+            except Exception as exc:  # noqa: BLE001 - one bad item must not kill the batch
+                logger.exception('Batch item %s failed', item_id)
+                self.store.set_item_status(
+                    item_id,
+                    'failed',
+                    {'message': str(exc), 'type': type(exc).__name__},
+                )
+
+
+@dataclass
+class Runtime:
+    pool: GraphitiPool
+    store: Store
+    worker: BatchWorker
+
+    @classmethod
+    async def create(cls) -> Runtime:
+        store = Store(_env('ZEP_COMPAT_DB_PATH', './data/zep_compat.sqlite3'))
+        pool = GraphitiPool(build_indices=_env_bool('ZEP_COMPAT_BUILD_INDICES', True))
+        worker = BatchWorker(
+            pool=pool,
+            store=store,
+            concurrency=int(_env('ZEP_COMPAT_BATCH_CONCURRENCY', '4') or 4),
+        )
+        await worker.resume_incomplete()
+        return cls(pool=pool, store=store, worker=worker)
+
+    async def close(self) -> None:
+        await self.worker.drain()
+        await self.pool.close()
+        self.store.close()

--- a/server/graph_service/zep_compat/store.py
+++ b/server/graph_service/zep_compat/store.py
@@ -1,0 +1,433 @@
+"""Durable state for the Zep-compatible layer.
+
+Graphiti itself owns the knowledge graph. This module owns only the metadata
+Zep Cloud keeps outside the graph and that MiroFish depends on:
+
+  * graph registry (so `GET graph/{id}` can 404 for an unknown graph)
+  * per-graph ontology (Zep stores it server-side; Graphiti wants it per call)
+  * batch + batch item lifecycle (MiroFish polls this and reconciles restarts)
+
+SQLite, because MiroFish's reconciliation paths assume the server remembers a
+batch across a lost response — and, after a restart, across a lost process.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import uuid as uuid_lib
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS graphs (
+    graph_id    TEXT PRIMARY KEY,
+    uuid        TEXT NOT NULL,
+    name        TEXT,
+    description TEXT,
+    time_zone   TEXT,
+    created_at  TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS ontologies (
+    graph_id     TEXT PRIMARY KEY,
+    entity_types TEXT NOT NULL,
+    edge_types   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS batches (
+    seq          INTEGER PRIMARY KEY AUTOINCREMENT,
+    batch_id     TEXT NOT NULL UNIQUE,
+    status       TEXT NOT NULL,
+    metadata     TEXT,
+    ignore_roles TEXT,
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL,
+    processed_at TEXT,
+    completed_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS batch_items (
+    item_id            TEXT PRIMARY KEY,
+    batch_id           TEXT NOT NULL,
+    sequence_index     INTEGER NOT NULL,
+    status             TEXT NOT NULL,
+    graph_id           TEXT,
+    episode_uuid       TEXT,
+    kind               TEXT NOT NULL DEFAULT 'graph_episode',
+    payload            TEXT,
+    data_type          TEXT,
+    name               TEXT,
+    source_description TEXT,
+    reference_time     TEXT,
+    metadata           TEXT,
+    error              TEXT,
+    created_at         TEXT NOT NULL,
+    updated_at         TEXT NOT NULL,
+    UNIQUE (batch_id, sequence_index)
+);
+
+CREATE TABLE IF NOT EXISTS uuid_index (
+    uuid     TEXT PRIMARY KEY,
+    graph_id TEXT NOT NULL,
+    kind     TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_items_batch ON batch_items (batch_id, sequence_index);
+CREATE INDEX IF NOT EXISTS idx_uuid_graph ON uuid_index (graph_id);
+"""
+
+TERMINAL_ITEM_STATES = ('succeeded', 'failed', 'skipped', 'canceled')
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
+
+
+def _dumps(value: Any) -> str | None:
+    return None if value is None else json.dumps(value)
+
+
+def _loads(value: str | None) -> Any:
+    return None if value in (None, '') else json.loads(value)
+
+
+class Store:
+    def __init__(self, path: str | Path):
+        self.path = str(path)
+        if self.path != ':memory:':
+            Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(self.path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        with self._lock:
+            self._conn.execute('PRAGMA journal_mode=WAL')
+            self._conn.execute('PRAGMA synchronous=NORMAL')
+            self._conn.executescript(_SCHEMA)
+            self._conn.commit()
+
+    @contextmanager
+    def _tx(self) -> Iterator[sqlite3.Connection]:
+        with self._lock:
+            try:
+                yield self._conn
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    # -- graphs -------------------------------------------------------------
+
+    def create_graph(
+        self,
+        graph_id: str,
+        name: str | None,
+        description: str | None,
+        time_zone: str | None,
+    ) -> dict[str, Any]:
+        created = _now()
+        graph_uuid = str(uuid_lib.uuid4())
+        with self._tx() as conn:
+            conn.execute(
+                'INSERT OR IGNORE INTO graphs '
+                '(graph_id, uuid, name, description, time_zone, created_at) '
+                'VALUES (?,?,?,?,?,?)',
+                (graph_id, graph_uuid, name, description, time_zone, created),
+            )
+        found = self.get_graph(graph_id)
+        assert found is not None
+        return found
+
+    def get_graph(self, graph_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            row = self._conn.execute(
+                'SELECT * FROM graphs WHERE graph_id = ?', (graph_id,)
+            ).fetchone()
+        return dict(row) if row else None
+
+    def delete_graph(self, graph_id: str) -> None:
+        with self._tx() as conn:
+            conn.execute('DELETE FROM graphs WHERE graph_id = ?', (graph_id,))
+            conn.execute('DELETE FROM ontologies WHERE graph_id = ?', (graph_id,))
+
+    # -- ontology -----------------------------------------------------------
+
+    def set_ontology(
+        self, graph_id: str, entity_types: list[dict], edge_types: list[dict]
+    ) -> None:
+        with self._tx() as conn:
+            conn.execute(
+                'INSERT INTO ontologies (graph_id, entity_types, edge_types, updated_at) '
+                'VALUES (?,?,?,?) ON CONFLICT(graph_id) DO UPDATE SET '
+                'entity_types=excluded.entity_types, edge_types=excluded.edge_types, '
+                'updated_at=excluded.updated_at',
+                (graph_id, json.dumps(entity_types), json.dumps(edge_types), _now()),
+            )
+
+    def get_ontology(self, graph_id: str) -> tuple[list[dict], list[dict]]:
+        with self._lock:
+            row = self._conn.execute(
+                'SELECT entity_types, edge_types FROM ontologies WHERE graph_id = ?',
+                (graph_id,),
+            ).fetchone()
+        if not row:
+            return [], []
+        return json.loads(row['entity_types']), json.loads(row['edge_types'])
+
+    def list_graph_ids(self) -> list[str]:
+        with self._lock:
+            rows = self._conn.execute(
+                'SELECT graph_id FROM graphs ORDER BY created_at DESC'
+            ).fetchall()
+        return [r['graph_id'] for r in rows]
+
+    # -- uuid -> graph index ------------------------------------------------
+    #
+    # graphiti 0.29.3 maps group_id onto the DATABASE name, so a node or
+    # episode UUID is only resolvable inside its own graph's database. Zep's
+    # GET graph/node/{uuid} and GET graph/episodes/{uuid} carry no graph_id, so
+    # remember which graph each UUID came from as we hand them out.
+
+    def remember_uuids(self, graph_id: str, kind: str, uuids: list[str]) -> None:
+        if not uuids:
+            return
+        with self._tx() as conn:
+            conn.executemany(
+                'INSERT INTO uuid_index (uuid, graph_id, kind) VALUES (?,?,?) '
+                'ON CONFLICT(uuid) DO UPDATE SET graph_id=excluded.graph_id',
+                [(u, graph_id, kind) for u in uuids if u],
+            )
+
+    def graph_id_for_uuid(self, uuid: str) -> str | None:
+        with self._lock:
+            row = self._conn.execute(
+                'SELECT graph_id FROM uuid_index WHERE uuid = ?', (uuid,)
+            ).fetchone()
+        return row['graph_id'] if row else None
+
+    # -- batches ------------------------------------------------------------
+
+    def create_batch(
+        self, metadata: dict[str, Any] | None, ignore_roles: list[str] | None
+    ) -> str:
+        batch_id = str(uuid_lib.uuid4())
+        stamp = _now()
+        with self._tx() as conn:
+            conn.execute(
+                'INSERT INTO batches '
+                '(batch_id, status, metadata, ignore_roles, created_at, updated_at) '
+                'VALUES (?,?,?,?,?,?)',
+                (batch_id, 'draft', _dumps(metadata), _dumps(ignore_roles), stamp, stamp),
+            )
+        return batch_id
+
+    def get_batch(self, batch_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            row = self._conn.execute(
+                'SELECT * FROM batches WHERE batch_id = ?', (batch_id,)
+            ).fetchone()
+        if not row:
+            return None
+        batch = dict(row)
+        batch['metadata'] = _loads(batch['metadata'])
+        batch['ignore_roles'] = _loads(batch['ignore_roles'])
+        return batch
+
+    def list_batches(
+        self, limit: int, cursor: int | None, status: str | None
+    ) -> tuple[list[dict[str, Any]], int | None]:
+        """Page batches by monotonic `seq`. Returns (batches, next_cursor)."""
+        sql = 'SELECT * FROM batches WHERE seq > ?'
+        params: list[Any] = [cursor or 0]
+        if status:
+            sql += ' AND status = ?'
+            params.append(status)
+        sql += ' ORDER BY seq ASC LIMIT ?'
+        params.append(limit + 1)
+        with self._lock:
+            rows = [dict(r) for r in self._conn.execute(sql, params).fetchall()]
+        has_more = len(rows) > limit
+        rows = rows[:limit]
+        for row in rows:
+            row['metadata'] = _loads(row['metadata'])
+            row['ignore_roles'] = _loads(row['ignore_roles'])
+        next_cursor = rows[-1]['seq'] if (has_more and rows) else None
+        return rows, next_cursor
+
+    def set_batch_status(
+        self,
+        batch_id: str,
+        status: str,
+        *,
+        processed: bool = False,
+        completed: bool = False,
+    ) -> None:
+        stamp = _now()
+        sets = ['status = ?', 'updated_at = ?']
+        params: list[Any] = [status, stamp]
+        if processed:
+            sets.append('processed_at = ?')
+            params.append(stamp)
+        if completed:
+            sets.append('completed_at = ?')
+            params.append(stamp)
+        params.append(batch_id)
+        with self._tx() as conn:
+            conn.execute(
+                f'UPDATE batches SET {", ".join(sets)} WHERE batch_id = ?', params
+            )
+
+    def claim_draft_batches(self) -> list[str]:
+        """Batches left mid-flight by a crash, so a restart can resume them."""
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT batch_id FROM batches WHERE status IN ('queued','processing')"
+            ).fetchall()
+        return [r['batch_id'] for r in rows]
+
+    # -- batch items --------------------------------------------------------
+
+    def add_items(self, batch_id: str, items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Append items, assigning globally increasing sequence_index.
+
+        MiroFish reconciles an ambiguous `batch.add` by listing items and
+        asserting the indexes are exactly range(expected_count), so the index
+        must be global across the whole batch, not per-request.
+        """
+        stamp = _now()
+        with self._tx() as conn:
+            row = conn.execute(
+                'SELECT COALESCE(MAX(sequence_index) + 1, 0) AS next FROM batch_items '
+                'WHERE batch_id = ?',
+                (batch_id,),
+            ).fetchone()
+            start = int(row['next'])
+            created: list[dict[str, Any]] = []
+            for offset, item in enumerate(items):
+                record = {
+                    'item_id': str(uuid_lib.uuid4()),
+                    'batch_id': batch_id,
+                    'sequence_index': start + offset,
+                    'status': 'pending',
+                    'graph_id': item.get('graph_id'),
+                    # Assign the episode UUID now: MiroFish reads episode_uuid
+                    # off the *add* response, long before processing runs.
+                    'episode_uuid': str(uuid_lib.uuid4()),
+                    'kind': item.get('kind') or 'graph_episode',
+                    'payload': item.get('payload'),
+                    'data_type': item.get('data_type') or 'text',
+                    'name': item.get('name'),
+                    'source_description': item.get('source_description'),
+                    'reference_time': item.get('reference_time'),
+                    'metadata': _dumps(item.get('metadata')),
+                    'error': None,
+                    'created_at': stamp,
+                    'updated_at': stamp,
+                }
+                conn.execute(
+                    'INSERT INTO batch_items (item_id, batch_id, sequence_index, status, '
+                    'graph_id, episode_uuid, kind, payload, data_type, name, '
+                    'source_description, reference_time, metadata, error, created_at, '
+                    'updated_at) VALUES (:item_id,:batch_id,:sequence_index,:status,'
+                    ':graph_id,:episode_uuid,:kind,:payload,:data_type,:name,'
+                    ':source_description,:reference_time,:metadata,:error,:created_at,'
+                    ':updated_at)',
+                    record,
+                )
+                created.append(record)
+        return created
+
+    def list_items(
+        self, batch_id: str, limit: int, cursor: int | None
+    ) -> tuple[list[dict[str, Any]], int | None]:
+        """Page items by sequence_index. Cursor is exclusive."""
+        start = -1 if cursor is None else cursor
+        with self._lock:
+            rows = [
+                dict(r)
+                for r in self._conn.execute(
+                    'SELECT * FROM batch_items WHERE batch_id = ? AND sequence_index > ? '
+                    'ORDER BY sequence_index ASC LIMIT ?',
+                    (batch_id, start, limit + 1),
+                ).fetchall()
+            ]
+        has_more = len(rows) > limit
+        rows = rows[:limit]
+        for row in rows:
+            row['metadata'] = _loads(row['metadata'])
+            row['error'] = _loads(row['error'])
+        next_cursor = rows[-1]['sequence_index'] if (has_more and rows) else None
+        return rows, next_cursor
+
+    def pending_items(self, batch_id: str) -> list[dict[str, Any]]:
+        with self._lock:
+            rows = self._conn.execute(
+                'SELECT * FROM batch_items WHERE batch_id = ? '
+                "AND status NOT IN ('succeeded','skipped','canceled') "
+                'ORDER BY sequence_index ASC',
+                (batch_id,),
+            ).fetchall()
+        out = []
+        for raw in rows:
+            row = dict(raw)
+            row['metadata'] = _loads(row['metadata'])
+            out.append(row)
+        return out
+
+    def find_item_by_episode_uuid(self, episode_uuid: str) -> dict[str, Any] | None:
+        """Look up a batch item by the episode UUID handed out at add time.
+
+        Needed because episode UUIDs are assigned when items are added, well
+        before the episode exists in the graph. A poll for one of those must
+        answer "not processed yet" rather than 404 — see the note in
+        router.get_episode.
+        """
+        with self._lock:
+            row = self._conn.execute(
+                'SELECT * FROM batch_items WHERE episode_uuid = ? LIMIT 1',
+                (episode_uuid,),
+            ).fetchone()
+        if not row:
+            return None
+        item = dict(row)
+        item['metadata'] = _loads(item['metadata'])
+        item['error'] = _loads(item['error'])
+        return item
+
+    def set_item_status(
+        self, item_id: str, status: str, error: dict[str, Any] | None = None
+    ) -> None:
+        with self._tx() as conn:
+            conn.execute(
+                'UPDATE batch_items SET status = ?, error = ?, updated_at = ? '
+                'WHERE item_id = ?',
+                (status, _dumps(error), _now(), item_id),
+            )
+
+    def mark_items_queued(self, batch_id: str) -> None:
+        with self._tx() as conn:
+            conn.execute(
+                "UPDATE batch_items SET status = 'queued', updated_at = ? "
+                "WHERE batch_id = ? AND status = 'pending'",
+                (_now(), batch_id),
+            )
+
+    def item_counts(self, batch_id: str) -> dict[str, int]:
+        with self._lock:
+            rows = self._conn.execute(
+                'SELECT status, COUNT(*) AS n FROM batch_items WHERE batch_id = ? '
+                'GROUP BY status',
+                (batch_id,),
+            ).fetchall()
+        counts = {r['status']: int(r['n']) for r in rows}
+        counts['total'] = sum(counts.values())
+        return counts

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "fastapi>=0.115.0",
-    "graphiti-core>=0.28.2",
+    "graphiti-core>=0.29.3",
     "pydantic-settings>=2.4.0",
     "uvicorn>=0.44.0",
     "httpx>=0.28.1",
@@ -27,12 +27,21 @@ dev = [
     "fastapi-cli>=0.0.5",
     # FalkorDB driver, needed by the live end-to-end test (tests/test_live_falkordb_int.py)
     # which exercises the db_backend='falkordb' path. Not a runtime dependency.
-    "graphiti-core[falkordb]>=0.28.2",
+    "graphiti-core[falkordb]>=0.29.3",
     # The exact SDK MiroFish runs. The zep_compat tests parse our responses with
     # zep-cloud's own parser, which is the whole point — pin it to the version
     # MiroFish pins so the contract under test is the real one.
     "zep-cloud==3.25.0",
 ]
+
+# graphiti-core comes from the fork checked out one directory up, NOT from PyPI.
+# The zep_compat layer is written against 0.29.3 fork behaviour: OpenAIGenericClient's
+# `structured_output_mode` kwarg (see zep_compat/runtime.py:build_graphiti) and
+# `group_id`-as-database-name in add_episode. Resolving graphiti-core from the registry
+# installs an older core whose OpenAIGenericClient rejects that kwarg, and every ingested
+# episode fails with a TypeError at batch time.
+[tool.uv.sources]
+graphiti-core = { path = "../", editable = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -28,6 +28,10 @@ dev = [
     # FalkorDB driver, needed by the live end-to-end test (tests/test_live_falkordb_int.py)
     # which exercises the db_backend='falkordb' path. Not a runtime dependency.
     "graphiti-core[falkordb]>=0.28.2",
+    # The exact SDK MiroFish runs. The zep_compat tests parse our responses with
+    # zep-cloud's own parser, which is the whole point — pin it to the version
+    # MiroFish pins so the contract under test is the real one.
+    "zep-cloud==3.25.0",
 ]
 
 [build-system]
@@ -39,6 +43,7 @@ packages = ["graph_service"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
+asyncio_mode = "auto"
 markers = [
     "integration: live end-to-end tests requiring FalkorDB and an OpenAI API key",
 ]

--- a/server/tests/test_zep_compat_contract.py
+++ b/server/tests/test_zep_compat_contract.py
@@ -1,0 +1,275 @@
+"""Contract tests: our responses must parse in the real zep-cloud SDK.
+
+These do not need a graph database, an LLM, or a network. They serialize the
+zep_compat response models exactly as FastAPI would and feed the JSON through
+zep-cloud's own `parse_obj_as`, which is the code path MiroFish executes.
+
+The point is to catch the aliasing trap: zep-cloud declares
+`uuid_: Annotated[str, FieldMetadata(alias='uuid')]`, so emitting `uuid_`
+instead of `uuid` fails client-side with a ValidationError that would otherwise
+only show up against real hardware.
+
+Run:  uv run --extra dev pytest tests/test_zep_compat_contract.py
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+zep_cloud = pytest.importorskip('zep_cloud', reason='zep-cloud is a dev-only dependency')
+from zep_cloud.core.pydantic_utilities import parse_obj_as  # noqa: E402
+
+from graph_service.zep_compat import models as m  # noqa: E402
+from graph_service.zep_compat.ontology import (  # noqa: E402
+    build_edge_types,
+    build_entity_types,
+    safe_field_name,
+)
+
+
+def roundtrip(model, zep_type):
+    """Serialize like FastAPI does, then parse like the SDK does."""
+    payload = json.loads(model.model_dump_json())
+    return parse_obj_as(zep_type, payload)
+
+
+def test_entity_node_roundtrip():
+    node = m.EntityNode(
+        uuid='n-1',
+        name='Alice',
+        summary='A person',
+        created_at=m.now_iso(),
+        labels=['Entity', 'Person'],
+        attributes={'role': 'journalist'},
+    )
+    parsed = roundtrip(node, zep_cloud.EntityNode)
+    assert parsed.uuid_ == 'n-1'
+    assert parsed.name == 'Alice'
+    assert parsed.labels == ['Entity', 'Person']
+    assert parsed.attributes == {'role': 'journalist'}
+
+
+def test_entity_edge_roundtrip_preserves_temporal_fields():
+    edge = m.EntityEdge(
+        uuid='e-1',
+        name='WORKS_FOR',
+        fact='Alice works for Acme',
+        source_node_uuid='n-1',
+        target_node_uuid='n-2',
+        created_at=m.now_iso(),
+        episodes=['ep-1'],
+        valid_at=m.now_iso(),
+        invalid_at=None,
+        expired_at=None,
+        attributes={'since': '2020'},
+    )
+    parsed = roundtrip(edge, zep_cloud.EntityEdge)
+    assert parsed.uuid_ == 'e-1'
+    assert parsed.source_node_uuid == 'n-1'
+    assert parsed.valid_at is not None
+    # MiroFish's zep_tools reads is_expired/is_invalid off these two.
+    assert parsed.expired_at is None
+    assert parsed.invalid_at is None
+
+
+def test_graph_roundtrip():
+    graph = m.Graph(
+        uuid='g-uuid', graph_id='g-1', name='n', description='d', created_at=m.now_iso()
+    )
+    parsed = roundtrip(graph, zep_cloud.Graph)
+    assert parsed.graph_id == 'g-1'
+    assert parsed.uuid_ == 'g-uuid'
+
+
+def test_episode_roundtrip():
+    episode = m.Episode(
+        uuid='ep-1',
+        content='hello',
+        created_at=m.now_iso(),
+        source='text',
+        source_description='chunk',
+        processed=True,
+    )
+    parsed = roundtrip(episode, zep_cloud.Episode)
+    assert parsed.uuid_ == 'ep-1'
+    assert parsed.source == 'text'
+    assert parsed.processed is True
+
+
+def test_batch_summary_roundtrip_exposes_polled_fields():
+    summary = m.BatchSummary(
+        batch_id='b-1',
+        status='processing',
+        item_count=10,
+        metadata={'mirofish_operation_id': 'op-1', 'graph_id': 'g-1'},
+        progress=m.BatchProgress(
+            total_items=10, succeeded_items=4, failed_items=0, percent_complete=40.0
+        ),
+        created_at=m.now_iso(),
+        updated_at=m.now_iso(),
+    )
+    parsed = roundtrip(summary, zep_cloud.BatchSummary)
+    assert parsed.batch_id == 'b-1'
+    assert parsed.status == 'processing'
+    # _wait_for_batch reads exactly these two off progress.
+    assert parsed.progress is not None
+    assert parsed.progress.percent_complete == 40.0
+    assert parsed.progress.succeeded_items == 4
+    # _find_batch_by_operation_id matches on these metadata keys.
+    assert parsed.metadata['mirofish_operation_id'] == 'op-1'
+
+
+def test_batch_item_detail_roundtrip_has_episode_uuid_and_index():
+    item = m.BatchItemDetail(
+        item_id='i-1',
+        batch_id='b-1',
+        status='pending',
+        sequence_index=0,
+        graph_id='g-1',
+        episode_uuid='ep-1',
+        created_at=m.now_iso(),
+    )
+    parsed = roundtrip(item, zep_cloud.BatchItemDetail)
+    # add_text_batches collects episode_uuid, and reconciliation asserts on
+    # sequence_index, so both must survive the wire.
+    assert parsed.episode_uuid == 'ep-1'
+    assert parsed.sequence_index == 0
+
+
+def test_batch_list_response_roundtrip():
+    payload = m.BatchListResponse(
+        batches=[m.BatchSummary(batch_id='b-1', status='draft')], next_cursor=7
+    )
+    parsed = roundtrip(payload, zep_cloud.types.batch_list_response.BatchListResponse)
+    assert parsed.batches is not None
+    assert parsed.batches[0].batch_id == 'b-1'
+    assert parsed.next_cursor == 7
+
+
+def test_batch_item_list_response_roundtrip():
+    payload = m.BatchItemListResponse(
+        items=[m.BatchItemDetail(item_id='i-1', sequence_index=3, status='succeeded')],
+        next_cursor=3,
+    )
+    parsed = roundtrip(payload, zep_cloud.BatchItemListResponse)
+    assert parsed.items is not None
+    assert parsed.items[0].sequence_index == 3
+    assert parsed.next_cursor == 3
+
+
+def test_graph_search_results_roundtrip():
+    results = m.GraphSearchResults(
+        nodes=[
+            m.EntityNode(uuid='n-1', name='A', summary='s', created_at=m.now_iso())
+        ],
+        edges=[
+            m.EntityEdge(
+                uuid='e-1',
+                name='R',
+                fact='f',
+                source_node_uuid='n-1',
+                target_node_uuid='n-2',
+                created_at=m.now_iso(),
+            )
+        ],
+        episodes=[m.Episode(uuid='ep-1', content='c', created_at=m.now_iso())],
+    )
+    parsed = roundtrip(results, zep_cloud.GraphSearchResults)
+    assert parsed.nodes and parsed.nodes[0].uuid_ == 'n-1'
+    assert parsed.edges and parsed.edges[0].uuid_ == 'e-1'
+    assert parsed.episodes and parsed.episodes[0].uuid_ == 'ep-1'
+
+
+def test_success_response_roundtrip():
+    parsed = roundtrip(m.SuccessResponse(message='done'), zep_cloud.SuccessResponse)
+    assert parsed.message == 'done'
+
+
+def test_emitted_json_uses_uuid_not_uuid_underscore():
+    """The trap, asserted directly."""
+    payload = json.loads(
+        m.EntityNode(
+            uuid='n-1', name='A', summary='s', created_at=m.now_iso()
+        ).model_dump_json()
+    )
+    assert 'uuid' in payload
+    assert 'uuid_' not in payload
+
+
+# ---------------------------------------------------------------------------
+# ontology translation
+# ---------------------------------------------------------------------------
+
+
+def test_ontology_request_parses_what_the_sdk_sends():
+    """Shape produced by zep_cloud's set_ontology -> PUT entity-types."""
+    body = {
+        'entity_types': [
+            {
+                'name': 'Journalist',
+                'description': 'A reporter',
+                'properties': [
+                    {'name': 'outlet', 'description': 'Employer', 'type': 'Text'},
+                    {'name': 'years_active', 'description': 'Tenure', 'type': 'Int'},
+                ],
+            }
+        ],
+        'edge_types': [
+            {
+                'name': 'REPORTS_ON',
+                'description': 'Covers a topic',
+                'properties': [],
+                'source_targets': [{'source': 'Journalist', 'target': 'Entity'}],
+            }
+        ],
+        'graph_ids': ['g-1'],
+        'user_ids': None,
+    }
+    request = m.SetEntityTypesRequest.model_validate(body)
+    entity_types = build_entity_types([t.model_dump() for t in request.entity_types])
+    edge_types, edge_map = build_edge_types([t.model_dump() for t in request.edge_types])
+
+    assert set(entity_types) == {'Journalist'}
+    fields = entity_types['Journalist'].model_fields
+    assert set(fields) == {'outlet', 'years_active'}
+    assert fields['years_active'].annotation == int | None
+    # The docstring is fed to Graphiti's extraction prompt as the definition.
+    assert entity_types['Journalist'].__doc__ == 'A reporter'
+
+    assert set(edge_types) == {'REPORTS_ON'}
+    assert edge_map == {('Journalist', 'Entity'): ['REPORTS_ON']}
+
+
+@pytest.mark.parametrize(
+    'reserved',
+    ['uuid', 'name', 'group_id', 'labels', 'created_at', 'summary', 'attributes',
+     'name_embedding'],
+)
+def test_reserved_attribute_names_are_renamed(reserved):
+    """Graphiti raises EntityTypeValidationError when a custom attribute shadows
+    an EntityNode field. MiroFish's own reserved list misses `labels` and
+    `attributes`, so the shim must defend itself."""
+    assert safe_field_name(reserved) == f'attr_{reserved}'
+
+
+def test_colliding_normalized_names_do_not_overwrite_each_other():
+    entity_types = build_entity_types(
+        [
+            {
+                'name': 'T',
+                'description': 'd',
+                'properties': [
+                    {'name': 'a-b', 'description': 'x', 'type': 'Text'},
+                    {'name': 'a b', 'description': 'y', 'type': 'Text'},
+                ],
+            }
+        ]
+    )
+    assert len(entity_types['T'].model_fields) == 2
+
+
+def test_entity_label_is_not_redefined():
+    """'Entity' is Graphiti's built-in default label."""
+    assert build_entity_types([{'name': 'Entity', 'description': 'd'}]) == {}

--- a/server/tests/test_zep_compat_e2e.py
+++ b/server/tests/test_zep_compat_e2e.py
@@ -1,0 +1,703 @@
+"""End-to-end: drive the shim with the REAL zep-cloud SDK over an ASGI transport.
+
+This is the test that actually proves the shim is a drop-in. It uses
+zep_cloud's own generated client — the same code MiroFish runs — so paths, HTTP
+methods, request bodies, response parsing, error mapping and the
+`zep-next-cursor` header are all exercised for real. No network, no graph
+database, no LLM: Graphiti's retrieval calls are stubbed with in-memory objects.
+
+MiroFish uses the sync `Zep` client; httpx can only drive an ASGI app
+asynchronously, so we use `AsyncZep`. Both are generated from one spec and share
+identical paths, payload shapes and response parsers.
+
+Run:  uv run --extra dev pytest tests/test_zep_compat_e2e.py
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+
+pytest.importorskip('zep_cloud', reason='zep-cloud is a dev-only dependency')
+pytest.importorskip('graphiti_core')
+
+from graphiti_core.edges import EntityEdge as GEntityEdge  # noqa: E402
+from graphiti_core.nodes import EntityNode as GEntityNode  # noqa: E402
+from graphiti_core.nodes import EpisodeType  # noqa: E402
+from graphiti_core.nodes import EpisodicNode as GEpisodicNode  # noqa: E402
+from zep_cloud import BatchAddItem, EntityEdgeSourceTarget, NotFoundError  # noqa: E402
+from zep_cloud.client import AsyncZep  # noqa: E402
+from zep_cloud.external_clients.ontology import EdgeModel, EntityModel, EntityText  # noqa: E402
+from pydantic import Field  # noqa: E402
+
+from graph_service.zep_compat import router as router_mod  # noqa: E402
+from graph_service.zep_compat.app import app  # noqa: E402
+from graph_service.zep_compat.runtime import (  # noqa: E402
+    BatchWorker,
+    GraphitiPool,
+    Runtime,
+)
+from graph_service.zep_compat.store import Store  # noqa: E402
+
+NOW = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# stubs
+# ---------------------------------------------------------------------------
+
+
+def make_node(uuid: str, name: str = 'N', group_id: str = 'g-1') -> GEntityNode:
+    return GEntityNode(
+        uuid=uuid,
+        name=name,
+        group_id=group_id,
+        labels=['Entity'],
+        created_at=NOW,
+        summary=f'summary of {name}',
+        attributes={'role': 'tester'},
+    )
+
+
+def make_edge(uuid: str, src: str = 'n-1', dst: str = 'n-2', group_id: str = 'g-1'):
+    return GEntityEdge(
+        uuid=uuid,
+        group_id=group_id,
+        source_node_uuid=src,
+        target_node_uuid=dst,
+        created_at=NOW,
+        name='WORKS_FOR',
+        fact=f'fact for {uuid}',
+        episodes=['ep-1'],
+        valid_at=NOW,
+        attributes={'since': '2020'},
+    )
+
+
+def make_episode(uuid: str, group_id: str = 'g-1') -> GEpisodicNode:
+    return GEpisodicNode(
+        uuid=uuid,
+        name='ep',
+        group_id=group_id,
+        labels=[],
+        created_at=NOW,
+        source=EpisodeType.text,
+        source_description='chunk',
+        content='hello world',
+        valid_at=NOW,
+        entity_edges=[],
+    )
+
+
+class StubGraphiti:
+    """Just enough Graphiti surface for the router, with recorded calls."""
+
+    def __init__(self):
+        self.driver = object()
+        self.added: list[dict] = []
+        self.cleared: list[list[str]] = []
+        self.saved_episodes: list = []
+        self.fail_payloads: set[str] = set()
+
+    async def add_episode(self, **kwargs):
+        if kwargs.get('episode_body') in self.fail_payloads:
+            raise RuntimeError('simulated extraction failure')
+        self.added.append(kwargs)
+        from graphiti_core.graphiti import AddEpisodeResults
+
+        return AddEpisodeResults(
+            episode=make_episode(kwargs.get('uuid') or 'ep-new', kwargs['group_id']),
+            episodic_edges=[],
+            nodes=[],
+            edges=[],
+            communities=[],
+            community_edges=[],
+        )
+
+    async def search_(self, **kwargs):
+        from graphiti_core.search.search_config import SearchResults
+
+        self.last_search = kwargs
+        return SearchResults(
+            nodes=[make_node('n-1', 'Alice')],
+            edges=[make_edge('e-1')],
+            episodes=[make_episode('ep-1')],
+        )
+
+    async def get_nodes_and_edges_by_episode(self, episode_uuids):
+        from graphiti_core.search.search_config import SearchResults
+
+        return SearchResults(nodes=[make_node('n-1')], edges=[make_edge('e-1')])
+
+    async def close(self):
+        pass
+
+
+@pytest.fixture
+def wired(tmp_path, monkeypatch):
+    """Mount the real app with a real Store and a stubbed Graphiti."""
+    store = Store(tmp_path / 'compat.sqlite3')
+    graphiti = StubGraphiti()
+    # One Graphiti per graph in production (group_id is the database name); the
+    # stub stands in for all of them here.
+    pool = GraphitiPool(factory=lambda graph_id: graphiti, build_indices=False)  # type: ignore[arg-type]
+    worker = BatchWorker(pool=pool, store=store, concurrency=2)
+
+    nodes = {'n-1': make_node('n-1', 'Alice'), 'n-2': make_node('n-2', 'Acme')}
+    episodes = {'ep-1': make_episode('ep-1')}
+
+    async def fake_node_get_by_uuid(driver, uuid):
+        from graphiti_core.errors import NodeNotFoundError
+
+        if uuid not in nodes:
+            raise NodeNotFoundError(uuid)
+        return nodes[uuid]
+
+    async def fake_episode_get_by_uuid(driver, uuid):
+        from graphiti_core.errors import NodeNotFoundError
+
+        if uuid not in episodes:
+            raise NodeNotFoundError(uuid)
+        return episodes[uuid]
+
+    # 250 nodes/edges so pagination is genuinely multi-page.
+    all_nodes = [make_node(f'n-{i:04d}', f'Node{i}') for i in range(250)]
+    all_edges = [make_edge(f'e-{i:04d}') for i in range(250)]
+
+    # The router pages with its own SKIP/LIMIT query (see paging.py) because
+    # graphiti_core's uuid_cursor is silently ignored on FalkorDB.
+    def offset_page(items, limit, offset):
+        window = items[offset : offset + limit]
+        has_more = len(items) > offset + limit
+        return window, (offset + limit if has_more else None)
+
+    async def fake_page_nodes(driver, group_id, limit, offset):
+        return offset_page(all_nodes, limit, offset)
+
+    async def fake_page_edges(driver, group_id, limit, offset):
+        return offset_page(all_edges, limit, offset)
+
+    async def fake_edges_by_node(driver, node_uuid):
+        return [make_edge('e-1', src=node_uuid), make_edge('e-2', dst=node_uuid)]
+
+    async def fake_clear_data(driver, group_ids=None):
+        graphiti.cleared.append(list(group_ids or []))
+
+    # The worker persists the EpisodicNode before calling add_episode, because
+    # graphiti's add_episode(uuid=...) loads an existing node rather than
+    # creating one. Record those saves instead of touching a database.
+    async def fake_episode_save(self, driver):
+        graphiti.saved_episodes.append(self)
+        episodes[self.uuid] = self
+
+    monkeypatch.setattr(router_mod.GEntityNode, 'get_by_uuid', fake_node_get_by_uuid)
+    monkeypatch.setattr(router_mod, 'page_nodes', fake_page_nodes)
+    monkeypatch.setattr(router_mod.GEpisodicNode, 'get_by_uuid', fake_episode_get_by_uuid)
+    monkeypatch.setattr(router_mod, 'page_edges', fake_page_edges)
+    monkeypatch.setattr(router_mod.GEntityEdge, 'get_by_node_uuid', fake_edges_by_node)
+    monkeypatch.setattr(router_mod, 'clear_data', fake_clear_data)
+    monkeypatch.setattr(GEpisodicNode, 'save', fake_episode_save)
+
+    # Node/episode UUIDs resolve to a graph through this index, which production
+    # populates whenever a UUID is handed out by a graph-scoped read.
+    store.create_graph('g-1', 'n', 'd', None)
+    store.remember_uuids('g-1', 'node', list(nodes))
+    store.remember_uuids('g-1', 'episode', list(episodes))
+
+    app.state.zep_runtime = Runtime(pool=pool, store=store, worker=worker)
+    try:
+        yield app.state.zep_runtime, graphiti, store
+    finally:
+        store.close()
+        app.state.zep_runtime = None
+
+
+@pytest.fixture
+async def client(wired):
+    """A real AsyncZep pointed at the in-process app, exactly as MiroFish
+    configures it: base_url ending in /api/v2."""
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url='http://shim') as http:
+        yield AsyncZep(api_key='local', base_url='http://shim/api/v2', httpx_client=http)
+
+
+pytestmark = pytest.mark.asyncio(loop_scope='function')
+
+
+# ---------------------------------------------------------------------------
+# graph lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_create_then_get_graph(client):
+    created = await client.graph.create(
+        graph_id='g-1', name='N', description='MiroFish Social Simulation Graph'
+    )
+    assert created.graph_id == 'g-1'
+    fetched = await client.graph.get('g-1')
+    assert fetched.graph_id == 'g-1'
+    assert fetched.uuid_
+
+
+async def test_get_unknown_graph_raises_not_found(client):
+    """MiroFish reconciles a lost create by calling graph.get and treating
+    NotFoundError as 'the create really did fail'."""
+    with pytest.raises(NotFoundError):
+        await client.graph.get('missing')
+
+
+async def test_delete_graph_clears_the_group(client, wired):
+    _, graphiti, _ = wired
+    await client.graph.create(graph_id='g-1', name='N', description='d')
+    await client.graph.delete(graph_id='g-1')
+    assert graphiti.cleared == [['g-1']]
+    with pytest.raises(NotFoundError):
+        await client.graph.get('g-1')
+
+
+async def test_delete_unknown_graph_raises_not_found(client):
+    """app/api/graph.py catches NotFoundError to keep teardown idempotent."""
+    with pytest.raises(NotFoundError):
+        await client.graph.delete(graph_id='missing')
+
+
+# ---------------------------------------------------------------------------
+# ontology
+# ---------------------------------------------------------------------------
+
+
+async def test_set_ontology_through_the_sdk_helper(client, wired):
+    """Exercises zep_cloud's EntityModel -> wire-schema conversion, the same
+    path graph_builder.set_ontology uses."""
+    _, _, store = wired
+
+    class Journalist(EntityModel):
+        """A reporter."""
+
+        outlet: EntityText = Field(description='Employer', default=None)
+
+    class ReportsOn(EdgeModel):
+        """Covers a topic."""
+
+        beat: EntityText = Field(description='Topic area', default=None)
+
+    await client.graph.set_ontology(
+        graph_ids=['g-1'],
+        entities={'Journalist': Journalist},
+        edges={
+            'REPORTS_ON': (
+                ReportsOn,
+                [EntityEdgeSourceTarget(source='Journalist', target='Entity')],
+            )
+        },
+    )
+
+    entity_specs, edge_specs = store.get_ontology('g-1')
+    assert [e['name'] for e in entity_specs] == ['Journalist']
+    assert entity_specs[0]['description'] == 'A reporter.'
+    assert [p['name'] for p in entity_specs[0]['properties']] == ['outlet']
+    assert edge_specs[0]['source_targets'] == [
+        {'source': 'Journalist', 'target': 'Entity'}
+    ]
+
+
+async def test_edge_only_ontology_is_accepted(client, wired):
+    """graph_builder passes entities={} for edge-only ontologies."""
+    _, _, store = wired
+
+    class Knows(EdgeModel):
+        """Knows someone."""
+
+    await client.graph.set_ontology(graph_ids=['g-1'], entities={}, edges={'KNOWS': Knows})
+    entity_specs, edge_specs = store.get_ontology('g-1')
+    assert entity_specs == []
+    assert [e['name'] for e in edge_specs] == ['KNOWS']
+
+
+# ---------------------------------------------------------------------------
+# single-episode ingest
+# ---------------------------------------------------------------------------
+
+
+async def test_graph_add_returns_an_episode_uuid(client, wired):
+    """zep_graph_memory_updater raises if graph.add returns no episode UUID."""
+    _, graphiti, _ = wired
+    await client.graph.create(graph_id='g-1', name='N', description='d')
+    episode = await client.graph.add(
+        graph_id='g-1',
+        type='text',
+        data='agent 7 posted something',
+        created_at='2024-01-01T00:00:00+00:00',
+        source_description='MiroFish simulation activity batch',
+        metadata={'source': 'mirofish_simulation', 'activity_count': 1},
+    )
+    assert episode.uuid_
+    assert graphiti.added[0]['group_id'] == 'g-1'
+    assert graphiti.added[0]['episode_body'] == 'agent 7 posted something'
+
+
+async def test_episode_get_reports_processed(client):
+    """The teardown drain polls episode.get until processed is True."""
+    episode = await client.graph.episode.get(uuid_='ep-1')
+    assert episode.processed is True
+    assert episode.content == 'hello world'
+
+
+async def test_episode_get_unknown_raises_a_404_api_error(client):
+    """Note the asymmetry: zep-cloud's graph.episode.get handles only 400 and
+    500, so a 404 arrives as a generic ApiError, NOT NotFoundError. MiroFish
+    treats a 404 ApiError as non-retryable and lets it propagate — which is why
+    a queued episode must report processed=false instead of 404."""
+    from zep_cloud.core.api_error import ApiError
+
+    with pytest.raises(ApiError) as excinfo:
+        await client.graph.episode.get(uuid_='nope')
+    assert excinfo.value.status_code == 404
+    assert not isinstance(excinfo.value, NotFoundError)
+
+
+async def test_queued_episode_reports_not_processed_instead_of_404(client, wired):
+    """batch.add hands out episode UUIDs before the episodes exist. Polling one
+    must not 404, or _wait_for_pending_episodes aborts the run."""
+    _, _, store = wired
+    batch_id = store.create_batch({'mirofish_operation_id': 'op-x'}, None)
+    created = store.add_items(
+        batch_id, [{'graph_id': 'g-1', 'payload': 'queued chunk', 'data_type': 'text'}]
+    )
+    episode_uuid = created[0]['episode_uuid']
+
+    episode = await client.graph.episode.get(uuid_=episode_uuid)
+    assert episode.uuid_ == episode_uuid
+    assert episode.processed is False
+    assert episode.content == 'queued chunk'
+
+
+async def test_failed_episode_surfaces_an_error_rather_than_polling_forever(
+    client, wired
+):
+    _, _, store = wired
+    batch_id = store.create_batch(None, None)
+    created = store.add_items(
+        batch_id, [{'graph_id': 'g-1', 'payload': 'doomed', 'data_type': 'text'}]
+    )
+    store.set_item_status(created[0]['item_id'], 'failed', {'message': 'llm exploded'})
+
+    from zep_cloud.core.api_error import ApiError
+
+    with pytest.raises(ApiError) as excinfo:
+        await client.graph.episode.get(uuid_=created[0]['episode_uuid'])
+    assert excinfo.value.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# reads
+# ---------------------------------------------------------------------------
+
+
+async def test_node_get_returns_the_fields_mirofish_reads(client):
+    node = await client.graph.node.get(uuid_='n-1')
+    assert node.uuid_ == 'n-1'
+    assert node.name == 'Alice'
+    assert node.labels == ['Entity']
+    assert node.summary == 'summary of Alice'
+    assert node.attributes == {'role': 'tester'}
+
+
+async def test_node_get_unknown_raises_not_found(client):
+    """This 404 is the only way 'entity not found' is expressed."""
+    with pytest.raises(NotFoundError):
+        await client.graph.node.get(uuid_='missing')
+
+
+async def test_node_get_edges_returns_a_bare_array(client):
+    edges = await client.graph.node.get_edges(node_uuid='n-1')
+    assert isinstance(edges, list)
+    assert {e.uuid_ for e in edges} == {'e-1', 'e-2'}
+    assert edges[0].fact
+    assert edges[0].source_node_uuid
+
+
+async def test_search_returns_nodes_and_edges(client):
+    results = await client.graph.search(
+        graph_id='g-1', query='what happened', limit=10, scope='edges',
+        reranker='cross_encoder',
+    )
+    assert results.edges and results.edges[0].fact == 'fact for e-1'
+    assert results.nodes and results.nodes[0].name == 'Alice'
+
+
+async def test_search_scope_nodes_and_rrf_reranker(client, wired):
+    _, graphiti, _ = wired
+    await client.graph.search(
+        graph_id='g-1', query='q', limit=20, scope='nodes', reranker='rrf'
+    )
+    assert graphiti.last_search['group_ids'] == ['g-1']
+    assert graphiti.last_search['config'].limit == 20
+
+
+async def test_search_limit_is_clamped_to_50(client, wired):
+    _, graphiti, _ = wired
+    await client.graph.search(graph_id='g-1', query='q', limit=5000, scope='edges')
+    assert graphiti.last_search['config'].limit == 50
+
+
+# ---------------------------------------------------------------------------
+# pagination via the zep-next-cursor response header
+# ---------------------------------------------------------------------------
+
+
+async def _drain_pages(api_call, graph_id):
+    """Mirror MiroFish's zep_paging._fetch_all loop, assertions included."""
+    items, cursor, seen = [], None, set()
+    while True:
+        kwargs = {'limit': 100}
+        if cursor is not None:
+            kwargs['cursor'] = cursor
+        response = await api_call(graph_id, **kwargs)
+        items.extend(response.data or [])
+        next_cursor = next(
+            (v for k, v in response.headers.items() if k.lower() == 'zep-next-cursor'),
+            None,
+        )
+        if next_cursor is None:
+            break
+        assert next_cursor != cursor, 'cursor must advance or MiroFish raises'
+        assert next_cursor not in seen
+        seen.add(next_cursor)
+        cursor = next_cursor
+    return items
+
+
+async def test_fetch_all_nodes_pagination(client):
+    nodes = await _drain_pages(
+        client.graph.node.with_raw_response.get_by_graph_id, 'g-1'
+    )
+    assert len(nodes) == 250
+    assert len({n.uuid_ for n in nodes}) == 250
+
+
+async def test_fetch_all_edges_pagination(client):
+    edges = await _drain_pages(
+        client.graph.edge.with_raw_response.get_by_graph_id, 'g-1'
+    )
+    assert len(edges) == 250
+    assert len({e.uuid_ for e in edges}) == 250
+
+
+# ---------------------------------------------------------------------------
+# the batch pipeline
+# ---------------------------------------------------------------------------
+
+
+TERMINAL = {'succeeded', 'partial', 'failed', 'invalid', 'canceled'}
+
+
+async def _await_terminal(client, batch_id, tries=200):
+    """Mirror MiroFish's _wait_for_batch poll, minus the 3s sleep."""
+    import asyncio
+
+    for _ in range(tries):
+        summary = await client.batch.get(batch_id=batch_id)
+        if summary.status in TERMINAL:
+            return summary
+        await asyncio.sleep(0.01)
+    raise AssertionError(f'batch {batch_id} never reached a terminal status')
+
+
+async def _run_batch(client, chunks, graph_id='g-1', per_call=None):
+    batch = await client.batch.create(
+        metadata={'mirofish_operation_id': 'op-1', 'graph_id': graph_id}
+    )
+    assert batch.status == 'draft'
+    per_call = per_call or len(chunks)
+    episode_uuids = []
+    for start in range(0, len(chunks), per_call):
+        details = await client.batch.add(
+            batch_id=batch.batch_id,
+            items=[
+                BatchAddItem(
+                    type='graph_episode',
+                    graph_id=graph_id,
+                    data=chunk,
+                    data_type='text',
+                    source_description='MiroFish source document chunk',
+                    metadata={'chunk_index': start + i},
+                )
+                for i, chunk in enumerate(chunks[start : start + per_call])
+            ],
+        )
+        episode_uuids.extend(d.episode_uuid for d in details)
+    await client.batch.process(batch_id=batch.batch_id)
+    return batch.batch_id, episode_uuids
+
+
+async def test_full_batch_lifecycle_reaches_succeeded(client, wired):
+    _, graphiti, _ = wired
+    batch_id, episode_uuids = await _run_batch(client, [f'chunk {i}' for i in range(5)])
+
+    assert all(episode_uuids) and len(set(episode_uuids)) == 5
+
+    summary = await _await_terminal(client, batch_id)
+    assert summary.status == 'succeeded'
+    assert summary.item_count == 5
+    assert summary.progress.succeeded_items == 5
+    assert summary.progress.percent_complete == 100.0
+
+    # The pre-assigned episode UUIDs are the ones actually ingested.
+    assert {kw['uuid'] for kw in graphiti.added} == set(episode_uuids)
+
+
+async def test_sequence_index_is_global_across_add_calls(client):
+    """add_text_batches asserts indexes == set(range(expected_count))."""
+    batch_id, _ = await _run_batch(
+        client, [f'chunk {i}' for i in range(7)], per_call=3
+    )
+    await _await_terminal(client, batch_id)
+    page = await client.batch.list_items(batch_id=batch_id, limit=100)
+    assert {i.sequence_index for i in page.items} == set(range(7))
+
+
+async def test_batch_item_pagination_cursor_advances(client):
+    batch_id, _ = await _run_batch(client, [f'chunk {i}' for i in range(150)])
+    items, cursor, seen = [], None, set()
+    while True:
+        page = await client.batch.list_items(
+            batch_id=batch_id, limit=100, cursor=cursor
+        )
+        items.extend(page.items or [])
+        if page.next_cursor is None:
+            break
+        assert page.next_cursor != cursor
+        assert page.next_cursor not in seen
+        seen.add(page.next_cursor)
+        cursor = page.next_cursor
+    assert len(items) == 150
+
+
+async def test_batch_can_be_found_by_operation_id(client):
+    """Mirrors _find_batch_by_operation_id after an ambiguous create."""
+    await _run_batch(client, ['a'])
+    matches, cursor = [], None
+    while True:
+        page = await client.batch.list(limit=100, cursor=cursor)
+        matches.extend(
+            b
+            for b in (page.batches or [])
+            if (b.metadata or {}).get('mirofish_operation_id') == 'op-1'
+            and (b.metadata or {}).get('graph_id') == 'g-1'
+        )
+        if page.next_cursor is None:
+            break
+        cursor = page.next_cursor
+    assert len(matches) == 1, 'MiroFish raises on more than one match'
+
+
+async def test_partial_batch_surfaces_the_failed_item_error(client, wired):
+    _, graphiti, _ = wired
+    graphiti.fail_payloads = {'chunk 1'}
+    batch_id, _ = await _run_batch(client, ['chunk 0', 'chunk 1', 'chunk 2'])
+
+    summary = await _await_terminal(client, batch_id)
+    assert summary.status == 'partial'
+
+    page = await client.batch.list_items(batch_id=batch_id, limit=100)
+    failed = [i for i in page.items if i.status not in {'succeeded', 'skipped'}]
+    assert len(failed) == 1
+    assert 'simulated extraction failure' in failed[0].error['message']
+
+
+async def test_all_items_failing_yields_failed_not_partial(client, wired):
+    _, graphiti, _ = wired
+    graphiti.fail_payloads = {'only'}
+    batch_id, _ = await _run_batch(client, ['only'])
+    summary = await _await_terminal(client, batch_id)
+    assert summary.status == 'failed'
+
+
+async def test_process_is_idempotent(client):
+    """A lost /process response makes MiroFish reconcile with a GET, but a
+    duplicate POST must not re-run the batch either."""
+    batch_id, _ = await _run_batch(client, ['a', 'b'])
+    again = await client.batch.process(batch_id=batch_id)
+    assert again.status != 'draft'
+
+
+async def test_batch_get_unknown_raises_not_found(client):
+    with pytest.raises(NotFoundError):
+        await client.batch.get(batch_id='missing')
+
+
+async def test_ontology_is_applied_to_batch_ingest(client, wired):
+    """The stored ontology must reach add_episode as Pydantic types."""
+    _, graphiti, store = wired
+    store.set_ontology(
+        'g-1',
+        [
+            {
+                'name': 'Journalist',
+                'description': 'A reporter',
+                'properties': [
+                    {'name': 'outlet', 'description': 'Employer', 'type': 'Text'}
+                ],
+            }
+        ],
+        [
+            {
+                'name': 'REPORTS_ON',
+                'description': 'Covers',
+                'properties': [],
+                'source_targets': [{'source': 'Journalist', 'target': 'Entity'}],
+            }
+        ],
+    )
+    batch_id, _ = await _run_batch(client, ['chunk'])
+    await _await_terminal(client, batch_id)
+    call = graphiti.added[0]
+    assert set(call['entity_types']) == {'Journalist'}
+    assert set(call['edge_types']) == {'REPORTS_ON'}
+    assert call['edge_type_map'] == {('Journalist', 'Entity'): ['REPORTS_ON']}
+
+
+# ---------------------------------------------------------------------------
+# empty-graph regression (found by smoke-testing against a real FalkorDB)
+# ---------------------------------------------------------------------------
+
+
+async def test_edge_listing_on_a_graph_with_no_edges_returns_empty(client, wired, monkeypatch):
+    """graphiti_core 0.29.3: EntityNode.get_by_group_ids returns [] when empty,
+    but EntityEdge.get_by_group_ids RAISES GroupsEdgesNotFoundError. A fresh
+    graph has no edges, so letting that escape 500s a completely normal read —
+    and MiroFish retries a 500 three times before failing the whole drain."""
+    from graphiti_core.errors import GroupsEdgesNotFoundError
+
+    async def raise_empty(driver, group_id, limit, offset):
+        raise GroupsEdgesNotFoundError([group_id])
+
+    monkeypatch.setattr(router_mod, 'page_edges', raise_empty)
+
+    response = await client.graph.edge.with_raw_response.get_by_graph_id('g-1', limit=100)
+    assert response.data == []
+    assert 'zep-next-cursor' not in {k.lower() for k in response.headers}
+
+
+async def test_node_listing_survives_an_empty_graph(client, wired, monkeypatch):
+    from graphiti_core.errors import GroupsNodesNotFoundError
+
+    async def raise_empty(driver, group_id, limit, offset):
+        raise GroupsNodesNotFoundError([group_id])
+
+    monkeypatch.setattr(router_mod, 'page_nodes', raise_empty)
+    response = await client.graph.node.with_raw_response.get_by_graph_id('g-1', limit=100)
+    assert response.data == []
+
+
+async def test_isolated_node_has_no_edges_without_erroring(client, wired, monkeypatch):
+    from graphiti_core.errors import EdgesNotFoundError
+
+    async def raise_empty(driver, node_uuid):
+        raise EdgesNotFoundError([node_uuid])
+
+    monkeypatch.setattr(router_mod.GEntityEdge, 'get_by_node_uuid', raise_empty)
+    assert await client.graph.node.get_edges(node_uuid='n-1') == []

--- a/server/tests/test_zep_compat_integration.py
+++ b/server/tests/test_zep_compat_integration.py
@@ -1,0 +1,261 @@
+"""Live integration: real FalkorDB + real Graphiti + the real zep-cloud SDK.
+
+The only thing stubbed is the LLM/embedder pair, so entity extraction returns
+nothing — that keeps the test deterministic and fast while still exercising every
+database query, index, driver call and HTTP route for real. This is the layer
+the pure-unit tests cannot cover, and it is where the raise-on-empty-edges bug
+was found.
+
+Opt in (a FalkorDB must be reachable):
+
+    docker run -d --name falkordb-it -p 6399:6379 falkordb/falkordb:latest
+    ZEP_COMPAT_IT=1 FALKORDB_IT_PORT=6399 \\
+      uv run --extra dev pytest tests/test_zep_compat_integration.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import uuid as uuid_lib
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+
+if not os.environ.get('ZEP_COMPAT_IT'):
+    pytest.skip('set ZEP_COMPAT_IT=1 to run live FalkorDB tests', allow_module_level=True)
+
+pytest.importorskip('zep_cloud')
+pytest.importorskip('falkordb', reason='pip install graphiti-core[falkordb]')
+
+from graphiti_core import Graphiti  # noqa: E402
+from graphiti_core.driver.falkordb_driver import FalkorDriver  # noqa: E402
+from graphiti_core.embedder.client import EmbedderClient  # noqa: E402
+from graphiti_core.llm_client.client import LLMClient  # noqa: E402
+from graphiti_core.llm_client.config import LLMConfig  # noqa: E402
+from zep_cloud import BatchAddItem  # noqa: E402
+from zep_cloud.client import AsyncZep  # noqa: E402
+
+from graph_service.zep_compat.app import app  # noqa: E402
+from graph_service.zep_compat.runtime import (  # noqa: E402
+    BatchWorker,
+    GraphitiPool,
+    PassthroughCrossEncoder,
+    Runtime,
+)
+from graph_service.zep_compat.store import Store  # noqa: E402
+
+EMBED_DIM = 1024
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio(loop_scope='function')]
+
+
+class DeterministicEmbedder(EmbedderClient):
+    async def create(self, input_data):
+        return [random.random() for _ in range(EMBED_DIM)]
+
+    async def create_batch(self, input_data_list):
+        return [[random.random() for _ in range(EMBED_DIM)] for _ in input_data_list]
+
+
+class EmptyExtractionLLM(LLMClient):
+    """Answers every structured request with a schema-shaped empty value."""
+
+    def __init__(self):
+        super().__init__(LLMConfig(api_key='local', model='stub'), cache=False)
+
+    async def _generate_response(
+        self, messages, response_model=None, max_tokens=4096, model_size=None
+    ):
+        if response_model is None:
+            return {}
+        out: dict = {}
+        for name, field in response_model.model_fields.items():
+            annotation = str(field.annotation).lower()
+            out[name] = [] if 'list' in annotation else None
+        return out
+
+
+@pytest.fixture
+async def live(tmp_path):
+    os.environ['EMBEDDING_DIM'] = str(EMBED_DIM)
+    os.environ.setdefault('GRAPHITI_TELEMETRY_ENABLED', 'false')
+
+    # graphiti 0.29.3 maps group_id onto the database name, so the pool builds
+    # one instance per graph with its driver pointed at a database named exactly
+    # graph_id. Do NOT prefix it: add_episode compares group_id to
+    # driver._database and clones away if they differ, which sends the ingest to
+    # a different database than the pre-saved episode. Tests get isolation from
+    # a unique graph_id instead.
+    def factory(graph_id: str) -> Graphiti:
+        instance = Graphiti(
+            graph_driver=FalkorDriver(
+                host=os.environ.get('FALKORDB_IT_HOST', '127.0.0.1'),
+                port=int(os.environ.get('FALKORDB_IT_PORT', '6399')),
+                database=graph_id,
+            ),
+            llm_client=EmptyExtractionLLM(),
+            embedder=DeterministicEmbedder(),
+            cross_encoder=PassthroughCrossEncoder(),
+            max_coroutines=2,
+        )
+        return instance
+
+    pool = GraphitiPool(factory=factory, build_indices=True)
+    store = Store(tmp_path / 'it.sqlite3')
+    worker = BatchWorker(pool=pool, store=store, concurrency=2)
+    app.state.zep_runtime = Runtime(pool=pool, store=store, worker=worker)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url='http://shim') as http:
+        client = AsyncZep(api_key='local', base_url='http://shim/api/v2', httpx_client=http)
+        try:
+            yield client, pool, store, f'it{uuid_lib.uuid4().hex[:8]}'
+        finally:
+            app.state.zep_runtime = None
+            store.close()
+            await pool.close()
+
+
+async def _await_terminal(client, batch_id, tries=600):
+    import asyncio
+
+    for _ in range(tries):
+        summary = await client.batch.get(batch_id=batch_id)
+        if summary.status in {'succeeded', 'partial', 'failed', 'invalid', 'canceled'}:
+            return summary
+        await asyncio.sleep(0.05)
+    raise AssertionError('batch never settled')
+
+
+async def test_fresh_graph_edge_listing_is_empty_not_an_error(live):
+    """The regression that motivated this file: a brand-new graph has zero
+    edges, and graphiti_core raises rather than returning []."""
+    client, _, _, gid = live
+    await client.graph.create(graph_id=gid, name='it', description='d')
+    response = await client.graph.edge.with_raw_response.get_by_graph_id(gid, limit=100)
+    assert response.data == []
+
+
+async def test_fresh_graph_node_listing_is_empty(live):
+    client, _, _, gid = live
+    await client.graph.create(graph_id=gid, name='it', description='d')
+    response = await client.graph.node.with_raw_response.get_by_graph_id(gid, limit=100)
+    assert response.data == []
+
+
+async def test_batch_ingest_persists_episodes_with_the_promised_uuids(live):
+    """The episode UUIDs handed out at batch.add time must be the UUIDs that
+    end up in the graph — MiroFish records them and polls them later."""
+    client, _, _, gid = live
+    await client.graph.create(graph_id=gid, name='it', description='d')
+
+    batch = await client.batch.create(metadata={'mirofish_operation_id': 'op-it'})
+    details = await client.batch.add(
+        batch_id=batch.batch_id,
+        items=[
+            BatchAddItem(
+                type='graph_episode',
+                graph_id=gid,
+                data=f'Document chunk number {i}.',
+                data_type='text',
+                source_description='MiroFish source document chunk',
+            )
+            for i in range(3)
+        ],
+    )
+    promised = [d.episode_uuid for d in details]
+    await client.batch.process(batch_id=batch.batch_id)
+
+    summary = await _await_terminal(client, batch.batch_id)
+    assert summary.status == 'succeeded', summary.progress
+
+    for episode_uuid in promised:
+        episode = await client.graph.episode.get(uuid_=episode_uuid)
+        assert episode.uuid_ == episode_uuid
+        assert episode.processed is True
+        assert episode.content.startswith('Document chunk number')
+
+
+async def test_queued_episode_is_not_processed_yet(live):
+    """Before /process runs, a promised UUID must answer processed=false rather
+    than 404 — a 404 here is a non-retryable ApiError inside MiroFish."""
+    client, _, _, gid = live
+    await client.graph.create(graph_id=gid, name='it', description='d')
+    batch = await client.batch.create(metadata=None)
+    details = await client.batch.add(
+        batch_id=batch.batch_id,
+        items=[BatchAddItem(type='graph_episode', graph_id=gid, data='x', data_type='text')],
+    )
+    episode = await client.graph.episode.get(uuid_=details[0].episode_uuid)
+    assert episode.processed is False
+
+
+async def test_search_runs_against_the_real_index(live):
+    """Extraction is stubbed so there is nothing to find; what matters is that
+    the hybrid search executes against real indexes without erroring."""
+    client, _, _, gid = live
+    await client.graph.create(graph_id=gid, name='it', description='d')
+    results = await client.graph.search(
+        graph_id=gid, query='anything', limit=10, scope='edges', reranker='rrf'
+    )
+    assert results.edges in (None, [])
+    assert results.nodes in (None, [])
+
+
+async def test_graph_delete_clears_the_group_and_then_404s(live):
+    client, pool, _, gid = live
+    await client.graph.create(graph_id=gid, name='it', description='d')
+    await client.graph.add(
+        graph_id=gid,
+        type='text',
+        data='Something happened.',
+        created_at=datetime.now(timezone.utc).isoformat(),
+        source_description='MiroFish simulation activity batch',
+    )
+    await client.graph.delete(graph_id=gid)
+
+    from zep_cloud import NotFoundError
+
+    with pytest.raises(NotFoundError):
+        await client.graph.get(gid)
+
+
+async def test_pagination_over_a_real_multi_page_node_set(live):
+    """Drive the zep-next-cursor loop exactly as MiroFish's zep_paging does,
+    against real rows and the driver's own uuid cursor."""
+    client, pool, _, gid = live
+    from graphiti_core.nodes import EntityNode
+
+    await client.graph.create(graph_id=gid, name='it', description='d')
+    graphiti = await pool.get(gid)
+    for i in range(120):
+        node = EntityNode(
+            uuid=str(uuid_lib.uuid4()),
+            name=f'Entity{i}',
+            group_id=gid,
+            labels=['Entity'],
+            created_at=datetime.now(timezone.utc),
+            summary=f'entity {i}',
+        )
+        await node.generate_name_embedding(graphiti.embedder)
+        await node.save(graphiti.driver)
+
+    seen, cursor, cursors = [], None, set()
+    while True:
+        kwargs = {'limit': 50}
+        if cursor is not None:
+            kwargs['cursor'] = cursor
+        response = await client.graph.node.with_raw_response.get_by_graph_id(gid, **kwargs)
+        seen.extend(response.data or [])
+        next_cursor = next(
+            (v for k, v in response.headers.items() if k.lower() == 'zep-next-cursor'), None
+        )
+        if next_cursor is None:
+            break
+        assert next_cursor != cursor and next_cursor not in cursors
+        cursors.add(next_cursor)
+        cursor = next_cursor
+
+    assert len(seen) == 120
+    assert len({n.uuid_ for n in seen}) == 120

--- a/server/tests/test_zep_compat_runtime_build.py
+++ b/server/tests/test_zep_compat_runtime_build.py
@@ -1,0 +1,50 @@
+"""Guards on how `build_graphiti` wires graphiti_core.
+
+The zep_compat layer is written against the graphiti-core fork that lives one
+directory up, not against the registry release. When the shim's dependency
+resolved to PyPI graphiti-core instead, nothing failed at import or at startup:
+`build_graphiti` is called lazily, the first time a graph is opened, so the
+mismatch only surfaced as every episode in an ingest batch dying with
+
+    OpenAIGenericClient.__init__() got an unexpected keyword argument
+    'structured_output_mode'
+
+These tests construct the real clients (no network: the OpenAI client and the
+FalkorDB redis client both connect lazily) so that a wrong graphiti-core is
+caught by `make test`, before a build ever runs.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import graphiti_core
+from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
+
+from graph_service.zep_compat.runtime import build_graphiti
+
+FORK_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_graphiti_core_is_the_sibling_fork():
+    resolved = Path(graphiti_core.__file__).resolve()
+    assert resolved.is_relative_to(FORK_ROOT), (
+        f'graphiti_core resolved to {resolved}, not the fork at {FORK_ROOT}. '
+        'Check [tool.uv.sources] in server/pyproject.toml and re-run `uv sync`.'
+    )
+
+
+def test_openai_generic_client_accepts_structured_output_mode():
+    assert 'structured_output_mode' in inspect.signature(OpenAIGenericClient.__init__).parameters
+
+
+def test_build_graphiti_constructs_with_structured_output(monkeypatch):
+    monkeypatch.setenv('GRAPHITI_DB_BACKEND', 'falkordb')
+    monkeypatch.setenv('GRAPHITI_RERANKER', 'none')
+    monkeypatch.delenv('GRAPHITI_STRUCTURED_OUTPUT_MODE', raising=False)
+
+    client = build_graphiti('build_graphiti_regression').llm_client
+
+    assert isinstance(client, OpenAIGenericClient)
+    assert client.structured_output_mode == 'json_schema'

--- a/server/tests/test_zep_compat_store.py
+++ b/server/tests/test_zep_compat_store.py
@@ -1,0 +1,270 @@
+"""Store tests for the invariants MiroFish's reconciliation logic depends on.
+
+No graph database, no LLM, no network — SQLite only.
+
+Run:  uv run --extra dev pytest tests/test_zep_compat_store.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graph_service.zep_compat.store import Store
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = Store(tmp_path / 'compat.sqlite3')
+    yield s
+    s.close()
+
+
+def _items(count, graph_id='g-1', start=0):
+    return [
+        {'graph_id': graph_id, 'payload': f'chunk-{i}', 'data_type': 'text'}
+        for i in range(start, start + count)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# graphs
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_graph_is_none_so_the_route_can_404(store):
+    assert store.get_graph('nope') is None
+
+
+def test_create_graph_is_idempotent(store):
+    first = store.create_graph('g-1', 'n', 'd', 'UTC')
+    second = store.create_graph('g-1', 'other', 'other', 'UTC')
+    # Same identity on repeat create; MiroFish may retry after a lost response.
+    assert first['uuid'] == second['uuid']
+    assert second['name'] == 'n'
+
+
+def test_delete_graph_removes_ontology_too(store):
+    store.create_graph('g-1', None, None, None)
+    store.set_ontology('g-1', [{'name': 'T', 'description': 'd'}], [])
+    store.delete_graph('g-1')
+    assert store.get_graph('g-1') is None
+    assert store.get_ontology('g-1') == ([], [])
+
+
+def test_ontology_upsert_replaces(store):
+    store.set_ontology('g-1', [{'name': 'A', 'description': 'd'}], [])
+    store.set_ontology('g-1', [{'name': 'B', 'description': 'd'}], [])
+    entities, edges = store.get_ontology('g-1')
+    assert [e['name'] for e in entities] == ['B']
+    assert edges == []
+
+
+# ---------------------------------------------------------------------------
+# batch item indexing — the reconciliation contract
+# ---------------------------------------------------------------------------
+
+
+def test_sequence_index_is_global_across_multiple_add_calls(store):
+    """add_text_batches asserts recovered indexes == set(range(expected)).
+
+    So indexes must be global across the whole batch, not per-request.
+    """
+    batch_id = store.create_batch({'mirofish_operation_id': 'op-1'}, None)
+    first = store.add_items(batch_id, _items(3))
+    second = store.add_items(batch_id, _items(2, start=3))
+
+    assert [i['sequence_index'] for i in first] == [0, 1, 2]
+    assert [i['sequence_index'] for i in second] == [3, 4]
+
+    all_items, _ = store.list_items(batch_id, limit=100, cursor=None)
+    assert {i['sequence_index'] for i in all_items} == set(range(5))
+
+
+def test_episode_uuid_assigned_at_add_time_and_is_unique(store):
+    """MiroFish reads episode_uuid off the *add* response, before processing."""
+    batch_id = store.create_batch(None, None)
+    created = store.add_items(batch_id, _items(4))
+    uuids = [i['episode_uuid'] for i in created]
+    assert all(uuids)
+    assert len(set(uuids)) == 4
+
+
+def test_episode_uuid_is_stable_between_add_and_list(store):
+    batch_id = store.create_batch(None, None)
+    created = store.add_items(batch_id, _items(2))
+    listed, _ = store.list_items(batch_id, limit=100, cursor=None)
+    assert [i['episode_uuid'] for i in created] == [i['episode_uuid'] for i in listed]
+
+
+# ---------------------------------------------------------------------------
+# pagination — MiroFish raises if a cursor fails to advance
+# ---------------------------------------------------------------------------
+
+
+def test_item_cursor_advances_and_terminates(store):
+    batch_id = store.create_batch(None, None)
+    store.add_items(batch_id, _items(250))
+
+    seen, cursor, seen_cursors = [], None, set()
+    while True:
+        page, next_cursor = store.list_items(batch_id, limit=100, cursor=cursor)
+        seen.extend(page)
+        if next_cursor is None:
+            break
+        assert next_cursor != cursor, 'cursor must advance or MiroFish raises'
+        assert next_cursor not in seen_cursors
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+
+    assert len(seen) == 250
+    assert {i['sequence_index'] for i in seen} == set(range(250))
+
+
+def test_item_last_page_returns_no_cursor(store):
+    batch_id = store.create_batch(None, None)
+    store.add_items(batch_id, _items(5))
+    page, next_cursor = store.list_items(batch_id, limit=100, cursor=None)
+    assert len(page) == 5
+    assert next_cursor is None
+
+
+def test_exact_page_boundary_does_not_emit_a_dangling_cursor(store):
+    """A cursor on an exactly-full final page would make MiroFish fetch an
+    empty page; harmless but it must still terminate."""
+    batch_id = store.create_batch(None, None)
+    store.add_items(batch_id, _items(100))
+    page, next_cursor = store.list_items(batch_id, limit=100, cursor=None)
+    assert len(page) == 100
+    assert next_cursor is None
+
+
+def test_batch_list_cursor_advances_and_finds_by_metadata(store):
+    """_find_batch_by_operation_id pages batch.list matching metadata."""
+    target = None
+    for i in range(150):
+        meta = {'mirofish_operation_id': f'op-{i}', 'graph_id': 'g-1'}
+        batch_id = store.create_batch(meta, None)
+        if i == 120:
+            target = batch_id
+
+    matches, cursor, seen_cursors = [], None, set()
+    while True:
+        page, next_cursor = store.list_batches(limit=100, cursor=cursor, status=None)
+        matches.extend(
+            b
+            for b in page
+            if (b['metadata'] or {}).get('mirofish_operation_id') == 'op-120'
+            and (b['metadata'] or {}).get('graph_id') == 'g-1'
+        )
+        if next_cursor is None:
+            break
+        assert next_cursor != cursor
+        assert next_cursor not in seen_cursors
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+
+    # Exactly one match, or MiroFish raises "refusing ambiguity".
+    assert len(matches) == 1
+    assert matches[0]['batch_id'] == target
+
+
+def test_batch_list_status_filter(store):
+    a = store.create_batch({'k': 'a'}, None)
+    store.create_batch({'k': 'b'}, None)
+    store.set_batch_status(a, 'succeeded', completed=True)
+    page, _ = store.list_batches(limit=100, cursor=None, status='succeeded')
+    assert [b['batch_id'] for b in page] == [a]
+
+
+# ---------------------------------------------------------------------------
+# status lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_new_batch_is_draft(store):
+    """_wait_for_batch's reconciliation treats None/draft as 'not processed'."""
+    batch_id = store.create_batch(None, None)
+    assert store.get_batch(batch_id)['status'] == 'draft'
+
+
+def test_counts_track_item_transitions(store):
+    batch_id = store.create_batch(None, None)
+    created = store.add_items(batch_id, _items(4))
+    assert store.item_counts(batch_id) == {'pending': 4, 'total': 4}
+
+    store.mark_items_queued(batch_id)
+    assert store.item_counts(batch_id)['queued'] == 4
+
+    store.set_item_status(created[0]['item_id'], 'succeeded')
+    store.set_item_status(created[1]['item_id'], 'failed', {'message': 'boom'})
+    counts = store.item_counts(batch_id)
+    assert counts['succeeded'] == 1
+    assert counts['failed'] == 1
+    assert counts['total'] == 4
+
+
+def test_failed_item_error_survives_listing(store):
+    """_wait_for_batch surfaces the first failed item's error."""
+    batch_id = store.create_batch(None, None)
+    created = store.add_items(batch_id, _items(1))
+    store.set_item_status(created[0]['item_id'], 'failed', {'message': 'llm timeout'})
+    items, _ = store.list_items(batch_id, limit=10, cursor=None)
+    assert items[0]['error'] == {'message': 'llm timeout'}
+
+
+def test_pending_items_excludes_settled_work(store):
+    batch_id = store.create_batch(None, None)
+    created = store.add_items(batch_id, _items(3))
+    store.set_item_status(created[0]['item_id'], 'succeeded')
+    store.set_item_status(created[1]['item_id'], 'skipped')
+    pending = store.pending_items(batch_id)
+    assert [i['item_id'] for i in pending] == [created[2]['item_id']]
+
+
+def test_failed_items_are_retried_on_resume(store):
+    """A crash mid-batch must not silently drop failed items."""
+    batch_id = store.create_batch(None, None)
+    created = store.add_items(batch_id, _items(2))
+    store.set_item_status(created[0]['item_id'], 'failed', {'message': 'x'})
+    assert {i['item_id'] for i in store.pending_items(batch_id)} == {
+        created[0]['item_id'],
+        created[1]['item_id'],
+    }
+
+
+def test_claim_draft_batches_finds_only_in_flight_work(store):
+    draft = store.create_batch(None, None)
+    queued = store.create_batch(None, None)
+    processing = store.create_batch(None, None)
+    done = store.create_batch(None, None)
+    store.set_batch_status(queued, 'queued', processed=True)
+    store.set_batch_status(processing, 'processing')
+    store.set_batch_status(done, 'succeeded', completed=True)
+
+    claimed = set(store.claim_draft_batches())
+    assert claimed == {queued, processing}
+    # A draft was never handed to /process, so resuming it would be wrong.
+    assert draft not in claimed
+
+
+def test_state_survives_reopen(tmp_path):
+    """Restart durability: MiroFish reconciles a batch after a lost response."""
+    path = tmp_path / 'compat.sqlite3'
+    first = Store(path)
+    batch_id = first.create_batch({'mirofish_operation_id': 'op-1'}, None)
+    created = first.add_items(batch_id, _items(2))
+    first.set_batch_status(batch_id, 'processing')
+    first.close()
+
+    second = Store(path)
+    try:
+        record = second.get_batch(batch_id)
+        assert record is not None
+        assert record['status'] == 'processing'
+        assert record['metadata']['mirofish_operation_id'] == 'op-1'
+        items, _ = second.list_items(batch_id, limit=10, cursor=None)
+        assert [i['episode_uuid'] for i in items] == [
+            i['episode_uuid'] for i in created
+        ]
+    finally:
+        second.close()

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -277,14 +277,15 @@ dev = [
     { name = "pytest-xdist" },
     { name = "python-dotenv" },
     { name = "ruff" },
+    { name = "zep-cloud" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastapi-cli", marker = "extra == 'dev'", specifier = ">=0.0.5" },
-    { name = "graphiti-core", specifier = ">=0.28.2" },
-    { name = "graphiti-core", extras = ["falkordb"], marker = "extra == 'dev'", specifier = ">=0.28.2" },
+    { name = "graphiti-core", editable = "../" },
+    { name = "graphiti-core", extras = ["falkordb"], marker = "extra == 'dev'", editable = "../" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", marker = "extra == 'dev'", specifier = ">=2.8.2" },
     { name = "pydantic-settings", specifier = ">=2.4.0" },
@@ -295,13 +296,14 @@ requires-dist = [
     { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.2.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.2" },
     { name = "uvicorn", specifier = ">=0.44.0" },
+    { name = "zep-cloud", marker = "extra == 'dev'", specifier = "==3.25.0" },
 ]
 provides-extras = ["dev"]
 
 [[package]]
 name = "graphiti-core"
-version = "0.28.2"
-source = { registry = "https://pypi.org/simple" }
+version = "0.29.3"
+source = { editable = "../" }
 dependencies = [
     { name = "neo4j" },
     { name = "numpy" },
@@ -311,15 +313,63 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/6d/81b78aec2030bff0030bbabb8b227a6fa3c5fb49fb11e8501e7d0f39f3fe/graphiti_core-0.28.2.tar.gz", hash = "sha256:9b2a72f117827e015a21b610eb2c3acbe05310b79736abef7372e81247578e9d", size = 6846195, upload-time = "2026-03-11T16:20:02.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/cd/e6203f1fee0a8e2a797f2d5f9a867513e0c63af4e19fdd1c5a7e14a47670/graphiti_core-0.28.2-py3-none-any.whl", hash = "sha256:4e1c19b7bc70a73a612a473144ed4b3fe615ac6d4c5d6b10f48e206a858bcb53", size = 314919, upload-time = "2026-03-11T16:20:01.037Z" },
-]
 
 [package.optional-dependencies]
 falkordb = [
     { name = "falkordb" },
 ]
+
+[package.metadata]
+requires-dist = [
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.49.0" },
+    { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.49.0" },
+    { name = "boto3", marker = "extra == 'dev'", specifier = ">=1.39.16" },
+    { name = "boto3", marker = "extra == 'neo4j-opensearch'", specifier = ">=1.39.16" },
+    { name = "boto3", marker = "extra == 'neptune'", specifier = ">=1.39.16" },
+    { name = "falkordb", marker = "extra == 'dev'", specifier = ">=1.1.2,<2.0.0" },
+    { name = "falkordb", marker = "extra == 'falkordb'", specifier = ">=1.1.2,<2.0.0" },
+    { name = "falkordblite", marker = "python_full_version >= '3.12' and extra == 'falkordblite'", specifier = ">=0.5.0" },
+    { name = "gliner2", marker = "python_full_version >= '3.11' and extra == 'gliner2'", specifier = ">=1.2.0" },
+    { name = "google-genai", marker = "extra == 'dev'", specifier = ">=1.8.0" },
+    { name = "google-genai", marker = "extra == 'google-genai'", specifier = ">=1.62.0" },
+    { name = "groq", marker = "extra == 'dev'", specifier = ">=0.2.0" },
+    { name = "groq", marker = "extra == 'groq'", specifier = ">=0.2.0" },
+    { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.29.5" },
+    { name = "jupyterlab", marker = "extra == 'dev'", specifier = ">=4.2.4" },
+    { name = "kuzu", marker = "extra == 'dev'", specifier = ">=0.11.3" },
+    { name = "kuzu", marker = "extra == 'kuzu'", specifier = ">=0.11.3" },
+    { name = "langchain-anthropic", marker = "extra == 'dev'", specifier = ">=0.2.4" },
+    { name = "langchain-aws", marker = "extra == 'dev'", specifier = ">=0.2.29" },
+    { name = "langchain-aws", marker = "extra == 'neptune'", specifier = ">=0.2.29" },
+    { name = "langchain-openai", marker = "extra == 'dev'", specifier = ">=0.2.6" },
+    { name = "langgraph", marker = "extra == 'dev'", specifier = ">=1.0.10" },
+    { name = "langsmith", marker = "extra == 'dev'", specifier = ">=0.1.108" },
+    { name = "neo4j", specifier = ">=5.26.0" },
+    { name = "numpy", specifier = ">=1.0.0" },
+    { name = "openai", specifier = ">=1.91.0" },
+    { name = "opensearch-py", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "opensearch-py", marker = "extra == 'neo4j-opensearch'", specifier = ">=3.0.0" },
+    { name = "opensearch-py", marker = "extra == 'neptune'", specifier = ">=3.0.0" },
+    { name = "opentelemetry-api", marker = "extra == 'tracing'", specifier = ">=1.20.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'dev'", specifier = ">=1.20.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'tracing'", specifier = ">=1.20.0" },
+    { name = "posthog", specifier = ">=3.0.0" },
+    { name = "pydantic", specifier = ">=2.11.5" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.404" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.1" },
+    { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "redis", marker = "python_full_version >= '3.12' and extra == 'falkordblite'", specifier = "<9" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.1" },
+    { name = "sentence-transformers", marker = "extra == 'dev'", specifier = ">=3.2.1" },
+    { name = "sentence-transformers", marker = "extra == 'sentence-transformers'", specifier = ">=3.2.1" },
+    { name = "tenacity", specifier = ">=9.0.0" },
+    { name = "transformers", marker = "extra == 'dev'", specifier = ">=4.45.2" },
+    { name = "voyageai", marker = "extra == 'dev'", specifier = ">=0.2.3" },
+    { name = "voyageai", marker = "extra == 'voyageai'", specifier = ">=0.2.3" },
+]
+provides-extras = ["anthropic", "groq", "google-genai", "kuzu", "falkordb", "falkordblite", "voyageai", "gliner2", "neo4j-opensearch", "sentence-transformers", "neptune", "tracing", "dev"]
 
 [[package]]
 name = "h11"
@@ -1338,4 +1388,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
     { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "zep-cloud"
+version = "3.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0d/7a866e1e1e5f0f1353eedf3d0e17df9b3cf362c494bccd41eb121b49c43f/zep_cloud-3.25.0.tar.gz", hash = "sha256:a77867e02c2a9036a20623e85d03415e237e76510b6e05ff2e9ab2cdced0aeb9", size = 94772, upload-time = "2026-07-16T00:46:43.918Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/fc/5ca2bdd20b83bd62bc2708580f756e704f69704709e0ed43e735aa590c1e/zep_cloud-3.25.0-py3-none-any.whl", hash = "sha256:94d9599038b154af9ad33cab4b4873ed9adb1bcaa48fc4c41cbd407c1a657ef5", size = 166438, upload-time = "2026-07-16T00:46:42.39Z" },
 ]


### PR DESCRIPTION
Adds graph_service/zep_compat, a drop-in replacement for the subset of the Zep Cloud API that MiroFish calls, so MiroFish can run with no hosted service. Zep Community Edition is discontinued and no self-hostable Zep server exists, so this is implemented directly on graphiti_core.

The contract was derived mechanically from the zep-cloud==3.25.0 wheel rather than from docs; WIRE_SPEC.md records it. 17 endpoints: graph create/get/delete/add/search, entity-types, node get/edges/listing, edge listing, episode get/mentions, and the six batches endpoints.

Four behaviours worth calling out, each covered by a test:

- The wire key is `uuid`, not `uuid_`. Fern declares `uuid_: Annotated[str, FieldMetadata(alias="uuid")]`, so emitting the Python name fails client-side. models.py uses wire names directly.

- graphiti_core 0.29.3 maps group_id onto the DATABASE name, and add_episode mutates self.driver to clone into it. Two concurrent add_episode calls for different graphs on one instance would write to the wrong database, so GraphitiPool keeps one instance per graph with its driver already pointed at a database named exactly graph_id. The pool asserts that invariant. Node/episode UUIDs are then only resolvable inside their own graph, hence the UUID->graph index.

- add_episode(uuid=...) means "process this existing episode", not "create with this UUID" — it calls EpisodicNode.get_by_uuid. But Zep's batch API promises the client an episode UUID at batch.add time, so ingest_episode persists the node first and keeps one UUID end to end.

- EntityNode.get_by_group_ids returns [] when empty but EntityEdge.get_by_group_ids raises. A fresh graph has no edges, so an unguarded read 500s on a normal state, which MiroFish retries three times before failing the whole drain.

Also works around an upstream bug: on FalkorDB the `WHERE n.uuid < $uuid` paging clause is silently not applied (verified against a live FalkorDB, where even a literal comparison returns every row, while ORDER BY and SKIP/LIMIT are exact). paging.py pages by offset instead.

Configured throughout for local inference: an OpenAI-compatible LLM and embeddings endpoint, FalkorDB or Neo4j, no reranker that phones home (Graphiti's OpenAI reranker scores with hard-coded OpenAI tokenizer IDs, which are meaningless to a Qwen or Llama tokenizer), and telemetry off.

Tests: 72 unit (no GPU, network or database) plus 7 opt-in live tests against a real FalkorDB. The e2e suite drives the shim with a real AsyncZep client over an ASGI transport, so paths, payloads, error mapping and the header-based pagination cursor are exercised against the same SDK MiroFish runs.

## Summary
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
**For new features and performance improvements:** Clearly describe the objective and rationale for this change.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

## Breaking Changes
- [ ] This PR contains breaking changes

If this is a breaking change, describe:
- What functionality is affected
- Migration path for existing users

## Checklist
- [ ] Code follows project style guidelines (`make lint` passes)
- [ ] Self-review completed
- [ ] Documentation updated where necessary
- [ ] No secrets or sensitive information committed

## Related Issues
Closes #[issue number]