### PR TITLE
fix: avoid duplicate episode provenance on resolved edges

### DIFF
--- a/graphiti_core/utils/maintenance/edge_operations.py
+++ b/graphiti_core/utils/maintenance/edge_operations.py
@@ -748,7 +748,7 @@ async def resolve_extracted_edge(
         resolved_edge = related_edges[duplicate_fact_id]
         break
 
-    if duplicate_fact_ids and episode is not None:
+    if duplicate_fact_ids and episode is not None and episode.uuid not in resolved_edge.episodes:
         resolved_edge.episodes.append(episode.uuid)
 
     # Process contradicted facts (continuous indexing across both lists)

--- a/tests/utils/maintenance/test_edge_operations.py
+++ b/tests/utils/maintenance/test_edge_operations.py
@@ -274,7 +274,7 @@ async def test_resolve_extracted_edge_uses_integer_indices_for_duplicates(mock_l
         name='test_edge',
         group_id='group_1',
         fact='User enjoys yoga',
-        episodes=['episode_1'],
+        episodes=['episode_1', episode.uuid],
         created_at=datetime.now(timezone.utc) - timedelta(days=1),
         valid_at=None,
         invalid_at=None,
@@ -328,6 +328,7 @@ async def test_resolve_extracted_edge_uses_integer_indices_for_duplicates(mock_l
     # Verify that the resolved edge is one of the duplicates (the first one found)
     # Check UUID since the episode list gets modified
     assert resolved_edge.uuid == related_edge_0.uuid
+    assert resolved_edge.episodes.count(episode.uuid) == 1
     assert episode.uuid in resolved_edge.episodes
 
 


### PR DESCRIPTION
## Summary

When an extracted edge is resolved as a duplicate, the selected edge always appends the current episode UUID. If that edge already references the episode, this creates duplicate provenance entries.

Guard the append with a membership check so the episode list remains unique while preserving the existing duplicate-resolution behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation/Tests

## Objective

Not applicable; this is a focused bug fix.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

Focused test: `DISABLE_FALKORDB=1 pytest tests/utils/maintenance/test_edge_operations.py::test_resolve_extracted_edge_uses_integer_indices_for_duplicates -q`

## Breaking Changes

- [ ] This PR contains breaking changes

## Checklist

- [x] Code follows project style guidelines (Ruff CI passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues

None.