### PR TITLE
fix(falkordb): use yielded node directly in episode fulltext search

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -395,17 +395,21 @@ class FalkorSearchOperations(SearchOperations):
         filter_params: dict[str, Any] = {}
         group_filter_query = ''
         if group_ids is not None:
-            group_filter_query += '\nAND e.group_id IN $group_ids'
+            group_filter_query += '\nWHERE e.group_id IN $group_ids'
             filter_params['group_ids'] = group_ids
 
+        # Use the node yielded by the fulltext procedure directly (as the node
+        # and community variants do). Re-matching it via
+        # `MATCH (e:Episodic) WHERE e.uuid = episode.uuid` cannot be answered
+        # from an index (the right-hand side is a per-row value), so every hit
+        # triggered a scan over all Episodic nodes — O(hits x episodes).
         cypher = (
             get_nodes_query(
                 'episode_content', '$query', limit=limit, provider=GraphProvider.FALKORDB
             )
             + """
-            YIELD node AS episode, score
-            MATCH (e:Episodic)
-            WHERE e.uuid = episode.uuid
+            YIELD node AS e, score
+            WITH e, score
             """
             + group_filter_query
             + """

--- a/tests/driver/test_falkordb_episode_fulltext.py
+++ b/tests/driver/test_falkordb_episode_fulltext.py
@@ -1,0 +1,106 @@
+"""Unit tests for the FalkorDB episode fulltext search query shape.
+
+Regression guard for https://github.com/getzep/graphiti/issues/1819: the
+fulltext procedure already yields the Episodic node, but the query used to
+re-match it via ``MATCH (e:Episodic) WHERE e.uuid = episode.uuid``. That
+predicate cannot be answered from an index (the right-hand side is a per-row
+value), so every fulltext hit triggered a scan over all Episodic nodes —
+O(hits x episodes) — which pins a FalkorDB core and wedges any search recipe
+that includes the episode scope once the graph is non-trivial.
+
+The tests assert on the generated Cypher with a mocked executor, so they need
+no live FalkorDB and run in CI regardless of whether the ``falkordb`` package
+is installed. They are deliberately scoped to the FalkorDB operations class:
+the Neo4j/Kuzu/Neptune implementations are not coupled to this query-plan
+workaround.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.driver.falkordb.operations.search_ops import FalkorSearchOperations
+from graphiti_core.search.search_filters import SearchFilters
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_executor():
+    executor = MagicMock(spec=GraphDriver)
+    executor.provider = GraphProvider.FALKORDB
+    executor.execute_query = AsyncMock(return_value=([], None, None))
+    return executor
+
+
+async def _run_search(executor, group_ids):
+    ops = FalkorSearchOperations()
+    return await ops.episode_fulltext_search(
+        executor, 'Duetto revenue', SearchFilters(), group_ids, limit=10
+    )
+
+
+async def test_episode_fulltext_uses_yielded_node_directly():
+    """The yielded node must be used as-is — no per-hit re-MATCH by uuid."""
+    executor = _make_executor()
+
+    await _run_search(executor, ['group-a'])
+
+    executor.execute_query.assert_awaited_once()
+    cypher = executor.execute_query.await_args.args[0]
+
+    # The O(hits x episodes) shape must not come back.
+    assert 'MATCH (e:Episodic)' not in cypher
+    assert 'episode.uuid' not in cypher
+    # The procedure's yielded node is the episode.
+    assert 'YIELD node AS e' in cypher
+
+
+async def test_episode_fulltext_group_filter_applies_to_yielded_node():
+    executor = _make_executor()
+
+    await _run_search(executor, ['group-a'])
+
+    cypher = executor.execute_query.await_args.args[0]
+    kwargs = executor.execute_query.await_args.kwargs
+
+    assert 'WHERE e.group_id IN $group_ids' in cypher
+    assert kwargs['group_ids'] == ['group-a']
+
+
+async def test_episode_fulltext_no_group_filter_when_group_ids_none():
+    executor = _make_executor()
+
+    await _run_search(executor, None)
+
+    cypher = executor.execute_query.await_args.args[0]
+    kwargs = executor.execute_query.await_args.kwargs
+
+    assert 'WHERE e.group_id IN $group_ids' not in cypher
+    assert 'group_ids' not in kwargs
+
+
+async def test_episode_fulltext_preserves_ordering_and_limit():
+    executor = _make_executor()
+
+    await _run_search(executor, ['group-a'])
+
+    cypher = executor.execute_query.await_args.args[0]
+    kwargs = executor.execute_query.await_args.kwargs
+
+    assert 'ORDER BY score DESC' in cypher
+    assert 'LIMIT $limit' in cypher
+    assert kwargs['limit'] == 10
+
+
+async def test_episode_fulltext_empty_query_short_circuits():
+    """An all-stopword/empty query must return before executing any Cypher."""
+    executor = _make_executor()
+    ops = FalkorSearchOperations()
+
+    result = await ops.episode_fulltext_search(
+        executor, 'the and or', SearchFilters(), ['group-a'], limit=10
+    )
+
+    assert result == []
+    executor.execute_query.assert_not_called()


### PR DESCRIPTION
Fixes #1819. Same O(matches × graph) class as #1500, on the episode path.

## Problem

`episode_fulltext_search` in `graphiti_core/driver/falkordb/operations/search_ops.py` re-matches every fulltext hit against all Episodic nodes:

```cypher
CALL db.idx.fulltext.queryNodes('episode_content', $query) YIELD node AS episode, score
MATCH (e:Episodic)
WHERE e.uuid = episode.uuid
```

The `WHERE e.uuid = episode.uuid` predicate can't be answered from an index (the right-hand side is a per-row value), so each yielded hit scans all Episodic nodes — O(hits × episodes) over content-heavy nodes. On our production FalkorDB graph (2,163 episodes, ~16k edges) any search recipe including the episode scope failed to complete within 30s, pinning a core; because FalkorDB keeps executing after the client gives up, unrelated queries then queue behind the abandoned scan, so one search degrades the whole instance.

## Fix

Use the node the procedure already yields — exactly as the `node_fulltext_search` and `community_fulltext_search` variants in the same file do:

```cypher
CALL db.idx.fulltext.queryNodes('episode_content', $query) YIELD node AS e, score
WITH e, score
WHERE e.group_id IN $group_ids
RETURN ... ORDER BY score DESC LIMIT $limit
```

Behavior is otherwise unchanged: optional `group_ids` filtering still applies to the yielded node, `EPISODIC_NODE_RETURN` / score ordering / `$limit` are preserved, and an empty/all-stopword query still returns before executing Cypher.

We're running this patch in production (alongside #1500's edge fixes): combined-recipe searches went from never completing to low single-digit seconds.

## Tests

`tests/driver/test_falkordb_episode_fulltext.py` — query-shape regression tests with a mocked executor (no live FalkorDB needed, mirrors `test_falkordb_ops_routing.py` conventions), scoped to the FalkorDB operations class so other providers aren't coupled to this query-plan workaround. Asserts the re-match shape is gone, the yielded node is used, group filtering/ordering/limit are preserved, and the empty-query short-circuit still holds. `ruff format` / `ruff check` clean; full `tests/driver/` suite passes.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_01Rw6VtYNo2cqrgzVdAAs3DU