### PR TITLE
perf(neo4j): use native vector indexes in similarity search with brute-force fallback

### DIFF
--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -60,8 +60,12 @@ from graphiti_core.search.search_filters import (
     node_search_filter_query_constructor,
 )
 
-NEO4J_NODE_VECTOR_INDEX = os.environ.get('GRAPHITI_NEO4J_NODE_VECTOR_INDEX', 'entity_name_embedding_vec')
-NEO4J_EDGE_VECTOR_INDEX = os.environ.get('GRAPHITI_NEO4J_EDGE_VECTOR_INDEX', 'relates_to_fact_embedding_vec')
+NEO4J_NODE_VECTOR_INDEX = os.environ.get(
+    'GRAPHITI_NEO4J_NODE_VECTOR_INDEX', 'entity_name_embedding_vec'
+)
+NEO4J_EDGE_VECTOR_INDEX = os.environ.get(
+    'GRAPHITI_NEO4J_EDGE_VECTOR_INDEX', 'relates_to_fact_embedding_vec'
+)
 NEO4J_VECTOR_OVERFETCH = int(os.environ.get('GRAPHITI_NEO4J_VECTOR_OVERFETCH', '4'))
 
 logger = logging.getLogger(__name__)

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import logging
+import os
 from collections import defaultdict
 from time import time
 from typing import Any
@@ -58,6 +59,10 @@ from graphiti_core.search.search_filters import (
     edge_search_filter_query_constructor,
     node_search_filter_query_constructor,
 )
+
+NEO4J_NODE_VECTOR_INDEX = os.environ.get('GRAPHITI_NEO4J_NODE_VECTOR_INDEX', 'entity_name_embedding_vec')
+NEO4J_EDGE_VECTOR_INDEX = os.environ.get('GRAPHITI_NEO4J_EDGE_VECTOR_INDEX', 'relates_to_fact_embedding_vec')
+NEO4J_VECTOR_OVERFETCH = int(os.environ.get('GRAPHITI_NEO4J_VECTOR_OVERFETCH', '4'))
 
 logger = logging.getLogger(__name__)
 
