### PR TITLE
feat(mcp): configure reranker provider, model, and search recipes

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -169,9 +169,20 @@ llm:
   # Optional for OpenAI-compatible providers: "json_schema" (default) or "json_object"
   structured_output_mode: "json_schema"
 
+reranker:
+  # "auto" infers from the LLM, then embedder, then falls back to local BGE.
+  # Or select "openai", "azure_openai", "gemini", or "bge" explicitly.
+  provider: "auto"
+
 database:
   provider: "falkordb"  # Default. Options: "falkordb", "neo4j"
 ```
+
+An explicit API-backed reranker reuses credentials from the matching `llm.providers` or
+`embedder.providers` entry, even when that provider is not selected for the LLM or embedder. For
+example, `reranker.provider: "gemini"` uses the configured Gemini API key. Set
+`RERANKER_PROVIDER` when using the shipped `config.yaml`, or `RERANKER__PROVIDER` with direct
+environment-based configuration.
 
 ### Using Ollama for Local LLM
 

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -173,6 +173,8 @@ reranker:
   # "auto" infers from the LLM, then embedder, then falls back to local BGE.
   # Or select "openai", "azure_openai", "gemini", or "bge" explicitly.
   provider: "auto"
+  # Optional API-backed reranker model override. Omit to use the client's default.
+  model: null
 
 database:
   provider: "falkordb"  # Default. Options: "falkordb", "neo4j"
@@ -181,8 +183,8 @@ database:
 An explicit API-backed reranker reuses credentials from the matching `llm.providers` or
 `embedder.providers` entry, even when that provider is not selected for the LLM or embedder. For
 example, `reranker.provider: "gemini"` uses the configured Gemini API key. Set
-`RERANKER_PROVIDER` when using the shipped `config.yaml`, or `RERANKER__PROVIDER` with direct
-environment-based configuration.
+`RERANKER_PROVIDER` and, optionally, `RERANKER_MODEL` when using the shipped `config.yaml`.
+For direct environment-based configuration, use `RERANKER__PROVIDER` and `RERANKER__MODEL`.
 
 ### Using Ollama for Local LLM
 

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -176,6 +176,12 @@ reranker:
   # Optional API-backed reranker model override. Omit to use the client's default.
   model: null
 
+graphiti:
+  # Select the search recipe independently for facts and nodes.
+  # Options: "rrf" (default) or "cross_encoder".
+  fact_reranker: "rrf"
+  node_reranker: "rrf"
+
 database:
   provider: "falkordb"  # Default. Options: "falkordb", "neo4j"
 ```
