### PR TITLE
fix(embedder): one Content per input so gemini-embedding-2 returns one vector per text

### DIFF
--- a/graphiti_core/embedder/gemini.py
+++ b/graphiti_core/embedder/gemini.py
@@ -42,6 +42,17 @@ DEFAULT_EMBEDDING_MODEL = 'text-embedding-001'  # gemini-embedding-001 or text-e
 DEFAULT_BATCH_SIZE = 100
 
 
+def _as_contents(texts: list[str]) -> list[types.Content]:
+    """One Content per input text.
+
+    google-genai (>= 2.x) routes ``gemini-embedding-2`` through the generateContent
+    conversion, where a ``list[str]`` becomes a *single* multi-part Content and the API
+    returns one embedding for the whole batch. Wrapping each text in its own Content keeps
+    one request per input for every model.
+    """
+    return [types.Content(role='user', parts=[types.Part.from_text(text=text)]) for text in texts]
+
+
 class GeminiEmbedderConfig(EmbedderConfig):
     embedding_model: str = Field(default=DEFAULT_EMBEDDING_MODEL)
     api_key: str | None = None
@@ -98,10 +109,11 @@ class GeminiEmbedder(EmbedderClient):
         Returns:
             A list of floats representing the embedding vector.
         """
+        texts = [input_data] if isinstance(input_data, str) else [str(item) for item in input_data]
         # Generate embeddings
         result = await self.client.aio.models.embed_content(
             model=self.config.embedding_model or DEFAULT_EMBEDDING_MODEL,
-            contents=[input_data],  # type: ignore[arg-type]  # mypy fails on broad union type
+            contents=_as_contents(texts),  # type: ignore[arg-type]
             config=types.EmbedContentConfig(output_dimensionality=self.config.embedding_dim),
         )
 
@@ -137,7 +149,7 @@ class GeminiEmbedder(EmbedderClient):
                 # Generate embeddings for this batch
                 result = await self.client.aio.models.embed_content(
                     model=self.config.embedding_model or DEFAULT_EMBEDDING_MODEL,
-                    contents=batch,  # type: ignore[arg-type]  # mypy fails on broad union type
+                    contents=_as_contents(batch),  # type: ignore[arg-type]
                     config=types.EmbedContentConfig(
                         output_dimensionality=self.config.embedding_dim
                     ),
@@ -145,6 +157,11 @@ class GeminiEmbedder(EmbedderClient):
 
                 if not result.embeddings or len(result.embeddings) == 0:
                     raise Exception('No embeddings returned')
+                if len(result.embeddings) != len(batch):
+                    # Callers zip inputs and vectors positionally; never return a misaligned batch.
+                    raise ValueError(
+                        f'Expected {len(batch)} embeddings, got {len(result.embeddings)}'
+                    )
 
                 # Process embeddings from this batch
                 for embedding in result.embeddings:
@@ -163,7 +180,7 @@ class GeminiEmbedder(EmbedderClient):
                         # Process each item individually
                         result = await self.client.aio.models.embed_content(
                             model=self.config.embedding_model or DEFAULT_EMBEDDING_MODEL,
-                            contents=[item],  # type: ignore[arg-type]  # mypy fails on broad union type
+                            contents=_as_contents([item]),  # type: ignore[arg-type]
                             config=types.EmbedContentConfig(
                                 output_dimensionality=self.config.embedding_dim
                             ),

--- a/tests/embedder/test_gemini.py
+++ b/tests/embedder/test_gemini.py
@@ -22,12 +22,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from embedder_fixtures import create_embedding_values
+from google.genai import types
 
 from graphiti_core.embedder.gemini import (
     DEFAULT_EMBEDDING_MODEL,
     GeminiEmbedder,
     GeminiEmbedderConfig,
 )
+
+
+def _texts(contents: Any) -> list[str]:
+    """Texts of the per-input Content objects the embedder hands to the SDK."""
+    assert all(isinstance(c, types.Content) and c.parts and len(c.parts) == 1 for c in contents)
+    return [c.parts[0].text for c in contents]
 
 
 def create_gemini_embedding(multiplier: float = 0.1, dimension: int = 1536) -> MagicMock:
@@ -132,7 +139,7 @@ class TestGeminiEmbedderCreate:
         mock_gemini_client.aio.models.embed_content.assert_called_once()
         _, kwargs = mock_gemini_client.aio.models.embed_content.call_args
         assert kwargs['model'] == DEFAULT_EMBEDDING_MODEL
-        assert kwargs['contents'] == ['Test input']
+        assert _texts(kwargs['contents']) == ['Test input']
 
         # Verify result is processed correctly
         assert result == mock_gemini_response.embeddings[0].values
@@ -261,7 +268,7 @@ class TestGeminiEmbedderCreateBatch:
         mock_gemini_client.aio.models.embed_content.assert_called_once()
         _, kwargs = mock_gemini_client.aio.models.embed_content.call_args
         assert kwargs['model'] == DEFAULT_EMBEDDING_MODEL
-        assert kwargs['contents'] == input_batch
+        assert _texts(kwargs['contents']) == input_batch
 
         # Verify all results are processed correctly
         assert len(result) == 3
@@ -393,3 +400,56 @@ class TestGeminiEmbedderCreateBatch:
 
 if __name__ == '__main__':
     pytest.main(['-xvs', __file__])
+
+
+class TestGeminiEmbedderEmbedding2Batching:
+    """google-genai >= 2.x collapses a list[str] into one multi-part Content for
+    gemini-embedding-2, which yields a single embedding for the whole batch."""
+
+    @pytest.mark.asyncio
+    async def test_each_input_is_its_own_content(
+        self, mock_gemini_client: Any, mock_gemini_batch_response: MagicMock
+    ) -> None:
+        embedder = GeminiEmbedder(
+            config=GeminiEmbedderConfig(
+                api_key='k', embedding_model='gemini-embedding-2', embedding_dim=3072
+            )
+        )
+        embedder.client = mock_gemini_client
+        mock_gemini_client.aio.models.embed_content.return_value = mock_gemini_batch_response
+
+        await embedder.create_batch(['a', 'b', 'c'])
+
+        _, kwargs = mock_gemini_client.aio.models.embed_content.call_args
+        contents = kwargs['contents']
+        assert len(contents) == 3
+        assert _texts(contents) == ['a', 'b', 'c']
+        assert kwargs['config'].output_dimensionality == 3072
+
+    @pytest.mark.asyncio
+    async def test_fewer_embeddings_than_inputs_falls_back_to_one_by_one(
+        self, mock_gemini_client: Any
+    ) -> None:
+        embedder = GeminiEmbedder(
+            config=GeminiEmbedderConfig(
+                api_key='k', embedding_model='gemini-embedding-2', embedding_dim=8
+            )
+        )
+        embedder.client = mock_gemini_client
+        collapsed = MagicMock()
+        collapsed.embeddings = [create_gemini_embedding(0.5, 8)]  # one vector for three inputs
+        single = MagicMock()
+        single.embeddings = [create_gemini_embedding(0.1, 8)]
+        mock_gemini_client.aio.models.embed_content.side_effect = [
+            collapsed,
+            single,
+            single,
+            single,
+        ]
+
+        result = await embedder.create_batch(['a', 'b', 'c'])
+
+        # batch call + three individual retries, never a misaligned 1-for-3 result
+        assert mock_gemini_client.aio.models.embed_content.call_count == 4
+        assert len(result) == 3
+        assert all(v == single.embeddings[0].values for v in result)


### PR DESCRIPTION
## Summary
With google-genai 2.x and a `gemini-embedding-2*` model, `GeminiEmbedder.create_batch()` returns **one** embedding for a batch of N texts. The SDK routes models matching `'gemini-embedding-2'` through `t.t_contents()` (`google/genai/models.py`), the generateContent conversion where a `list[str]` is a single multi-part `Content`, so the whole batch is embedded as one input. Callers zip inputs and vectors positionally: `EntityNode.generate_name_embedding` / `EntityEdge` bulk paths raise on the strict zip, and the dedup candidate search silently degrades to a single vector. Reproduced against the live API with google-genai 2.8.0 and 2.22.0 (3 strings → 1 embedding with `gemini-embedding-2`, 3 with `gemini-embedding-001`).

Fix: wrap every text in its own `types.Content` in `create()` and `create_batch()` (semantically identical for every model, one request per input), and refuse a batch whose embedding count does not match the input count, which routes the batch to the existing per-item fallback instead of returning a misaligned list.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Testing
- [x] Unit tests added/updated (`tests/embedder/test_gemini.py`: the request body carries one `Content` per input for both models; a 1-for-N response falls back to per-item calls and returns N vectors)
- [ ] Integration tests added/updated
- [x] All existing tests pass (`tests/embedder/test_gemini.py`, 17 passed)

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`ruff` and `pyright` clean on changed files)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
None
