### PR TITLE
fix: route Neo4j fulltext searches through the overridable query builder

### DIFF
--- a/graphiti_core/driver/neo4j/operations/search_ops.py
+++ b/graphiti_core/driver/neo4j/operations/search_ops.py
@@ -84,7 +84,7 @@ class Neo4jSearchOperations(SearchOperations):
         group_ids: list[str] | None = None,
         limit: int = 10,
     ) -> list[EntityNode]:
-        fuzzy_query = _build_neo4j_fulltext_query(query, group_ids)
+        fuzzy_query = self.build_fulltext_query(query, group_ids, MAX_QUERY_LENGTH)
         if fuzzy_query == '':
             return []
 
@@ -237,7 +237,7 @@ class Neo4jSearchOperations(SearchOperations):
         group_ids: list[str] | None = None,
         limit: int = 10,
     ) -> list[EntityEdge]:
-        fuzzy_query = _build_neo4j_fulltext_query(query, group_ids)
+        fuzzy_query = self.build_fulltext_query(query, group_ids, MAX_QUERY_LENGTH)
         if fuzzy_query == '':
             return []
 
@@ -404,7 +404,7 @@ class Neo4jSearchOperations(SearchOperations):
         group_ids: list[str] | None = None,
         limit: int = 10,
     ) -> list[EpisodicNode]:
-        fuzzy_query = _build_neo4j_fulltext_query(query, group_ids)
+        fuzzy_query = self.build_fulltext_query(query, group_ids, MAX_QUERY_LENGTH)
         if fuzzy_query == '':
             return []
 
@@ -447,7 +447,7 @@ class Neo4jSearchOperations(SearchOperations):
         group_ids: list[str] | None = None,
         limit: int = 10,
     ) -> list[CommunityNode]:
-        fuzzy_query = _build_neo4j_fulltext_query(query, group_ids)
+        fuzzy_query = self.build_fulltext_query(query, group_ids, MAX_QUERY_LENGTH)
         if fuzzy_query == '':
             return []
 


### PR DESCRIPTION
### What

`SearchOperations` declares `build_fulltext_query` as an override point, but the four fulltext search methods in `Neo4jSearchOperations` call the module-level `_build_neo4j_fulltext_query` directly:

```python
fuzzy_query = _build_neo4j_fulltext_query(query, group_ids)
```

So a subclass that overrides the method is silently bypassed. This routes all four through `self.build_fulltext_query`.

### Why it matters

Any Bolt-compatible backend that reuses `Neo4jSearchOperations` — ArcadeDB is the case we hit (#1259 / #1310) — inherits Neo4j's Lucene field-scoped syntax no matter what it overrides. The override point exists; it just isn't used. The FalkorDB and Kuzu backends avoid this only by reimplementing the methods wholesale.

### The `MAX_QUERY_LENGTH` detail

`MAX_QUERY_LENGTH` is passed explicitly rather than relying on the default. The direct calls default to `MAX_QUERY_LENGTH` (128); `build_fulltext_query`'s own default is 8000. Omitting it would quietly raise the cap 60×, changing which queries short-circuit to `''`. `search_utils.py:94` already calls it in this explicit form.

### Behaviour

No change for Neo4j — `build_fulltext_query` delegates to `_build_neo4j_fulltext_query` with the same argument. This only makes the declared extension point work.

### Verification

- `pytest tests/utils tests/driver tests/test_edge_db_queries.py tests/test_node_label_security.py` — 253 passed, 1 skipped
- `ruff check` and `ruff format --check` clean on the changed file

4 lines changed, one file. Not an integration, so no RFC — but it is a prerequisite for the ArcadeDB backend discussed in #1259 to work without duplicating the search operations.