@@ -185,6 +191,13 @@ An explicit API-backed reranker reuses credentials from the matching `llm.provid
 example, `reranker.provider: "gemini"` uses the configured Gemini API key. Set
 `RERANKER_PROVIDER` and, optionally, `RERANKER_MODEL` when using the shipped `config.yaml`.
 For direct environment-based configuration, use `RERANKER__PROVIDER` and `RERANKER__MODEL`.
+
+The MCP search tools use RRF by default. Set `graphiti.fact_reranker` or
+`graphiti.node_reranker` to `"cross_encoder"` to make `search_memory_facts` or `search_nodes`
+use the configured cross encoder. A centered search still uses node-distance reranking because
+that recipe is what gives `center_node_uuid` its ranking effect. With the shipped `config.yaml`,
+the corresponding environment variables are `FACT_RERANKER` and `NODE_RERANKER`; direct nested
+configuration uses `GRAPHITI__FACT_RERANKER` and `GRAPHITI__NODE_RERANKER`.
 
 ### Using Ollama for Local LLM
 

--- a/mcp_server/config/config.yaml
+++ b/mcp_server/config/config.yaml
@@ -73,6 +73,12 @@ embedder:
       api_url: ${VOYAGE_API_URL:https://api.voyageai.com/v1}
       model: "voyage-3"
 
+# By default, infer a reranker from the LLM and embedder providers, then fall back to local BGE.
+# Set this explicitly to openai, azure_openai, gemini, or bge to override that selection.
+# API-backed rerankers reuse credentials from the matching llm.providers or embedder.providers block.
+reranker:
+  provider: ${RERANKER_PROVIDER:auto}
+
 database:
   provider: "falkordb"  # Default: falkordb. Options: neo4j, falkordb
 

--- a/mcp_server/config/config.yaml
+++ b/mcp_server/config/config.yaml
@@ -76,8 +76,10 @@ embedder:
 # By default, infer a reranker from the LLM and embedder providers, then fall back to local BGE.
 # Set this explicitly to openai, azure_openai, gemini, or bge to override that selection.
 # API-backed rerankers reuse credentials from the matching llm.providers or embedder.providers block.
+# Optionally set RERANKER_MODEL to override the provider client's default model.
 reranker:
   provider: ${RERANKER_PROVIDER:auto}
+  model: ${RERANKER_MODEL:}
 
 database:
   provider: "falkordb"  # Default: falkordb. Options: neo4j, falkordb

--- a/mcp_server/config/config.yaml
+++ b/mcp_server/config/config.yaml
@@ -101,6 +101,10 @@ graphiti:
   group_id: ${GRAPHITI_GROUP_ID:main}
   episode_id_prefix: ${EPISODE_ID_PREFIX:}
   user_id: ${USER_ID:mcp_user}
+  # Search recipe used by search_memory_facts and search_nodes.
+  # cross_encoder activates the reranker configured above; rrf avoids reranker API calls.
+  fact_reranker: ${FACT_RERANKER:rrf}
+  node_reranker: ${NODE_RERANKER:rrf}
   entity_types:
     - name: "Preference"
       description: "User preferences, choices, opinions, or selections (PRIORITIZE over most other types except User/Assistant)"

--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -181,6 +181,14 @@ class EmbedderConfig(BaseModel):
     providers: EmbedderProvidersConfig = Field(default_factory=EmbedderProvidersConfig)
 
 
+class RerankerConfig(BaseModel):
+    """Cross-encoder reranker configuration."""
+
+    provider: Literal['auto', 'openai', 'azure_openai', 'gemini', 'bge'] = Field(
+        default='auto', description='Reranker provider'
+    )
+
+
 class Neo4jProviderConfig(BaseModel):
     """Neo4j provider configuration."""
 
@@ -277,6 +285,7 @@ class GraphitiConfig(BaseSettings):
     server: ServerConfig = Field(default_factory=ServerConfig)
     llm: LLMConfig = Field(default_factory=LLMConfig)
     embedder: EmbedderConfig = Field(default_factory=EmbedderConfig)
+    reranker: RerankerConfig = Field(default_factory=RerankerConfig)
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)
     graphiti: GraphitiAppConfig = Field(default_factory=GraphitiAppConfig)
 

--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -273,6 +273,12 @@ class GraphitiAppConfig(BaseModel):
     group_id: str = Field(default='main', description='Group ID')
     episode_id_prefix: str | None = Field(default='', description='Episode ID prefix')
     user_id: str = Field(default='mcp_user', description='User ID')
+    fact_reranker: Literal['rrf', 'cross_encoder'] = Field(
+        default='rrf', description='Reranking strategy used by search_memory_facts'
+    )
+    node_reranker: Literal['rrf', 'cross_encoder'] = Field(
+        default='rrf', description='Reranking strategy used by search_nodes'
+    )
     entity_types: list[EntityTypeConfig] = Field(default_factory=list)
     edge_types: list[EdgeTypeConfig] = Field(default_factory=list)
     edge_type_map: list[EdgeTypeMapEntry] = Field(default_factory=list)

--- a/mcp_server/src/config/schema.py
+++ b/mcp_server/src/config/schema.py
@@ -187,6 +187,10 @@ class RerankerConfig(BaseModel):
     provider: Literal['auto', 'openai', 'azure_openai', 'gemini', 'bge'] = Field(
         default='auto', description='Reranker provider'
     )
+    model: str | None = Field(
+        default=None,
+        description='Optional model override for API-backed rerankers',
+    )
 
 
 class Neo4jProviderConfig(BaseModel):

--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -221,7 +221,9 @@ class GraphitiService:
             # Create cross-encoder (reranker) client. Without this, Graphiti defaults to
             # OpenAIRerankerClient, which needs an OpenAI API key even on non-OpenAI setups.
             # Reranker setup errors must remain fatal rather than silently restoring that default.
-            cross_encoder_client = CrossEncoderFactory.create(self.config.llm, self.config.embedder)
+            cross_encoder_client = CrossEncoderFactory.create(
+                self.config.llm, self.config.embedder, self.config.reranker
+            )
 
             # Get database configuration
             db_config = DatabaseDriverFactory.create_config(self.config.database)

--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -544,15 +544,21 @@ async def search_nodes(
 
         # center_node_uuid is only honored by the node_distance reranker, so select
         # that recipe when a center node is given (mirroring core's Graphiti.search);
-        # otherwise use RRF.
+        # otherwise use the configured node recipe.
         from graphiti_core.search.search_config_recipes import (
+            NODE_HYBRID_SEARCH_CROSS_ENCODER,
             NODE_HYBRID_SEARCH_NODE_DISTANCE,
             NODE_HYBRID_SEARCH_RRF,
         )
 
-        node_config = (
-            NODE_HYBRID_SEARCH_NODE_DISTANCE if center_node_uuid else NODE_HYBRID_SEARCH_RRF
+        node_recipe = (
+            NODE_HYBRID_SEARCH_NODE_DISTANCE
+            if center_node_uuid
+            else NODE_HYBRID_SEARCH_CROSS_ENCODER
+            if config.graphiti.node_reranker == 'cross_encoder'
+            else NODE_HYBRID_SEARCH_RRF
         )
+        node_config = node_recipe.model_copy(update={'limit': max_nodes})
         results = await client.search_(
             query=query,
             config=node_config,
@@ -638,13 +644,28 @@ async def search_memory_facts(
             else []
         )
 
-        relevant_edges = await client.search(
+        from graphiti_core.search.search_config_recipes import (
+            EDGE_HYBRID_SEARCH_CROSS_ENCODER,
+            EDGE_HYBRID_SEARCH_NODE_DISTANCE,
+            EDGE_HYBRID_SEARCH_RRF,
+        )
+
+        edge_recipe = (
+            EDGE_HYBRID_SEARCH_NODE_DISTANCE
+            if center_node_uuid
+            else EDGE_HYBRID_SEARCH_CROSS_ENCODER
+            if config.graphiti.fact_reranker == 'cross_encoder'
+            else EDGE_HYBRID_SEARCH_RRF
+        )
+        edge_config = edge_recipe.model_copy(update={'limit': max_facts})
+        results = await client.search_(
             group_ids=effective_group_ids,
             query=query,
-            num_results=max_facts,
+            config=edge_config,
             center_node_uuid=center_node_uuid,
             search_filter=search_filter,
         )
+        relevant_edges = results.edges
 
         if not relevant_edges:
             return FactSearchResponse(message='No relevant facts found', facts=[])

--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -6,7 +6,7 @@ from graphiti_core.llm_client import LLMClient, OpenAIClient
 from graphiti_core.llm_client.config import LLMConfig as GraphitiLLMConfig
 from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
 
-from config.schema import DatabaseConfig, EmbedderConfig, LLMConfig
+from config.schema import DatabaseConfig, EmbedderConfig, LLMConfig, RerankerConfig
 
 # Try to import FalkorDriver if available
 try:
@@ -414,16 +414,39 @@ class CrossEncoderFactory:
     """Factory for creating cross-encoder (reranker) clients based on configuration.
 
     Graphiti defaults the cross_encoder to OpenAIRerankerClient, which needs an OpenAI API key.
-    To keep the server usable on non-OpenAI setups, pick a reranker from the LLM provider, then
-    the embedder provider, and fall back to the local BGE reranker.
+    To keep the server usable on non-OpenAI setups, honor an explicit reranker provider when
+    configured. Otherwise, pick one from the LLM provider, then the embedder provider, and fall
+    back to the local BGE reranker.
     """
 
     @staticmethod
-    def create(llm_config: LLMConfig, embedder_config: EmbedderConfig) -> CrossEncoderClient:
+    def create(
+        llm_config: LLMConfig,
+        embedder_config: EmbedderConfig,
+        reranker_config: RerankerConfig | None = None,
+    ) -> CrossEncoderClient:
         """Create a cross-encoder client based on the configured providers."""
         import logging
 
         logger = logging.getLogger(__name__)
+
+        provider = reranker_config.provider if reranker_config is not None else 'auto'
+        if provider != 'auto':
+            if provider == 'bge':
+                return CrossEncoderFactory._local_reranker(logger)
+
+            for source, config in (('LLM', llm_config), ('embedder', embedder_config)):
+                explicit_config = config.model_copy(update={'provider': provider})
+                reranker = CrossEncoderFactory._reranker_for_provider(
+                    source, explicit_config, logger
+                )
+                if reranker is not None:
+                    return reranker
+
+            raise ValueError(
+                f"Reranker provider '{provider}' is not configured under "
+                'llm.providers or embedder.providers'
+            )
 
         # Try the LLM provider first, then the embedder, before falling back to a local model.
         for source, config in (('LLM', llm_config), ('embedder', embedder_config)):
@@ -431,8 +454,11 @@ class CrossEncoderFactory:
             if reranker is not None:
                 return reranker
 
-        # No provider reranker available (e.g. Anthropic LLM + Voyage embedder), so use the
-        # local BGE cross-encoder, which needs no API key.
+        return CrossEncoderFactory._local_reranker(logger)
+
+    @staticmethod
+    def _local_reranker(logger) -> CrossEncoderClient:
+        """Create the local BGE fallback reranker."""
         logger.warning(
             'No provider reranker available, using local BGERerankerClient '
             '(downloads BAAI/bge-reranker-v2-m3, ~2.3 GB, on first run)'

--- a/mcp_server/src/services/factories.py
+++ b/mcp_server/src/services/factories.py
@@ -431,6 +431,7 @@ class CrossEncoderFactory:
         logger = logging.getLogger(__name__)
 
         provider = reranker_config.provider if reranker_config is not None else 'auto'
+        model = reranker_config.model if reranker_config is not None else None
         if provider != 'auto':
             if provider == 'bge':
                 return CrossEncoderFactory._local_reranker(logger)
@@ -438,7 +439,7 @@ class CrossEncoderFactory:
             for source, config in (('LLM', llm_config), ('embedder', embedder_config)):
                 explicit_config = config.model_copy(update={'provider': provider})
                 reranker = CrossEncoderFactory._reranker_for_provider(
-                    source, explicit_config, logger
+                    source, explicit_config, logger, model
                 )
                 if reranker is not None:
                     return reranker
@@ -450,7 +451,7 @@ class CrossEncoderFactory:
 
         # Try the LLM provider first, then the embedder, before falling back to a local model.
         for source, config in (('LLM', llm_config), ('embedder', embedder_config)):
-            reranker = CrossEncoderFactory._reranker_for_provider(source, config, logger)
+            reranker = CrossEncoderFactory._reranker_for_provider(source, config, logger, model)
             if reranker is not None:
                 return reranker
 
@@ -479,7 +480,10 @@ class CrossEncoderFactory:
 
     @staticmethod
     def _reranker_for_provider(
-        source: str, config: LLMConfig | EmbedderConfig, logger
+        source: str,
+        config: LLMConfig | EmbedderConfig,
+        logger,
+        model: str | None = None,
     ) -> CrossEncoderClient | None:
         """Return a reranker for this provider, or None if it has no native one."""
         provider = config.provider.lower()
@@ -497,6 +501,7 @@ class CrossEncoderFactory:
                     config=GraphitiLLMConfig(
                         api_key=config.providers.openai.api_key,
                         base_url=config.providers.openai.api_url,
+                        model=model,
                     )
                 )
 
@@ -517,7 +522,8 @@ class CrossEncoderFactory:
 
                 logger.info(f'Using OpenAIRerankerClient (Azure) from {source} provider')
                 return OpenAIRerankerClient(
-                    client=AsyncOpenAI(base_url=base_url, api_key=azure_config.api_key)
+                    config=GraphitiLLMConfig(model=model),
+                    client=AsyncOpenAI(base_url=base_url, api_key=azure_config.api_key),
                 )
 
             case 'gemini':
@@ -529,7 +535,10 @@ class CrossEncoderFactory:
 
                 logger.info(f'Using GeminiRerankerClient from {source} provider')
                 return GeminiRerankerClient(
-                    config=GraphitiLLMConfig(api_key=config.providers.gemini.api_key)
+                    config=GraphitiLLMConfig(
+                        api_key=config.providers.gemini.api_key,
+                        model=model,
+                    )
                 )
 
             case _:

--- a/mcp_server/tests/test_cross_encoder_factory.py
+++ b/mcp_server/tests/test_cross_encoder_factory.py
@@ -26,6 +26,7 @@ from config.schema import (
     LLMConfig,
     LLMProvidersConfig,
     OpenAIProviderConfig,
+    RerankerConfig,
     VoyageProviderConfig,
 )
 from services.factories import CrossEncoderFactory
@@ -57,6 +58,28 @@ class TestCrossEncoderFactory:
             providers=EmbedderProvidersConfig(gemini=GeminiProviderConfig(api_key='test-key')),
         )
         assert isinstance(CrossEncoderFactory.create(llm, embedder), GeminiRerankerClient)
+
+    def test_graphiti_config_accepts_explicit_reranker_provider(self):
+        config = GraphitiConfig(reranker={'provider': 'gemini'})
+
+        assert config.model_dump().get('reranker') == {'provider': 'gemini'}
+
+    def test_explicit_gemini_reranker_overrides_provider_inference(self):
+        llm = LLMConfig(
+            provider='openai',
+            providers=LLMProvidersConfig(
+                openai=OpenAIProviderConfig(api_key='openai-key'),
+                gemini=GeminiProviderConfig(api_key='gemini-key'),
+            ),
+        )
+        embedder = EmbedderConfig(
+            provider='openai',
+            providers=EmbedderProvidersConfig(openai=OpenAIProviderConfig(api_key='openai-key')),
+        )
+
+        reranker = CrossEncoderFactory.create(llm, embedder, RerankerConfig(provider='gemini'))
+
+        assert isinstance(reranker, GeminiRerankerClient)
 
     def test_missing_local_reranker_dependency_is_actionable(self, monkeypatch, caplog):
         llm = LLMConfig(
@@ -100,3 +123,35 @@ async def test_graphiti_service_does_not_swallow_reranker_configuration_error(mo
 
     with pytest.raises(ValueError, match='reranker setup failed'):
         await service.initialize()
+
+
+@pytest.mark.asyncio
+async def test_graphiti_service_uses_explicit_reranker_config(monkeypatch):
+    constructed = {}
+    fake_client = Mock()
+    fake_client.build_indices_and_constraints = AsyncMock()
+
+    def capture_graphiti(**kwargs):
+        constructed.update(kwargs)
+        return fake_client
+
+    monkeypatch.setattr(graphiti_mcp_server, 'Graphiti', capture_graphiti)
+    config = GraphitiConfig(
+        llm=LLMConfig(
+            provider='openai',
+            providers=LLMProvidersConfig(
+                openai=OpenAIProviderConfig(api_key='openai-key'),
+                gemini=GeminiProviderConfig(api_key='gemini-key'),
+            ),
+        ),
+        embedder=EmbedderConfig(
+            provider='openai',
+            providers=EmbedderProvidersConfig(openai=OpenAIProviderConfig(api_key='openai-key')),
+        ),
+        reranker=RerankerConfig(provider='gemini'),
+        database=DatabaseConfig(provider='neo4j'),
+    )
+
+    await graphiti_mcp_server.GraphitiService(config).initialize()
+
+    assert isinstance(constructed['cross_encoder'], GeminiRerankerClient)

--- a/mcp_server/tests/test_cross_encoder_factory.py
+++ b/mcp_server/tests/test_cross_encoder_factory.py
@@ -60,9 +60,12 @@ class TestCrossEncoderFactory:
         assert isinstance(CrossEncoderFactory.create(llm, embedder), GeminiRerankerClient)
 
     def test_graphiti_config_accepts_explicit_reranker_provider(self):
-        config = GraphitiConfig(reranker={'provider': 'gemini'})
+        config = GraphitiConfig(reranker={'provider': 'gemini', 'model': 'gemini-2.5-flash'})
 
-        assert config.model_dump().get('reranker') == {'provider': 'gemini'}
+        assert config.model_dump().get('reranker') == {
+            'provider': 'gemini',
+            'model': 'gemini-2.5-flash',
+        }
 
     def test_explicit_gemini_reranker_overrides_provider_inference(self):
         llm = LLMConfig(
@@ -80,6 +83,47 @@ class TestCrossEncoderFactory:
         reranker = CrossEncoderFactory.create(llm, embedder, RerankerConfig(provider='gemini'))
 
         assert isinstance(reranker, GeminiRerankerClient)
+
+    def test_explicit_reranker_model_is_passed_to_provider_client(self):
+        llm = LLMConfig(
+            provider='openai',
+            providers=LLMProvidersConfig(
+                openai=OpenAIProviderConfig(api_key='openai-key'),
+                gemini=GeminiProviderConfig(api_key='gemini-key'),
+            ),
+        )
+        embedder = EmbedderConfig(
+            provider='openai',
+            providers=EmbedderProvidersConfig(openai=OpenAIProviderConfig(api_key='openai-key')),
+        )
+
+        reranker = CrossEncoderFactory.create(
+            llm,
+            embedder,
+            RerankerConfig(provider='gemini', model='gemini-2.5-flash'),
+        )
+
+        assert isinstance(reranker, GeminiRerankerClient)
+        assert reranker.config.model == 'gemini-2.5-flash'
+
+    def test_reranker_model_applies_when_provider_is_inferred(self):
+        llm = LLMConfig(
+            provider='openai',
+            providers=LLMProvidersConfig(openai=OpenAIProviderConfig(api_key='openai-key')),
+        )
+        embedder = EmbedderConfig(
+            provider='openai',
+            providers=EmbedderProvidersConfig(openai=OpenAIProviderConfig(api_key='openai-key')),
+        )
+
+        reranker = CrossEncoderFactory.create(
+            llm,
+            embedder,
+            RerankerConfig(model='gpt-4.1-mini'),
+        )
+
+        assert isinstance(reranker, OpenAIRerankerClient)
+        assert reranker.config.model == 'gpt-4.1-mini'
 
     def test_missing_local_reranker_dependency_is_actionable(self, monkeypatch, caplog):
         llm = LLMConfig(

--- a/mcp_server/tests/test_search_reranker_config.py
+++ b/mcp_server/tests/test_search_reranker_config.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Unit tests for MCP search recipe selection."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+# Add the src directory to the path (mirrors the other MCP unit tests)
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+from graphiti_core.search.search_config import EdgeReranker, NodeReranker, SearchResults
+from graphiti_core.search.search_config_recipes import (
+    EDGE_HYBRID_SEARCH_CROSS_ENCODER,
+    NODE_HYBRID_SEARCH_CROSS_ENCODER,
+)
+
+import graphiti_mcp_server
+from config.schema import GraphitiConfig
+
+
+def install_fake_service(monkeypatch):
+    client = AsyncMock()
+    client.search_.return_value = SearchResults()
+    service = AsyncMock()
+    service.get_client.return_value = client
+    monkeypatch.setattr(graphiti_mcp_server, 'graphiti_service', service)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_search_nodes_uses_configured_cross_encoder_recipe(monkeypatch):
+    client = install_fake_service(monkeypatch)
+    monkeypatch.setattr(
+        graphiti_mcp_server,
+        'config',
+        GraphitiConfig(graphiti={'node_reranker': 'cross_encoder'}),
+        raising=False,
+    )
+
+    await graphiti_mcp_server.search_nodes('query', max_nodes=7)
+
+    search_config = client.search_.await_args.kwargs['config']
+    assert search_config.node_config.reranker is NodeReranker.cross_encoder
+    assert search_config.limit == 7
+    assert NODE_HYBRID_SEARCH_CROSS_ENCODER.limit == 10
+
+
+@pytest.mark.asyncio
+async def test_search_nodes_center_node_keeps_distance_recipe(monkeypatch):
+    client = install_fake_service(monkeypatch)
+    monkeypatch.setattr(
+        graphiti_mcp_server,
+        'config',
+        GraphitiConfig(graphiti={'node_reranker': 'cross_encoder'}),
+        raising=False,
+    )
+
+    await graphiti_mcp_server.search_nodes('query', center_node_uuid='center')
+
+    search_config = client.search_.await_args.kwargs['config']
+    assert search_config.node_config.reranker is NodeReranker.node_distance
+
+
+@pytest.mark.asyncio
+async def test_search_memory_facts_uses_configured_cross_encoder_recipe(monkeypatch):
+    client = install_fake_service(monkeypatch)
+    monkeypatch.setattr(
+        graphiti_mcp_server,
+        'config',
+        GraphitiConfig(graphiti={'fact_reranker': 'cross_encoder'}),
+        raising=False,
+    )
+
+    await graphiti_mcp_server.search_memory_facts('query', max_facts=8)
+
+    search_config = client.search_.await_args.kwargs['config']
+    assert search_config.edge_config.reranker is EdgeReranker.cross_encoder
+    assert search_config.limit == 8
+    assert EDGE_HYBRID_SEARCH_CROSS_ENCODER.limit == 10
+
+
+@pytest.mark.asyncio
+async def test_search_memory_facts_center_node_keeps_distance_recipe(monkeypatch):
+    client = install_fake_service(monkeypatch)
+    monkeypatch.setattr(
+        graphiti_mcp_server,
+        'config',
+        GraphitiConfig(graphiti={'fact_reranker': 'cross_encoder'}),
+        raising=False,
+    )
+
+    await graphiti_mcp_server.search_memory_facts('query', center_node_uuid='center')
+
+    search_config = client.search_.await_args.kwargs['config']
+    assert search_config.edge_config.reranker is EdgeReranker.node_distance


### PR DESCRIPTION
## Summary

- add explicit `reranker.provider` selection while preserving provider inference as the default
- add an optional `reranker.model` override for API-backed rerankers
- add independent `graphiti.fact_reranker` and `graphiti.node_reranker` recipe controls (`rrf` or `cross_encoder`)
- preserve node-distance reranking when `center_node_uuid` is supplied
- document YAML and environment-variable configuration

```yaml
reranker:
  provider: gemini
  model: gemini-2.5-flash

graphiti:
  fact_reranker: cross_encoder
  node_reranker: rrf
```

## Why

The MCP server previously inferred the cross-encoder provider and both MCP search tools selected RRF recipes, so an initialized cross encoder could remain unused. This makes provider/model selection explicit and lets operators activate cross-encoder reranking per search surface without changing the default behavior.

## Compatibility

All new settings default to existing behavior:

- provider inference remains `auto`
- provider-client default models remain unchanged when `reranker.model` is omitted
- both search tools remain on RRF unless explicitly configured
- centered searches retain node-distance reranking

## Validation

- 71 relevant MCP unit tests pass
- changed MCP source files pass Pyright
- repository Ruff lint and format checks pass

Supersedes #1698 and carries forward the original July implementation commit with its authorship and history intact.

Closes #1697.