### PR TITLE
fix(communities): bound the label_propagation loop so build_communities terminates

### DIFF
--- a/graphiti_core/driver/operations/graph_utils.py
+++ b/graphiti_core/driver/operations/graph_utils.py
@@ -14,9 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import logging
 from collections import defaultdict
 
 from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+# Floor for the iteration budget, so tiny graphs still get room to converge.
+MIN_LABEL_PROPAGATION_ITERATIONS = 10
 
 
 class Neighbor(BaseModel):
@@ -25,9 +31,31 @@ class Neighbor(BaseModel):
 
 
 def label_propagation(projection: dict[str, list[Neighbor]]) -> list[list[str]]:
+    """Label-propagation community detection.
+
+    The loop is bounded: label propagation is not guaranteed to converge, and on
+    balanced graph shapes the assignments can oscillate indefinitely. One
+    relabelling pass per node is a generous budget — a run that has not settled
+    by then is oscillating, not converging slowly — so on reaching the cap we
+    log a warning and return the partition reached so far. That is a legitimate
+    result for a heuristic algorithm; spinning forever is not.
+    """
     community_map = {uuid: i for i, uuid in enumerate(projection.keys())}
 
+    max_iterations = max(len(projection), MIN_LABEL_PROPAGATION_ITERATIONS)
+    iteration = 0
+
     while True:
+        iteration += 1
+        if iteration > max_iterations:
+            logger.warning(
+                'label_propagation did not converge within %d iterations over %d nodes; '
+                'returning the current partition',
+                max_iterations,
+                len(projection),
+            )
+            break
+
         no_change = True
         new_community_map: dict[str, int] = {}
 

--- a/graphiti_core/utils/maintenance/community_operations.py
+++ b/graphiti_core/utils/maintenance/community_operations.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from pydantic import BaseModel
 
 from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.driver.operations.graph_utils import MIN_LABEL_PROPAGATION_ITERATIONS
 from graphiti_core.edges import CommunityEdge
 from graphiti_core.embedder import EmbedderClient
 from graphiti_core.helpers import semaphore_gather
@@ -99,7 +100,20 @@ def label_propagation(projection: dict[str, list[Neighbor]]) -> list[list[str]]:
 
     community_map = {uuid: i for i, uuid in enumerate(projection.keys())}
 
+    max_iterations = max(len(projection), MIN_LABEL_PROPAGATION_ITERATIONS)
+    iteration = 0
+
     while True:
+        iteration += 1
+        if iteration > max_iterations:
+            logger.warning(
+                'label_propagation did not converge within %d iterations over %d nodes; '
+                'returning the current partition',
+                max_iterations,
+                len(projection),
+            )
+            break
+
         no_change = True
         new_community_map: dict[str, int] = {}
 

