### PR TITLE
fix(search): use the standard RRF constant (k=60) instead of 1

### DIFF
--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -64,6 +64,9 @@ logger = logging.getLogger(__name__)
 RELEVANT_SCHEMA_LIMIT = 10
 DEFAULT_MIN_SCORE = 0.6
 DEFAULT_MMR_LAMBDA = 0.5
+# Standard RRF smoothing constant (Cormack et al. 2009). A small value such as 1
+# makes a single list's rank-1 outweigh agreement across lists.
+DEFAULT_RRF_RANK_CONST = 60
 MAX_SEARCH_DEPTH = 3
 MAX_QUERY_LENGTH = 128
 
@@ -1762,7 +1765,7 @@ async def get_edge_invalidation_candidates(
 
 # takes in a list of rankings of uuids
 def rrf(
-    results: list[list[str]], rank_const=1, min_score: float = 0
+    results: list[list[str]], rank_const: int = DEFAULT_RRF_RANK_CONST, min_score: float = 0
 ) -> tuple[list[str], list[float]]:
     scores: dict[str, float] = defaultdict(float)
     for result in results:

--- a/tests/utils/search/test_rrf.py
+++ b/tests/utils/search/test_rrf.py
@@ -1,0 +1,24 @@
+from graphiti_core.search.search_utils import DEFAULT_RRF_RANK_CONST, rrf
+
+
+def test_default_constant_is_the_standard_sixty():
+    assert DEFAULT_RRF_RANK_CONST == 60
+
+
+def test_agreement_across_lists_beats_a_single_top_hit():
+    # X is ranked 4th by both retrievers; Y is ranked 1st by one of them only.
+    # RRF's purpose is that cross-list agreement wins - with rank_const=1 it did not.
+    ranked, scores = rrf([['Y', 'p', 'q', 'X'], ['r', 's', 't', 'X']])
+    assert ranked[0] == 'X'
+    assert scores[0] > scores[1]
+
+
+def test_rank_const_one_reproduces_the_old_winner_take_all_behaviour():
+    ranked, _ = rrf([['Y', 'p', 'q', 'X'], ['r', 's', 't', 'X']], rank_const=1)
+    assert ranked[0] != 'X'
+
+
+def test_min_score_filters_by_fused_score():
+    ranked, scores = rrf([['a', 'b'], ['a', 'c']], min_score=2 / 61)
+    assert ranked == ['a']
+    assert len(scores) == 1


### PR DESCRIPTION
## Summary
`rrf()` fused ranks with `rank_const=1`. With k=1 the first hit of any single list scores 1.0 while a document ranked 4th by *every* list scores 0.5, so cross-list agreement — the property reciprocal rank fusion exists for — loses to a single list's confidence. In hybrid search this means a BM25 lexical decoy at rank 1 reliably outranks the document both BM25 and vector search agreed on. This PR uses the conventional k=60 (Cormack, Clarke & Buettcher, 2009) via a named `DEFAULT_RRF_RANK_CONST`.

```
vector = [Y, p, q, X]   bm25 = [r, s, t, X]      # X agreed by both at rank 4
k=1  : Y 1.000  r 1.000  p 0.500  X 0.500 …      # X ends up 4th
k=60 : X 0.0317 Y 0.0167 r 0.0167 …              # X first
```

Fused scores shrink from the ~1.0 scale to ~0.016 per list. Nothing in the repository sets `reranker_min_score` above the default 0 and the fused scores are not surfaced to callers, but a downstream caller who tuned `reranker_min_score` against the old scale would need to adjust it.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Testing
- [x] Unit tests added/updated (`tests/utils/search/test_rrf.py`: the agreement property, the old winner-take-all behaviour under k=1, `min_score` on the fused scale)
- [ ] Integration tests added/updated
- [x] All existing tests pass (`tests/utils`, `tests/driver`, `tests/cross_encoder` unit modules)

## Breaking Changes
- [ ] This PR contains breaking changes (see the `reranker_min_score` note above)

## Checklist
- [x] Code follows project style guidelines (`ruff` and `pyright` clean on changed files)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
None
