### PR TITLE
fix(ci): bump gh-action-pypi-publish for metadata 2.5

### DIFF
--- a/.github/workflows/release-graphiti-core.yml
+++ b/.github/workflows/release-graphiti-core.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Build project for distribution
         run: uv build
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
## Summary
- The `v0.30.0` PyPI release failed at publish with `InvalidDistribution: '2.5' is not a valid metadata version` ([run](https://github.com/getzep/graphiti/actions/runs/33543087248/job/99973890142)).
- Hatchling 1.32 now emits core metadata 2.5; the workflow was still pinned to `gh-action-pypi-publish` v1.13.0 (Twine 6), which rejects that version before upload.
- Bump the pin to v1.14.2 (`dc37677`), which ships Twine 7 / packaging 26.2 and accepts metadata 2.5.

## Test plan
- [ ] After merge, re-run the failed `Release to PyPI` workflow for tag `v0.30.0` (the package was never uploaded)
- [ ] Confirm `graphiti-core==0.30.0` appears on PyPI


Made with [Cursor](https://cursor.com)