--- a/tests/test_label_propagation_termination.py
+++ b/tests/test_label_propagation_termination.py
@@ -1,0 +1,150 @@
+import logging
+import threading
+
+import pytest
+
+from graphiti_core.driver.operations.graph_utils import Neighbor, label_propagation
+from graphiti_core.utils.maintenance.community_operations import (
+    Neighbor as MaintenanceNeighbor,
+)
+from graphiti_core.utils.maintenance.community_operations import (
+    label_propagation as maintenance_label_propagation,
+)
+
+TIMEOUT_SECONDS = 5.0
+
+
+def _two_node_flip(neighbor_cls):
+    """Minimal non-converging case: two nodes that swap communities every pass.
+
+    With edge_count > 1, ``candidate_rank > 1`` holds, so each node adopts its
+    neighbour's community rather than falling back to the monotonic
+    ``max(candidate, curr)`` tie-break. The two assignments then swap forever.
+    """
+    return {
+        'x': [neighbor_cls(node_uuid='y', edge_count=2)],
+        'y': [neighbor_cls(node_uuid='x', edge_count=2)],
+    }
+
+
+def _balanced_triangle(neighbor_cls):
+    """Three mutually connected nodes with equal weights: no plurality winner."""
+    return {
+        'a': [
+            neighbor_cls(node_uuid='b', edge_count=2),
+            neighbor_cls(node_uuid='c', edge_count=2),
+        ],
+        'b': [
+            neighbor_cls(node_uuid='a', edge_count=2),
+            neighbor_cls(node_uuid='c', edge_count=2),
+        ],
+        'c': [
+            neighbor_cls(node_uuid='a', edge_count=2),
+            neighbor_cls(node_uuid='b', edge_count=2),
+        ],
+    }
+
+
+def _converging_triangle(neighbor_cls):
+    """edge_count=1 throughout, so the max() tie-break converges in a few passes."""
+    return {
+        'a': [
+            neighbor_cls(node_uuid='b', edge_count=1),
+            neighbor_cls(node_uuid='c', edge_count=1),
+        ],
+        'b': [
+            neighbor_cls(node_uuid='a', edge_count=1),
+            neighbor_cls(node_uuid='c', edge_count=1),
+        ],
+        'c': [
+            neighbor_cls(node_uuid='a', edge_count=1),
+            neighbor_cls(node_uuid='b', edge_count=1),
+        ],
+    }
+
+
+def _run_with_timeout(fn):
+    """Run fn() on a worker thread and fail if it does not return in time.
+
+    A non-terminating run cannot be interrupted, so the thread is daemonised and
+    the test fails rather than hanging the suite.
+    """
+    box: dict[str, object] = {}
+
+    def target():
+        try:
+            box['value'] = fn()
+        except Exception as exc:  # pragma: no cover - re-raised below
+            box['exc'] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    thread.join(TIMEOUT_SECONDS)
+    if thread.is_alive():
+        pytest.fail(f'label_propagation did not terminate within {TIMEOUT_SECONDS}s')
+    if 'exc' in box:
+        raise box['exc']  # type: ignore[misc]
+    return box['value']
+
+
+def _assert_partitions_every_node(partition, expected_nodes):
+    seen: set[str] = set()
+    for cluster in partition:
+        for node in cluster:
+            assert node not in seen, f'node {node!r} appears in more than one cluster'
+            seen.add(node)
+    assert seen == expected_nodes
+
+
+@pytest.mark.parametrize(
+    ('func', 'neighbor_cls'),
+    [
+        (label_propagation, Neighbor),
+        (maintenance_label_propagation, MaintenanceNeighbor),
+    ],
+    ids=['graph_utils', 'community_operations'],
+)
+@pytest.mark.parametrize(
+    ('builder', 'nodes'),
+    [
+        (_two_node_flip, {'x', 'y'}),
+        (_balanced_triangle, {'a', 'b', 'c'}),
+    ],
+    ids=['two_node_flip', 'balanced_triangle'],
+)
+def test_terminates_on_non_converging_graphs(func, neighbor_cls, builder, nodes):
+    partition = _run_with_timeout(lambda: func(builder(neighbor_cls)))
+    _assert_partitions_every_node(partition, nodes)
+
+
+@pytest.mark.parametrize(
+    ('func', 'neighbor_cls'),
+    [
+        (label_propagation, Neighbor),
+        (maintenance_label_propagation, MaintenanceNeighbor),
+    ],
+    ids=['graph_utils', 'community_operations'],
+)
+def test_converging_graph_is_unaffected_by_the_cap(func, neighbor_cls, caplog):
+    """A graph that settles must exit via no_change, not via the iteration cap."""
+    with caplog.at_level(logging.WARNING):
+        partition = func(_converging_triangle(neighbor_cls))
+
+    assert len(partition) == 1
+    _assert_partitions_every_node(partition, {'a', 'b', 'c'})
+    assert not [r for r in caplog.records if 'did not converge' in r.getMessage()]
+
+
+@pytest.mark.parametrize(
+    ('func', 'neighbor_cls'),
+    [
+        (label_propagation, Neighbor),
+        (maintenance_label_propagation, MaintenanceNeighbor),
+    ],
+    ids=['graph_utils', 'community_operations'],
+)
+def test_warns_when_the_cap_is_reached(func, neighbor_cls, caplog):
+    with caplog.at_level(logging.WARNING):
+        func(_two_node_flip(neighbor_cls))
+
+    assert [r for r in caplog.records if 'did not converge' in r.getMessage()]


### PR DESCRIPTION
## What's the problem

`label_propagation` loops `while True` and exits only on convergence — but label propagation isn't guaranteed to converge. On balanced graph shapes the assignments oscillate indefinitely and the loop never returns.

This isn't theoretical. On a ~1.2k-entity / 649-edge graph, `build_communities` ran CPU-bound for **over four hours** producing nothing before I killed it by hand. Because the call is synchronous and CPU-bound it also blocks the event loop, so a client-side cancellation can't be processed while it spins.

## Minimal reproduction

Two nodes are enough:

```python
from graphiti_core.driver.operations.graph_utils import Neighbor, label_propagation

# hangs forever on main
label_propagation({
    'x': [Neighbor(node_uuid='y', edge_count=2)],
    'y': [Neighbor(node_uuid='x', edge_count=2)],
})
```

With `edge_count > 1`, `candidate_rank > 1` holds, so each node adopts its neighbour's community rather than falling back to the monotonic `max(candidate, curr)` tie-break — and the two labels swap on every pass, forever. A balanced triangle (three nodes, all `edge_count=2`) behaves the same way: no plurality winner exists, so nothing ever settles.

## The fix

Bound the loop at one relabelling pass per node, with a floor of 10 for small graphs. A run that hasn't settled by then is oscillating rather than converging slowly, so we log a warning and return the partition reached so far.

Label propagation is a heuristic, not an exact algorithm, so a partition from a truncated run is a legitimate result — spinning forever is not. The convergence exit path (`no_change`) is untouched, so graphs that do settle behave exactly as before.

Both copies of the algorithm are fixed:

- `graphiti_core/driver/operations/graph_utils.py` — used by all four drivers
- `graphiti_core/utils/maintenance/community_operations.py` — reachable from the public `Graphiti.build_communities` API via `get_community_clusters`

## Tests

`tests/test_label_propagation_termination.py`, parametrised over both implementations:

- the two non-converging shapes terminate within a timeout
- a converging graph still exits via `no_change`, with no warning logged
- the warning fires when the cap is reached

Against unpatched `main` the termination tests hang indefinitely; with this change the suite completes in about 0.1s. `ruff format` and `ruff check` are clean.

## Notes

Happy to adjust the budget heuristic or make the cap configurable if you'd prefer that shape. I've been running an equivalent fix locally against 0.29.2 and 0.30.1.
