### PR TITLE
fix(search): apply cross-encoder threshold after reranking

### DIFF
--- a/graphiti_core/search/search.py
+++ b/graphiti_core/search/search.py
@@ -394,7 +394,7 @@ async def edge_search(
                     )
             elif config.reranker == EdgeReranker.cross_encoder:
                 search_result_uuids = [[edge.uuid for edge in result] for result in search_results]
-                rrf_result_uuids, _ = rrf(search_result_uuids, min_score=reranker_min_score)
+                rrf_result_uuids, _ = rrf(search_result_uuids)
                 rrf_edges = [edge_uuid_map[uuid] for uuid in rrf_result_uuids][: 2 * limit]
                 fact_to_uuid_map = {edge.fact: edge.uuid for edge in rrf_edges}
                 with _trace_phase(

--- a/tests/utils/search/test_edge_cross_encoder_rrf_shortlist.py
+++ b/tests/utils/search/test_edge_cross_encoder_rrf_shortlist.py
@@ -121,3 +121,40 @@ async def test_smoke_alice_works_at_zep_reaches_cross_encoder(monkeypatch):
     assert edges[0].fact == 'Alice works at Zep'
     assert len(edges) == limit
     assert len(scores) == limit
+
+
+@pytest.mark.asyncio
+async def test_cross_encoder_min_score_is_applied_after_reranking(monkeypatch):
+    """Cross-encoder thresholds should not filter candidates in RRF score space."""
+    first = _edge('edge-1', 'lexical first')
+    second = _edge('edge-2', 'semantic answer')
+    ranked_passages: list[str] = []
+
+    async def fake_fulltext(*args, **kwargs):
+        return [first, second]
+
+    class RecordingCrossEncoder:
+        async def rank(self, query: str, passages: list[str]):
+            ranked_passages.extend(passages)
+            return [(second.fact, 0.99), (first.fact, 0.81)]
+
+    monkeypatch.setattr('graphiti_core.search.search.edge_fulltext_search', fake_fulltext)
+
+    edges, scores = await edge_search(
+        driver=SimpleNamespace(),
+        cross_encoder=RecordingCrossEncoder(),
+        query='semantic answer',
+        query_vector=[0.1, 0.2, 0.3],
+        group_ids=None,
+        config=EdgeSearchConfig(
+            search_methods=[EdgeSearchMethod.bm25],
+            reranker=EdgeReranker.cross_encoder,
+        ),
+        search_filter=SearchFilters(),
+        limit=2,
+        reranker_min_score=0.8,
+    )
+
+    assert ranked_passages == [first.fact, second.fact]
+    assert [edge.uuid for edge in edges] == [second.uuid, first.uuid]
+    assert scores == [0.99, 0.81]


### PR DESCRIPTION
## Summary

Fixes #1817.

When `EdgeReranker.cross_encoder` is selected, `reranker_min_score` was passed to the RRF shortlist. RRF scores and cross-encoder scores use different scales, so valid candidates could be discarded before the cross-encoder evaluated them.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective

Build the cross-encoder shortlist from the unfiltered RRF ordering, then apply `reranker_min_score` only to the cross-encoder scores. This preserves candidates whose RRF score is below the cross-encoder threshold but whose cross-encoder score meets it.

## Implementation

The cross-encoder branch now calls `rrf()` without a minimum score. The existing final cross-encoder score filter remains unchanged. Other rerankers retain their existing threshold behavior.

Added a deterministic regression using two mocked BM25 edges: the second edge has an RRF score of `0.5` but a cross-encoder score of `0.99`, and must reach the cross-encoder and be returned first.

## Testing

- `D:\\project\\tscodex\\github_pr\\graphiti-1820-work-20260904\\.venv\\Scripts\\python.exe -m pytest -p no:cacheprovider tests/utils/search/test_edge_cross_encoder_rrf_shortlist.py -q` — 3 passed
- `D:\\project\\tscodex\\github_pr\\graphiti-1820-work-20260904\\.venv\\Scripts\\ruff.exe check graphiti_core/search/search.py tests/utils/search/test_edge_cross_encoder_rrf_shortlist.py` — passed
- `D:\\project\\tscodex\\github_pr\\graphiti-1820-work-20260904\\.venv\\Scripts\\ruff.exe format --check graphiti_core/search/search.py tests/utils/search/test_edge_cross_encoder_rrf_shortlist.py` — passed
- `D:\\project\\tscodex\\github_pr\\graphiti-1820-work-20260904\\.venv\\Scripts\\pyright.exe graphiti_core/search/search.py` — 0 errors
- `git diff --check` — passed

The full no-DB suite was attempted with FalkorDB, Kuzu, and Neptune disabled, but collection stopped at seven pre-existing missing optional provider dependencies (`sentence-transformers`, `google-genai`, `voyageai`, and `anthropic`). The focused test is provider-, database-, network-, GPU-, and API-key-free.

## Breaking Changes

- [ ] This PR contains breaking changes

## Checklist

- [x] Code follows project style guidelines for the touched files
- [x] Self-review completed
- [x] Documentation updated where necessary (no public API change)
- [x] No secrets or sensitive information committed

## Related Issues

Closes #1817

## AI Disclosure

This contribution was prepared with AI assistance and reviewed against the Issue reproduction, current source, and local test results.
