### PR TITLE
fix(falkordb): match hyphenated group ids in fulltext queries

### DIFF
--- a/graphiti_core/driver/falkordb/fulltext.py
+++ b/graphiti_core/driver/falkordb/fulltext.py
@@ -50,9 +50,20 @@ def sanitize_falkor_fulltext_query(query: str) -> str:
     return ' '.join(query.translate(_SEPARATOR_MAP).split())
 
 
-def _escape_fulltext_group_id(group_id: str) -> str:
-    """Escape a validated group ID for RediSearch fulltext syntax."""
-    return re.sub(r'([^a-zA-Z0-9])', r'\\\1', group_id)
+def _group_id_phrase(group_id: str) -> str:
+    """Quote a validated group ID as the phrase RediSearch indexed it as.
+
+    RediSearch tokenizes TEXT fields on separators, so a stored group_id such as
+    ``ko-verify`` is the token sequence ``ko verify``. Escaping the hyphen
+    (``"ko\\-verify"``) matched nothing; the phrase ``"ko verify"`` does. Characters that
+    are not separators but still special to the query syntax - the default group id ``_``
+    above all - do need escaping (``"\\_"``), or the query silently matches nothing.
+    """
+    phrase = sanitize_falkor_fulltext_query(group_id)
+    # Escape only what RediSearch treats specially; word characters of any script pass through
+    # (an escaped Hangul syllable such as \\한 no longer matches the indexed token).
+    phrase = re.sub(r'([^\w ]|_)', r'\\\1', phrase)
+    return f'"{phrase}"'
 
 
 def build_falkor_fulltext_query(
@@ -65,8 +76,8 @@ def build_falkor_fulltext_query(
 
     group_filter = ''
     if group_ids:
-        escaped_group_ids = [f'"{_escape_fulltext_group_id(group_id)}"' for group_id in group_ids]
-        group_filter = f'(@group_id:{"|".join(escaped_group_ids)})'
+        phrases = [_group_id_phrase(group_id) for group_id in group_ids if group_id.strip()]
+        group_filter = f'(@group_id:{"|".join(phrases)})' if phrases else ''
 
     filtered_words = [
         word

--- a/tests/driver/test_falkordb_fulltext_group_id.py
+++ b/tests/driver/test_falkordb_fulltext_group_id.py
@@ -1,0 +1,34 @@
+"""FalkorDB fulltext group filter: group ids must match the way RediSearch tokenized them."""
+
+from graphiti_core.driver.falkordb.fulltext import _group_id_phrase, build_falkor_fulltext_query
+
+
+def test_plain_group_id_is_quoted_unchanged():
+    assert build_falkor_fulltext_query('alice', ['main']) == '(@group_id:"main") (alice)'
+
+
+def test_hyphenated_group_id_becomes_the_indexed_phrase():
+    # RediSearch splits TEXT fields on separators, so the stored value "ko-verify" is the
+    # token sequence "ko verify". The escaped form "ko\-verify" never matched anything, which
+    # made every BM25 search scoped to a hyphenated group return no results.
+    assert build_falkor_fulltext_query('alice', ['ko-verify']) == '(@group_id:"ko verify") (alice)'
+
+
+def test_multiple_group_ids_are_ored():
+    assert (
+        build_falkor_fulltext_query('alice', ['main', 'team-a'])
+        == '(@group_id:"main"|"team a") (alice)'
+    )
+
+
+def test_non_separator_special_characters_stay_escaped():
+    # '_' is not a separator, so it is not a phrase boundary - but an unescaped '_' in the
+    # phrase matches nothing, and '_' is FalkorDB's default group id.
+    assert build_falkor_fulltext_query('alice', ['team_a']) == '(@group_id:"team\\_a") (alice)'
+    assert build_falkor_fulltext_query('alice', ['_']) == '(@group_id:"\\_") (alice)'
+
+
+def test_group_id_phrase_leaves_non_latin_letters_unescaped():
+    # validate_group_id rejects such ids today, but the phrase builder must not escape letters:
+    # RediSearch does not match an escaped Hangul syllable against the indexed token.
+    assert _group_id_phrase('한국어-그룹') == '"한국어 그룹"'


### PR DESCRIPTION
## Summary
On FalkorDB, every BM25 search scoped to a hyphenated `group_id` (e.g. `ko-verify`) returned zero results. `build_falkor_fulltext_query` escaped the hyphen (`@group_id:"ko\-verify"`), but RediSearch indexes TEXT fields on separators, so the stored value is the token sequence `ko` + `verify` and the escaped form never matches. The filter now quotes the group id as the phrase it was indexed as (`"ko verify"`), reusing the separator table the query sanitizer already applies. Plain ids (`main`) are unchanged; characters that are not separators but are special to the query syntax - notably the default group id `_` - are still escaped (`"\_"`, `"team\_a"`).

Reproduced against `falkordb/falkordb:latest`: `(@group_id:"ko\-verify") (@search_text:(x))` → 0 rows; `(@group_id:"ko verify") …` → match.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Testing
- [x] Unit tests added/updated (`tests/driver/test_falkordb_fulltext_group_id.py`)
- [ ] Integration tests added/updated
- [x] All existing tests pass (`tests/driver`, `tests/utils`, `tests/cross_encoder` unit modules)

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`ruff` and `pyright` clean on changed files)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
None