@@ -405,6 +410,47 @@ async def edge_similarity_search(
         else:
             return []
     else:
+        if driver.provider == GraphProvider.NEO4J:
+            try:
+                query = (
+                    """
+                    CALL db.index.vector.queryRelationships($index_name, $knn_limit, $search_vector)
+                    YIELD relationship AS r, score
+                    WITH r, score
+                    MATCH (n)-[r]->(m)
+                    WITH r AS e, n, m, score
+                    WHERE score > $min_score
+                    """
+                    + (' AND ' + (' AND '.join(filter_queries)) if filter_queries else '')
+                    + """
+                    RETURN
+                    """
+                    + get_entity_edge_return_query(driver.provider)
+                    + """
+                    ORDER BY score DESC
+                    LIMIT $limit
+                    """
+                )
+
+                # Neo4j vector index and cosine function scores share the same [0, 1] scale.
+                records, _, _ = await driver.execute_query(
+                    query,
+                    index_name=NEO4J_EDGE_VECTOR_INDEX,
+                    knn_limit=max(limit * NEO4J_VECTOR_OVERFETCH, 64),
+                    search_vector=search_vector,
+                    limit=limit,
+                    min_score=min_score,
+                    routing_='r',
+                    **filter_params,
+                )
+            except Exception:
+                logger.warning(
+                    'Neo4j edge vector index search failed; falling back to cosine scan',
+                    exc_info=True,
+                )
+            else:
+                return [get_entity_edge_from_record(record, driver.provider) for record in records]
+
         query = (
             match_query
             + filter_query
@@ -738,6 +784,44 @@ async def node_similarity_search(
         else:
             return []
     else:
+        if driver.provider == GraphProvider.NEO4J:
+            try:
+                query = (
+                    """
+                    CALL db.index.vector.queryNodes($index_name, $knn_limit, $search_vector)
+                    YIELD node AS n, score
+                    WHERE score > $min_score
+                    """
+                    + (' AND ' + (' AND '.join(filter_queries)) if filter_queries else '')
+                    + """
+                    RETURN
+                    """
+                    + get_entity_node_return_query(driver.provider)
+                    + """
+                    ORDER BY score DESC
+                    LIMIT $limit
+                    """
+                )
+
+                # Neo4j vector index and cosine function scores share the same [0, 1] scale.
+                records, _, _ = await driver.execute_query(
+                    query,
+                    index_name=NEO4J_NODE_VECTOR_INDEX,
+                    knn_limit=max(limit * NEO4J_VECTOR_OVERFETCH, 64),
+                    search_vector=search_vector,
+                    limit=limit,
+                    min_score=min_score,
+                    routing_='r',
+                    **filter_params,
+                )
+            except Exception:
+                logger.warning(
+                    'Neo4j node vector index search failed; falling back to cosine scan',
+                    exc_info=True,
+                )
+            else:
+                return [get_entity_node_from_record(record, driver.provider) for record in records]
+
         query = (
             """
                                                                                                                                     MATCH (n:Entity)


### PR DESCRIPTION
## Summary

Neo4j similarity search in `node_similarity_search` / `edge_similarity_search` currently computes `vector.similarity.cosine()` inline over every candidate node/edge — an O(N) full scan that never uses Neo4j's native vector indexes (available since 5.13). On larger graphs this makes every `add_episode` dedup pass take minutes.

Ref: #1793

## What this PR does

- On `GraphProvider.NEO4J`, both functions now try the native index path first:
  - nodes: `CALL db.index.vector.queryNodes($index_name, $knn_limit, $search_vector)`
  - edges: `CALL db.index.vector.queryRelationships($index_name, $knn_limit, $search_vector)`
- Group-id and search filters are applied post-ANN, with a configurable over-fetch multiplier so post-filtering does not starve the result set (`knn_limit = max(limit * overfetch, 64)`).
- **Any** exception on the fast path (index missing, older Neo4j, etc.) logs a warning and falls through to the existing brute-force query unchanged — no behavior change for deployments without vector indexes.
- Index names and over-fetch are overridable via env:
  - `GRAPHITI_NEO4J_NODE_VECTOR_INDEX` (default `entity_name_embedding_vec`)
  - `GRAPHITI_NEO4J_EDGE_VECTOR_INDEX` (default `relates_to_fact_embedding_vec`)
  - `GRAPHITI_NEO4J_VECTOR_OVERFETCH` (default `4`)
- Score semantics are compatible as-is: Neo4j normalizes both the vector index score and `vector.similarity.cosine()` to [0, 1] via (cos+1)/2, so `min_score` needs no rescaling.

Expected indexes (created by the operator, e.g.):

```cypher
CREATE VECTOR INDEX entity_name_embedding_vec IF NOT EXISTS
FOR (n:Entity) ON (n.name_embedding)
OPTIONS {indexConfig: {`vector.dimensions`: 1536, `vector.similarity_function`: 'cosine'}};

CREATE VECTOR INDEX relates_to_fact_embedding_vec IF NOT EXISTS
FOR ()-[r:RELATES_TO]-() ON (r.fact_embedding)
OPTIONS {indexConfig: {`vector.dimensions`: 1536, `vector.similarity_function`: 'cosine'}};
```

## Measurements

Production graph, Neo4j 5.26.0, 33k `Entity.name_embedding` + 87k `RELATES_TO.fact_embedding` (1536-dim), 4 GB host:

| query | before (inline cosine scan) | after (native index) |
|---|---|---|
| node top-10 similarity | 217.3 s | 4.1 s |
| edge top-10 similarity | (same scan shape) | 3.2 s |

Top-10 result uuids are identical between the two paths on the same query vector.

## Test plan

- `python -m py_compile` passes; diff is confined to the two functions plus three module-level constants.
- Verified live on Neo4j 5.26.0: fast path returns identical top-10 uuids vs the brute-force query; removing the index triggers the logged fallback and results remain correct.
- Running in production since 2026-09-02 with no fallback warnings in logs.
