### PR TITLE
fix(search): let the node and community cross-encoders score the summary, not just the name

### DIFF
--- a/graphiti_core/search/search.py
+++ b/graphiti_core/search/search.py
@@ -69,6 +69,11 @@ from graphiti_core.tracer import NoOpTracer, Tracer
 logger = logging.getLogger(__name__)
 
 
+def _node_passage(node: EntityNode | CommunityNode) -> str:
+    """Text the cross-encoder scores for a node: name plus summary when there is one."""
+    return f'{node.name}: {node.summary}' if node.summary else node.name
+
+
 def _enum_value(value: Any) -> Any:
     return value.value if hasattr(value, 'value') else value
 
@@ -597,23 +602,27 @@ async def node_search(
                         reranker_min_score,
                     )
             elif config.reranker == NodeReranker.cross_encoder:
-                name_to_uuid_map = {node.name: node.uuid for node in list(node_uuid_map.values())}
+                # Score the summary along with the name: the name alone rarely carries the
+                # query's meaning ("who leads the search team?" vs. "Kim Minsu").
+                passage_to_uuid_map = {
+                    _node_passage(node): node.uuid for node in list(node_uuid_map.values())
+                }
 
                 with _trace_phase(
                     search_tracer,
                     'search.node_search.cross_encoder_rank',
-                    {'candidate_count': len(name_to_uuid_map)},
+                    {'candidate_count': len(passage_to_uuid_map)},
                 ):
