### PR TITLE
docs(mcp_server): fix broken link and copy-paste compose commands

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -282,7 +282,7 @@ The easiest way to run with Neo4j is using the provided Docker Compose configura
 
 ```bash
 # This starts both Neo4j and the MCP server
-docker compose -f docker/docker-compose.neo4j.yaml up
+docker compose -f docker/docker-compose-neo4j.yml up
 ```
 
 #### Option 2: Direct Execution with Existing Neo4j
@@ -311,7 +311,7 @@ uv run main.py --config config/config-docker-neo4j.yaml
 
 ```bash
 # This starts both FalkorDB (Redis-based) and the MCP server
-docker compose -f docker/docker-compose.falkordb.yaml up
+docker compose -f docker/docker-compose-falkordb.yml up
 ```
 
 #### Option 2: Direct Execution with Existing FalkorDB
@@ -624,7 +624,7 @@ docker compose up
 }
 ```
 
-3. Add the Graphiti rules to Cursor's User Rules. See [cursor_rules.md](cursor_rules.md) for details.
+3. Add the Graphiti rules to Cursor's User Rules. See [cursor_rules.md](docs/cursor_rules.md) for details.
 
 4. Kick off an agent session in Cursor.
 


### PR DESCRIPTION
## Type of change

- [x] 📝 Documentation

## What does this PR do?

Three small fixes in `mcp_server/README.md`, each verified against the repo tree:

1. The Cursor setup step links `cursor_rules.md`, which lives at `mcp_server/docs/cursor_rules.md` — the relative link resolved to the nonexistent `mcp_server/cursor_rules.md` and 404'd.
2. The Neo4j Docker Compose command referenced `docker/docker-compose.neo4j.yaml`; the file on disk is `docker/docker-compose-neo4j.yml` (and this README already links the correct name at the "Option 2" mention).
3. Same for the FalkorDB command: `docker/docker-compose.falkordb.yaml` → `docker/docker-compose-falkordb.yml`.

Copied commands previously failed immediately with "no such file".

## How was this tested?

- [x] `git ls-files` verification of both compose filenames and the cursor_rules.md location
- [x] All other links in the README already resolve; no other dead relative links in tracked markdown (checked repo-wide)

## Breaking changes

None.
