### PR TITLE
fix(falkordb): drop standalone fulltext punctuation

### DIFF
--- a/graphiti_core/driver/falkordb/fulltext.py
+++ b/graphiti_core/driver/falkordb/fulltext.py
@@ -71,7 +71,7 @@ def build_falkor_fulltext_query(
     filtered_words = [
         word
         for word in sanitize_falkor_fulltext_query(query).split()
-        if word.lower() not in STOPWORDS
+        if word.lower() not in STOPWORDS and (len(word) > 1 or word.isalnum())
     ]
     if not filtered_words:
         return ''

--- a/graphiti_core/driver/falkordb/fulltext.py
+++ b/graphiti_core/driver/falkordb/fulltext.py
@@ -71,7 +71,7 @@ def build_falkor_fulltext_query(
     filtered_words = [
         word
         for word in sanitize_falkor_fulltext_query(query).split()
-        if word.lower() not in STOPWORDS and (len(word) > 1 or word.isalnum())
+        if word.lower() not in STOPWORDS and any(character.isalnum() for character in word)
     ]
     if not filtered_words:
         return ''

--- a/tests/utils/search/test_search_security.py
+++ b/tests/utils/search/test_search_security.py
@@ -102,6 +102,23 @@ def test_falkordb_fulltext_query_returns_empty_on_punctuation_only():
     assert result == ''
 
 
+@pytest.mark.parametrize(
+    ('query', 'expected'),
+    [
+        (
+            'sessions/<enc-cwd>/<ISO-ts>_<uuid>.jsonl',
+            '(@group_id:"group1") (sessions | enc | cwd | ISO | ts | uuid | jsonl)',
+        ),
+        ('a_b', '(@group_id:"group1") (a_b)'),
+    ],
+)
+def test_falkordb_fulltext_query_drops_standalone_punctuation_tokens(query: str, expected: str):
+    """Standalone punctuation tokens should not produce invalid RediSearch queries."""
+    from graphiti_core.driver.falkordb.operations.search_ops import _build_falkor_fulltext_query
+
+    assert _build_falkor_fulltext_query(query, ['group1']) == expected
+
+
 def test_falkordb_driver_build_fulltext_query_strips_backticks():
     """FalkorDriver.build_fulltext_query should also strip backticks."""
     from graphiti_core.driver.falkordb_driver import FalkorDriver

--- a/tests/utils/search/test_search_security.py
+++ b/tests/utils/search/test_search_security.py
@@ -110,10 +110,11 @@ def test_falkordb_fulltext_query_returns_empty_on_punctuation_only():
             '(@group_id:"group1") (sessions | enc | cwd | ISO | ts | uuid | jsonl)',
         ),
         ('a_b', '(@group_id:"group1") (a_b)'),
+        ('foo __ bar', '(@group_id:"group1") (foo | bar)'),
     ],
 )
 def test_falkordb_fulltext_query_drops_standalone_punctuation_tokens(query: str, expected: str):
-    """Standalone punctuation tokens should not produce invalid RediSearch queries."""
+    """Tokens without alphanumeric characters should not enter RediSearch queries."""
     from graphiti_core.driver.falkordb.operations.search_ops import _build_falkor_fulltext_query
 
     assert _build_falkor_fulltext_query(query, ['group1']) == expected


### PR DESCRIPTION
## Summary

Fixes #1820.

FalkorDB fulltext queries can contain a standalone `_` token after sanitization. RediSearch rejects that token with a syntax error, so searches for identifier-shaped text such as `..._<uuid>...` fail instead of returning results.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective

Remove standalone non-alphanumeric tokens from the FalkorDB fulltext term list before joining terms with ` | `. This prevents invalid RediSearch queries while preserving embedded underscores such as `a_b`, which are valid search terms.

## Implementation

The existing stopword filter now also excludes one-character tokens that are not alphanumeric. The change is shared by the module-level builder and its existing driver/operations wrappers, so no public API or database schema changes are involved.

Added a parameterized regression covering the reported identifier-shaped query and the embedded-underscore compatibility case.

## Testing

- `.venv\\Scripts\\python.exe -m pytest -p no:cacheprovider tests/utils/search/test_search_security.py tests/utils/search/search_utils_test.py -q` — 22 passed
- `.venv\\Scripts\\ruff.exe check graphiti_core/driver/falkordb/fulltext.py tests/utils/search/test_search_security.py` — passed
- `.venv\\Scripts\\ruff.exe format --check graphiti_core/driver/falkordb/fulltext.py tests/utils/search/test_search_security.py` — passed
- `.venv\\Scripts\\pyright.exe graphiti_core/driver/falkordb/fulltext.py` — 0 errors
- `git diff --check` — passed

The full no-DB test command was attempted with FalkorDB, Kuzu, and Neptune disabled, but collection stopped at seven pre-existing missing optional provider dependencies (`sentence-transformers`, `google-genai`, `voyageai`, and `anthropic`). No database, LLM, API key, or network service is needed for the focused regression.

## Breaking Changes

- [ ] This PR contains breaking changes

## Checklist

- [x] Code follows project style guidelines for the touched files
- [x] Self-review completed
- [x] Documentation updated where necessary (no public API change)
- [x] No secrets or sensitive information committed

## Related Issues

Closes #1820

## AI Disclosure

This contribution was prepared with AI assistance and reviewed against the Issue reproduction, current source, and local test results.
