### PR TITLE
docs: fix a root-relative image path and a dead cursor_rules link

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ frequently changing data. Graphiti addresses these challenges by providing:
   for enterprise workloads.
 
 <p align="center">
-    <img src="/images/graphiti-intro-slides-stock-2.gif" alt="Graphiti structured + unstructured demo" width="700px">
+    <img src="images/graphiti-intro-slides-stock-2.gif" alt="Graphiti structured + unstructured demo" width="700px">
 </p>
 
 ## Graphiti vs. GraphRAG

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -624,7 +624,7 @@ docker compose up
 }
 ```
 
-3. Add the Graphiti rules to Cursor's User Rules. See [cursor_rules.md](cursor_rules.md) for details.
+3. Add the Graphiti rules to Cursor's User Rules. See [cursor_rules.md](docs/cursor_rules.md) for details.
 
 4. Kick off an agent session in Cursor.
 


### PR DESCRIPTION
- `README.md`: the demo GIF used `src="/images/...")` — the leading slash resolves to the GitHub domain root and the image 404s; now repo-relative like the other two images (target verified to exist).
- `mcp_server/README.md`: linked `cursor_rules.md`; the file lives at `mcp_server/docs/cursor_rules.md`. Docs-only link fixes.