### PR TITLE
Bump graphiti-core to 0.30.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "graphiti-core"
 description = "A temporal graph building library"
-version = "0.29.3"
+version = "0.29.4"
 authors = [
     { name = "Paul Paliychuk", email = "paul@getzep.com" },
     { name = "Preston Rasmussen", email = "preston@getzep.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "graphiti-core"
 description = "A temporal graph building library"
-version = "0.29.4"
+version = "0.30.0"
 authors = [
     { name = "Paul Paliychuk", email = "paul@getzep.com" },
     { name = "Preston Rasmussen", email = "preston@getzep.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1097,7 +1097,7 @@ wheels = [
 
 [[package]]
 name = "graphiti-core"
-version = "0.29.3"
+version = "0.29.4"
 source = { editable = "." }
 dependencies = [
     { name = "neo4j" },

--- a/uv.lock
+++ b/uv.lock
@@ -1097,7 +1097,7 @@ wheels = [
 
 [[package]]
 name = "graphiti-core"
-version = "0.29.4"
+version = "0.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "neo4j" },


### PR DESCRIPTION
## Summary
- Bump `graphiti-core` from `0.29.3` to `0.30.0` so the changes on `main` since `v0.29.3` ship as a minor release.
- Notable core changes in this window: preserve prior node attributes when no entity type applies, balanced-merge edge cross-encoder shortlist (#1754), and `source_node_uuid` / `target_node_uuid` / `episodes` on `FactResult` (#1750).

## Test plan
- [ ] Confirm `pyproject.toml` and `uv.lock` both report `0.30.0`
- [ ] After merge, tag `v0.30.0` to trigger the PyPI release workflow
- [ ] After PyPI publish, bump server/MCP `graphiti-core` requirements separately