### PR TITLE
Bump graphiti-core to 0.30.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "graphiti-core"
 description = "A temporal graph building library"
-version = "0.30.0"
+version = "0.30.1"
 authors = [
     { name = "Paul Paliychuk", email = "paul@getzep.com" },
     { name = "Preston Rasmussen", email = "preston@getzep.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1097,7 +1097,7 @@ wheels = [
 
 [[package]]
 name = "graphiti-core"
-version = "0.30.0"
+version = "0.30.1"
 source = { editable = "." }
 dependencies = [
     { name = "neo4j" },


### PR DESCRIPTION
## Summary
- `v0.30.0` never made it to PyPI: hatchling now emits metadata 2.5, and the tagged workflow still had the old publish action.
- The action bump is on `main` (#1821), but `v0.30.0` is a protected tag and cannot be moved onto that commit.
- Bump to `0.30.1` so we can push a **new** tag that includes both the package version and the working publish workflow.

## Test plan
- [ ] Tag `v0.30.1` (pushed with this release) triggers **Release to PyPI**
- [ ] Confirm the publish step succeeds and `graphiti-core==0.30.1` is on PyPI
- [ ] Optionally dispatch **Release Server Container** with `0.30.1`


Made with [Cursor](https://cursor.com)