-                    reranked_node_names = await cross_encoder.rank(
-                        query, list(name_to_uuid_map.keys())
+                    reranked_passages = await cross_encoder.rank(
+                        query, list(passage_to_uuid_map.keys())
                     )
                 reranked_uuids = [
-                    name_to_uuid_map[name]
-                    for name, score in reranked_node_names
+                    passage_to_uuid_map[passage]
+                    for passage, score in reranked_passages
                     if score >= reranker_min_score
                 ]
                 node_scores = [
-                    score for _, score in reranked_node_names if score >= reranker_min_score
+                    score for _, score in reranked_passages if score >= reranker_min_score
                 ]
             elif config.reranker == NodeReranker.episode_mentions:
                 with _trace_phase(
@@ -845,18 +854,20 @@ async def community_search(
                         reranker_min_score,
                     )
             elif config.reranker == CommunityReranker.cross_encoder:
-                name_to_uuid_map = {
-                    node.name: node.uuid for result in search_results for node in result
+                passage_to_uuid_map = {
+                    _node_passage(node): node.uuid for result in search_results for node in result
                 }
                 with _trace_phase(
                     search_tracer,
                     'search.community_search.cross_encoder_rank',
-                    {'candidate_count': len(name_to_uuid_map)},
+                    {'candidate_count': len(passage_to_uuid_map)},
                 ):
-                    reranked_nodes = await cross_encoder.rank(query, list(name_to_uuid_map.keys()))
+                    reranked_nodes = await cross_encoder.rank(
+                        query, list(passage_to_uuid_map.keys())
+                    )
                 reranked_uuids = [
-                    name_to_uuid_map[name]
-                    for name, score in reranked_nodes
+                    passage_to_uuid_map[passage]
+                    for passage, score in reranked_nodes
                     if score >= reranker_min_score
                 ]
                 community_scores = [

--- a/tests/utils/search/test_community_cross_encoder_passages.py
+++ b/tests/utils/search/test_community_cross_encoder_passages.py
@@ -1,0 +1,63 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from graphiti_core.nodes import CommunityNode
+from graphiti_core.search.search import community_search
+from graphiti_core.search.search_config import (
+    CommunityReranker,
+    CommunitySearchConfig,
+    CommunitySearchMethod,
+)
+
+
+def _community(uuid: str, name: str, summary: str = '') -> CommunityNode:
+    return CommunityNode(
+        uuid=uuid,
+        name=name,
+        group_id='group_1',
+        summary=summary,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.mark.asyncio
+async def test_community_cross_encoder_sees_the_summary(monkeypatch):
+    target = _community('c-search', 'Cluster 7', 'people and work around the search team')
+    decoy = _community('c-design', 'Search', 'the design team and its tooling')
+    ranked_passages: list[str] = []
+
+    async def fake_fulltext(*args, **kwargs):
+        return [decoy]
+
+    async def fake_similarity(*args, **kwargs):
+        return [target]
+
+    class RecordingCrossEncoder:
+        async def rank(self, query: str, passages: list[str]):
+            ranked_passages.extend(passages)
+            scored = [(p, 0.99 if 'around the search team' in p else 0.1) for p in passages]
+            scored.sort(key=lambda item: item[1], reverse=True)
+            return scored
+
+    monkeypatch.setattr('graphiti_core.search.search.community_fulltext_search', fake_fulltext)
+    monkeypatch.setattr('graphiti_core.search.search.community_similarity_search', fake_similarity)
+
+    communities, scores = await community_search(
+        driver=SimpleNamespace(),
+        cross_encoder=RecordingCrossEncoder(),
+        query='what is going on around the search team?',
+        query_vector=[0.1, 0.2, 0.3],
+        group_ids=None,
+        config=CommunitySearchConfig(
+            search_methods=[CommunitySearchMethod.bm25, CommunitySearchMethod.cosine_similarity],
+            reranker=CommunityReranker.cross_encoder,
+        ),
+        limit=2,
+    )
+
+    assert 'Cluster 7: people and work around the search team' in ranked_passages
+    assert communities[0].uuid == target.uuid
+    assert len(communities) == 2
+    assert len(scores) == 2

--- a/tests/utils/search/test_node_cross_encoder_passages.py
+++ b/tests/utils/search/test_node_cross_encoder_passages.py
@@ -1,0 +1,66 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from graphiti_core.nodes import EntityNode
+from graphiti_core.search.search import node_search
+from graphiti_core.search.search_config import NodeReranker, NodeSearchConfig, NodeSearchMethod
+from graphiti_core.search.search_filters import SearchFilters
+
+
+def _node(uuid: str, name: str, summary: str = '') -> EntityNode:
+    return EntityNode(
+        uuid=uuid,
+        name=name,
+        group_id='group_1',
+        labels=['Entity'],
+        summary=summary,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.mark.asyncio
+async def test_node_cross_encoder_sees_the_summary(monkeypatch):
+    """The answer lives in a summary; the name alone would give the cross-encoder nothing."""
+    leader = _node('n-leader', 'Kim Minsu', 'leads the search team')
+    decoy = _node('n-decoy', 'Search Team', 'was founded in 2026')  # lexical decoy on the name
+    nameless_context = _node('n-plain', 'Scope Labs')  # no summary at all
+    ranked_passages: list[str] = []
+
+    async def fake_fulltext(*args, **kwargs):
+        return [decoy, nameless_context]
+
+    async def fake_similarity(*args, **kwargs):
+        return [leader]
+
+    class RecordingCrossEncoder:
+        async def rank(self, query: str, passages: list[str]):
+            ranked_passages.extend(passages)
+            scored = [(p, 0.99 if 'leads the search team' in p else 0.1) for p in passages]
+            scored.sort(key=lambda item: item[1], reverse=True)
+            return scored
+
+    monkeypatch.setattr('graphiti_core.search.search.node_fulltext_search', fake_fulltext)
+    monkeypatch.setattr('graphiti_core.search.search.node_similarity_search', fake_similarity)
+
+    nodes, scores = await node_search(
+        driver=SimpleNamespace(),
+        cross_encoder=RecordingCrossEncoder(),
+        query='who leads the search team?',
+        query_vector=[0.1, 0.2, 0.3],
+        group_ids=None,
+        config=NodeSearchConfig(
+            search_methods=[NodeSearchMethod.bm25, NodeSearchMethod.cosine_similarity],
+            reranker=NodeReranker.cross_encoder,
+        ),
+        search_filter=SearchFilters(),
+        limit=3,
+    )
+
+    assert 'Kim Minsu: leads the search team' in ranked_passages
+    assert 'Search Team: was founded in 2026' in ranked_passages
+    assert 'Scope Labs' in ranked_passages  # no summary -> name only, no dangling colon
+    assert nodes[0].uuid == leader.uuid
+    assert len(nodes) == 3
+    assert len(scores) == 3


### PR DESCRIPTION
## Summary
The node and community cross-encoder rerankers passed only `node.name` to `cross_encoder.rank()`. For a query like "who leads the search team?" a candidate named "Kim Minsu" carries none of the query's meaning, so every candidate scored alike and the reranker could not improve on the fused order. Both scopes now score `"name: summary"` (name alone when the summary is empty), matching the edge scope, which already ranks the full fact text.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Testing
- [x] Unit tests added/updated (`tests/utils/search/test_node_cross_encoder_passages.py`, `test_community_cross_encoder_passages.py`): the answer lives in a summary while a lexical decoy shares the query's words in its name; the summary-bearing node must rank first and a node without a summary must be passed as its bare name.
- [ ] Integration tests added/updated
- [x] All existing tests pass (`tests/utils`, `tests/driver`, `tests/cross_encoder` unit modules)

## Breaking Changes
- [ ] This PR contains breaking changes

Note: the passage→uuid mapping is still a dict, so two candidates with an identical name *and* summary collapse to one, as two identically named candidates already did.

## Checklist
- [x] Code follows project style guidelines (`ruff` and `pyright` clean on changed files)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
None
