### PR TITLE
fix(mcp): make LLM and embedder client construction fatal

### DIFF
--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -202,21 +202,13 @@ class GraphitiService:
     async def initialize(self) -> None:
         """Initialize the Graphiti client with factory-created components."""
         try:
-            # Create clients using factories
-            llm_client = None
-            embedder_client = None
-
-            # Create LLM client based on configured provider
-            try:
-                llm_client = LLMClientFactory.create(self.config.llm)
-            except Exception as e:
-                logger.warning(f'Failed to create LLM client: {e}')
-
-            # Create embedder client based on configured provider
-            try:
-                embedder_client = EmbedderFactory.create(self.config.embedder)
-            except Exception as e:
-                logger.warning(f'Failed to create embedder client: {e}')
+            # Create clients using factories. LLM and embedder construction errors
+            # must remain fatal, same as the cross-encoder below: Graphiti.__init__()
+            # silently substitutes an unconfigured default (OpenAIClient() /
+            # OpenAIEmbedder()) for any client left as None, which would bypass this
+            # server's configured provider entirely rather than fail loudly.
+            llm_client = LLMClientFactory.create(self.config.llm)
+            embedder_client = EmbedderFactory.create(self.config.embedder)
 
             # Create cross-encoder (reranker) client. Without this, Graphiti defaults to
             # OpenAIRerankerClient, which needs an OpenAI API key even on non-OpenAI setups.
@@ -321,18 +313,10 @@ class GraphitiService:
 
             logger.info('Successfully initialized Graphiti client')
 
-            # Log configuration details
-            if llm_client:
-                logger.info(
-                    f'Using LLM provider: {self.config.llm.provider} / {self.config.llm.model}'
-                )
-            else:
-                logger.info('No LLM client configured - entity extraction will be limited')
-
-            if embedder_client:
-                logger.info(f'Using Embedder provider: {self.config.embedder.provider}')
-            else:
-                logger.info('No Embedder client configured - search will be limited')
+            # Log configuration details. llm_client and embedder_client are always
+            # set by this point: construction failures above are fatal, not swallowed.
+            logger.info(f'Using LLM provider: {self.config.llm.provider} / {self.config.llm.model}')
+            logger.info(f'Using Embedder provider: {self.config.embedder.provider}')
 
             if self.entity_types:
                 entity_type_names = list(self.entity_types.keys())

--- a/mcp_server/tests/test_cross_encoder_factory.py
+++ b/mcp_server/tests/test_cross_encoder_factory.py
@@ -5,7 +5,6 @@ import builtins
 import logging
 import sys
 from pathlib import Path
-from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -15,14 +14,11 @@ sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
 from graphiti_core.cross_encoder.gemini_reranker_client import GeminiRerankerClient
 from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient
 
-import graphiti_mcp_server
 from config.schema import (
     AnthropicProviderConfig,
-    DatabaseConfig,
     EmbedderConfig,
     EmbedderProvidersConfig,
     GeminiProviderConfig,
-    GraphitiConfig,
     LLMConfig,
     LLMProvidersConfig,
     OpenAIProviderConfig,
@@ -81,22 +77,3 @@ class TestCrossEncoderFactory:
             CrossEncoderFactory.create(llm, embedder)
 
         assert '~2.3 GB' in caplog.text
-
-
-@pytest.mark.asyncio
-async def test_graphiti_service_does_not_swallow_reranker_configuration_error(monkeypatch):
-    error = ValueError('reranker setup failed')
-
-    def fail_reranker_setup(*_args):
-        raise error
-
-    fake_client = Mock()
-    fake_client.build_indices_and_constraints = AsyncMock()
-    monkeypatch.setattr(CrossEncoderFactory, 'create', fail_reranker_setup)
-    monkeypatch.setattr(graphiti_mcp_server, 'Graphiti', Mock(return_value=fake_client))
-    service = graphiti_mcp_server.GraphitiService(
-        GraphitiConfig(database=DatabaseConfig(provider='neo4j'))
-    )
-
-    with pytest.raises(ValueError, match='reranker setup failed'):
-        await service.initialize()

--- a/mcp_server/tests/test_graphiti_service_initialization.py
+++ b/mcp_server/tests/test_graphiti_service_initialization.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Unit tests for GraphitiService.initialize() client-construction error handling.
+
+LLM, embedder, and cross-encoder construction failures must all be fatal:
+Graphiti.__init__() silently substitutes an unconfigured default client for
+any of these left as None, which would bypass the server's configured
+provider entirely rather than fail loudly.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+# Add the src directory to the path (mirrors the other factory tests)
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+import graphiti_mcp_server
+from config.schema import DatabaseConfig, GraphitiConfig
+from services.factories import CrossEncoderFactory, EmbedderFactory, LLMClientFactory
+
+
+def _service() -> graphiti_mcp_server.GraphitiService:
+    return graphiti_mcp_server.GraphitiService(
+        GraphitiConfig(database=DatabaseConfig(provider='neo4j'))
+    )
+
+
+@pytest.mark.asyncio
+async def test_llm_client_configuration_error_is_not_swallowed(monkeypatch):
+    def fail_llm_setup(*_args):
+        raise ValueError('llm setup failed')
+
+    monkeypatch.setattr(LLMClientFactory, 'create', fail_llm_setup)
+
+    with pytest.raises(ValueError, match='llm setup failed'):
+        await _service().initialize()
+
+
+@pytest.mark.asyncio
+async def test_embedder_configuration_error_is_not_swallowed(monkeypatch):
+    def fail_embedder_setup(*_args):
+        raise ValueError('embedder setup failed')
+
+    monkeypatch.setattr(LLMClientFactory, 'create', lambda *_args: Mock())
+    monkeypatch.setattr(EmbedderFactory, 'create', fail_embedder_setup)
+
+    with pytest.raises(ValueError, match='embedder setup failed'):
+        await _service().initialize()
+
+
+@pytest.mark.asyncio
+async def test_reranker_configuration_error_is_not_swallowed(monkeypatch):
+    def fail_reranker_setup(*_args):
+        raise ValueError('reranker setup failed')
+
+    monkeypatch.setattr(LLMClientFactory, 'create', lambda *_args: Mock())
+    monkeypatch.setattr(EmbedderFactory, 'create', lambda *_args: Mock())
+    monkeypatch.setattr(CrossEncoderFactory, 'create', fail_reranker_setup)
+
+    with pytest.raises(ValueError, match='reranker setup failed'):
+        await _service().initialize()


### PR DESCRIPTION
## Summary
LLM and embedder client construction failures were caught and only logged as warnings; Graphiti then silently used an unconfigured default OpenAIClient()/OpenAIEmbedder(), ignoring the caller's actual provider. Makes both fatal, matching the cross-encoder construction two lines below, which already states and follows this principle.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

## Breaking Changes
- [x] This PR contains breaking changes

A misconfigured LLM or embedder provider now fails server startup instead of silently degrading to an unconfigured OpenAI default. Migration: fix the provider config so factory construction succeeds.

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Closes #1827
