### PR TITLE
chore(gemini): opt out of the SDK's automatic function calling loop

### DIFF
--- a/graphiti_core/cross_encoder/gemini_reranker_client.py
+++ b/graphiti_core/cross_encoder/gemini_reranker_client.py
@@ -110,6 +110,9 @@ Provide only a number between 0 and 100 (no explanation, just the number):"""
                             system_instruction='You are an expert at rating passage relevance. Respond with only a number from 0-100.',
                             temperature=0.0,
                             max_output_tokens=3,
+                            automatic_function_calling=types.AutomaticFunctionCallingConfig(
+                                disable=True
+                            ),
                         ),
                     )
                     for prompt_messages in scoring_prompts

--- a/graphiti_core/llm_client/gemini_client.py
+++ b/graphiti_core/llm_client/gemini_client.py
@@ -297,6 +297,9 @@ class GeminiClient(LLMClient):
                 response_schema=response_model if response_model else None,
                 system_instruction=system_prompt,
                 thinking_config=self.thinking_config,
+                # No tools are passed, so opt out of the SDK's automatic-function-calling
+                # loop; google-genai >= 2.22 warns when AFC is left enabled here.
+                automatic_function_calling=types.AutomaticFunctionCallingConfig(disable=True),
             )
 
             # Generate content using the simple string approach


### PR DESCRIPTION
## Summary
Neither `GeminiClient` nor `GeminiRerankerClient` passes tools, yet google-genai runs every `generate_content` call through its automatic-function-calling (AFC) loop by default. Since google-genai 2.22.0 that logs a per-process warning recommending `Chat.send_message` for AFC, and every call logs an `AFC is enabled with max remote calls: 10` INFO line. Setting `automatic_function_calling=AutomaticFunctionCallingConfig(disable=True)` on both configs skips the loop and both log lines. No behaviour change: with no tools declared the loop never ran a function call.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests
- [x] Maintenance (no behaviour change)

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass (`tests/llm_client/test_gemini_client.py`, `tests/cross_encoder/test_gemini_reranker_client.py`, 39 passed)

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`ruff` and `pyright` clean on changed files)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
None
