### PR TITLE
Bump graphiti-core to 0.30.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "graphiti-core"
 description = "A temporal graph building library"
-version = "0.30.1"
+version = "0.30.2"
 authors = [
     { name = "Paul Paliychuk", email = "paul@getzep.com" },
     { name = "Preston Rasmussen", email = "preston@getzep.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1097,7 +1097,7 @@ wheels = [
 
 [[package]]
 name = "graphiti-core"
-version = "0.30.1"
+version = "0.30.2"
 source = { editable = "." }
 dependencies = [
     { name = "neo4j" },


### PR DESCRIPTION
## Summary
- Bump `graphiti-core` from 0.30.1 to 0.30.2 in `pyproject.toml` and `uv.lock`.
- Patch release for the contributor fixes and other changes already on `main` since 0.30.1 (including #1856, #1711, #1699, #1760, #1688).

## Test plan
- [ ] Confirm `pyproject.toml` and `uv.lock` both report `0.30.2`.
- [ ] After merge, confirm the release workflow publishes `graphiti-core==0.30.2` to PyPI.


Made with [Cursor](https://cursor.com)