### PR TITLE
docs: fix README factual drift (SEMAPHORE_LIMIT, Kuzu version, database defaults)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Requirements:
 
 - Python 3.10 or higher
 - Neo4j 5.26 / FalkorDB 1.1.2 / Amazon Neptune Database Cluster or Neptune Analytics Graph + Amazon OpenSearch
-  Serverless collection (serves as the full text search backend) / Kuzu 0.11.2 (**deprecated**, see below)
+  Serverless collection (serves as the full text search backend) / Kuzu 0.11.3 (**deprecated**, see below)
 - OpenAI API key (Graphiti defaults to OpenAI for LLM inference and embedding)
 
 > [!IMPORTANT]
@@ -257,7 +257,7 @@ pip install graphiti-core[neptune]
 Graphiti's ingestion pipelines are designed for high concurrency. By default, concurrency is set low to avoid LLM
 Provider 429 Rate Limit Errors. If you find Graphiti slow, please increase concurrency as described below.
 
-Concurrency controlled by the `SEMAPHORE_LIMIT` environment variable. By default, `SEMAPHORE_LIMIT` is set to `10`
+Concurrency controlled by the `SEMAPHORE_LIMIT` environment variable. By default, `SEMAPHORE_LIMIT` is set to `20`
 concurrent operations to help prevent `429` rate limit errors from your LLM provider. If you encounter such errors, try
 lowering this value.
 
@@ -341,8 +341,8 @@ must be set.
 
 Database names are configured directly in the driver constructors:
 
-- **Neo4j**: Database name defaults to `neo4j` (hardcoded in Neo4jDriver)
-- **FalkorDB**: Database name defaults to `default_db` (hardcoded in FalkorDriver)
+- **Neo4j**: Database name defaults to `neo4j` (driver default, configurable via the `database` parameter)
+- **FalkorDB**: Database name defaults to `default_db` (driver default, configurable via the `database` parameter)
 
 As of v0.17.0, if you need to customize your database configuration, you can instantiate a database driver and pass it
 to the Graphiti constructor using the `graph_driver` parameter.


### PR DESCRIPTION
## Type of change

- [x] 📝 Documentation

## What does this PR do?

Fixes three places where the main README has drifted from the code (each verified at the cited source line):

1. `SEMAPHORE_LIMIT` default: README said `10`, but `graphiti_core/helpers.py:38` defaults to `20` (and has always done so). The MCP server's separate default of 10 is correct in `mcp_server/README.md` and is untouched.
2. Requirements list said `Kuzu 0.11.2`, while `pyproject.toml` pins the extra at `kuzu>=0.11.3`. The sibling Neo4j/FalkorDB versions in the same list match their pins.
3. The database-name section called the Neo4j/FalkorDB defaults "hardcoded", but both are plain driver parameter defaults (`database: str = 'neo4j'` in `neo4j_driver.py`, `database: str = 'default_db'` in `falkordb_driver.py`) — and the README's own example fifteen lines below passes `database="my_custom_database"`, contradicting the wording.

## How was this tested?

- [x] Each claim cross-checked against `graphiti_core/helpers.py`, `pyproject.toml`, and the two driver constructors
- [x] Docs-only change

## Breaking changes

None.
