### PR TITLE
Fix registered edge names for disallowed signatures

### DIFF
--- a/graphiti_core/utils/maintenance/edge_operations.py
+++ b/graphiti_core/utils/maintenance/edge_operations.py
@@ -458,6 +458,7 @@ async def resolve_extracted_edges(
     # `edge_types_lst` stores the subset of custom edge definitions whose
     # node signature matches each extracted edge.
     edge_types_lst: list[dict[str, type[BaseModel]]] = []
+    invalid_registered_edge_types: list[bool] = []
     for extracted_edge in extracted_edges:
         source_node = uuid_entity_map.get(extracted_edge.source_node_uuid)
         target_node = uuid_entity_map.get(extracted_edge.target_node_uuid)
@@ -482,6 +483,14 @@ async def resolve_extracted_edges(
                     continue
 
                 extracted_edge_types[type_name] = type_model
+
+        # A registered custom type is only valid for its configured endpoint signatures.
+        # Keep unregistered names untouched, but fall back to the generic relationship when
+        # extraction assigned a registered type to a disallowed node pair. The final resolved
+        # edge is normalized below as resolution may reuse an existing edge.
+        invalid_registered_edge_types.append(
+            extracted_edge.name in edge_types and extracted_edge.name not in extracted_edge_types
+        )
 
         edge_types_lst.append(extracted_edge_types)
 
@@ -511,10 +520,16 @@ async def resolve_extracted_edges(
     resolved_edges: list[EntityEdge] = []
     invalidated_edges: list[EntityEdge] = []
     new_edges: list[EntityEdge] = []
-    for extracted_edge, result in zip(extracted_edges, results, strict=True):
+    for extracted_edge, result, invalid_registered_edge_type in zip(
+        extracted_edges, results, invalid_registered_edge_types, strict=True
+    ):
         resolved_edge = result[0]
         invalidated_edge_chunk = result[1]
         # result[2] is duplicate_edges list
+
+        if invalid_registered_edge_type:
+            resolved_edge.name = 'RELATES_TO'
+            resolved_edge.attributes = {}
 
         resolved_edges.append(resolved_edge)
         invalidated_edges.extend(invalidated_edge_chunk)

--- a/tests/utils/maintenance/test_edge_operations.py
+++ b/tests/utils/maintenance/test_edge_operations.py
@@ -156,6 +156,10 @@ class OccurredAtEdge(BaseModel):
     """Edge model stub for OCCURRED_AT."""
 
 
+class MakesEdge(BaseModel):
+    """Edge model stub for MAKES."""
+
+
 @pytest.mark.asyncio
 async def test_resolve_extracted_edges_keeps_unknown_names(monkeypatch):
     from graphiti_core.utils.maintenance import edge_operations as edge_ops
@@ -234,6 +238,102 @@ async def test_resolve_extracted_edges_keeps_unknown_names(monkeypatch):
     assert resolved_edges[0].name == 'INTERACTED_WITH'
     assert invalidated_edges == []
     assert new_edges == resolved_edges  # No duplicates, so all edges are new
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('reuse_existing', [False, True])
+async def test_resolve_extracted_edges_resets_registered_name_for_disallowed_signature(
+    monkeypatch, reuse_existing
+):
+    from graphiti_core.utils.maintenance import edge_operations as edge_ops
+
+    monkeypatch.setattr(edge_ops, 'create_entity_edge_embeddings', AsyncMock(return_value=None))
+    get_between_nodes = AsyncMock(return_value=[])
+    monkeypatch.setattr(EntityEdge, 'get_between_nodes', get_between_nodes)
+
+    async def immediate_gather(*aws, max_coroutines=None):
+        return [await aw for aw in aws]
+
+    monkeypatch.setattr(edge_ops, 'semaphore_gather', immediate_gather)
+    search = AsyncMock(return_value=SearchResults())
+    monkeypatch.setattr(edge_ops, 'search', search)
+
+    llm_client = MagicMock()
+    llm_client.generate_response = AsyncMock(
+        return_value={
+            'duplicate_facts': [],
+            'contradicted_facts': [],
+        }
+    )
+    clients = SimpleNamespace(
+        driver=MagicMock(),
+        llm_client=llm_client,
+        embedder=MagicMock(),
+        cross_encoder=MagicMock(),
+    )
+
+    source_node = EntityNode(
+        uuid='source_uuid',
+        name='Product Node',
+        group_id='group_1',
+        labels=['Product'],
+    )
+    target_node = EntityNode(
+        uuid='target_uuid',
+        name='Company Node',
+        group_id='group_1',
+        labels=['Company'],
+    )
+    extracted_edge = EntityEdge(
+        source_node_uuid=source_node.uuid,
+        target_node_uuid=target_node.uuid,
+        name='MAKES',
+        group_id='group_1',
+        fact='Product is made by company',
+        episodes=[],
+        created_at=datetime.now(timezone.utc),
+        valid_at=None,
+        invalid_at=None,
+    )
+    if reuse_existing:
+        get_between_nodes.return_value = [
+            EntityEdge(
+                source_node_uuid=source_node.uuid,
+                target_node_uuid=target_node.uuid,
+                name='MAKES',
+                group_id='group_1',
+                fact=extracted_edge.fact,
+                attributes={'legacy': 'value'},
+                episodes=[],
+                created_at=datetime.now(timezone.utc),
+                valid_at=None,
+                invalid_at=None,
+            )
+        ]
+        search.return_value = SearchResults(edges=get_between_nodes.return_value)
+    episode = EpisodicNode(
+        uuid='episode_uuid',
+        name='Episode',
+        group_id='group_1',
+        source='message',
+        source_description='desc',
+        content='Episode content',
+        valid_at=datetime.now(timezone.utc),
+    )
+
+    resolved_edges, invalidated_edges, new_edges = await resolve_extracted_edges(
+        clients,
+        [extracted_edge],
+        episode,
+        [source_node, target_node],
+        {'MAKES': MakesEdge},
+        {('Company', 'Product'): ['MAKES']},
+    )
+
+    assert resolved_edges[0].name == 'RELATES_TO'
+    assert resolved_edges[0].attributes == {}
+    assert invalidated_edges == []
+    assert new_edges == ([] if reuse_existing else resolved_edges)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Fix registered custom edge names being retained when extracted endpoint labels do not match the configured signature.
- Normalize the final resolved edge to `RELATES_TO`, including when an existing edge is reused, and clear incompatible structured attributes.
- Add regression coverage for both new edges and exact-fact reuse of existing edges.

Fixes #1830

## Verification

- `pytest tests/utils/maintenance/test_edge_operations.py -q` — 11 passed
- Core no-database unit scope with optional-provider tests unavailable in the local environment — 305 passed, 11 skipped
- Ruff check and format — passed
- Pyright on `graphiti_core/utils/maintenance/edge_operations.py` — passed
- Full repository Pyright is currently blocked by 13 pre-existing missing optional dependency/type errors in unrelated driver and provider modules.

## AI disclosure

This pull request was prepared with AI assistance. The change was reviewed, tested, and verified locally by the contributor.
