### PR TITLE
fix: settle bounded gather tasks before propagating failures

### DIFF
--- a/graphiti_core/helpers.py
+++ b/graphiti_core/helpers.py
@@ -124,13 +124,26 @@ async def semaphore_gather(
     *coroutines: Coroutine,
     max_coroutines: int | None = None,
 ) -> list[Any]:
+    """Run bounded concurrent work, settling owned coroutines before returning an error."""
     semaphore = asyncio.Semaphore(max_coroutines or SEMAPHORE_LIMIT)
 
     async def _wrap_coroutine(coroutine):
         async with semaphore:
             return await coroutine
 
-    return await asyncio.gather(*(_wrap_coroutine(coroutine) for coroutine in coroutines))
+    tasks = [asyncio.create_task(_wrap_coroutine(coroutine)) for coroutine in coroutines]
+    try:
+        return await asyncio.gather(*tasks)
+    except BaseException:
+        # gather() does not cancel siblings when one child fails or is cancelled.
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+    finally:
+        # Wrappers cancelled before acquiring a slot never await their inputs.
+        for coroutine in coroutines:
+            coroutine.close()
 
 
 def validate_group_id(group_id: str | None) -> bool:

--- a/tests/test_semaphore_gather.py
+++ b/tests/test_semaphore_gather.py
@@ -1,0 +1,109 @@
+import asyncio
+import inspect
+from unittest.mock import Mock
+
+import pytest
+
+from graphiti_core.cross_encoder.client import CrossEncoderClient
+from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.embedder.client import EmbedderClient
+from graphiti_core.graphiti import Graphiti
+from graphiti_core.helpers import semaphore_gather
+from graphiti_core.llm_client.client import LLMClient
+
+
+@pytest.mark.parametrize('error_type', [RuntimeError, asyncio.CancelledError])
+async def test_search_drains_sibling_queries_on_failure(monkeypatch, error_type):
+    sibling_started = asyncio.Event()
+    sibling_closed = asyncio.Event()
+    sibling_tasks = []
+    error = error_type('query failed')
+
+    async def failing_query(*args, **kwargs):
+        await sibling_started.wait()
+        raise error
+
+    async def pending_query(*args, **kwargs):
+        sibling_tasks.append(asyncio.current_task())
+        sibling_started.set()
+        try:
+            await asyncio.Future()
+        finally:
+            await asyncio.sleep(0)
+            sibling_closed.set()
+
+    monkeypatch.setattr('graphiti_core.search.search.edge_fulltext_search', failing_query)
+    monkeypatch.setattr('graphiti_core.search.search.edge_similarity_search', pending_query)
+    driver = Mock(spec=GraphDriver, provider=GraphProvider.NEO4J)
+    embedder = Mock(spec=EmbedderClient)
+    embedder.create.return_value = [0.1, 0.2]
+    graphiti = Graphiti(
+        graph_driver=driver,
+        llm_client=Mock(spec=LLMClient),
+        embedder=embedder,
+        cross_encoder=Mock(spec=CrossEncoderClient),
+    )
+
+    try:
+        with pytest.raises(error_type) as exc_info:
+            await graphiti.search('where does Alice work?')
+
+        assert exc_info.value is error
+        assert sibling_closed.is_set()
+        assert all(task.done() for task in sibling_tasks)
+    finally:
+        for task in sibling_tasks:
+            task.cancel()
+        await asyncio.gather(*sibling_tasks, return_exceptions=True)
+
+
+async def test_cancel_closes_coroutines_waiting_for_a_slot():
+    started = asyncio.Event()
+    closed = asyncio.Event()
+
+    async def active():
+        started.set()
+        try:
+            await asyncio.Future()
+        finally:
+            closed.set()
+
+    async def queued():
+        pytest.fail('The queued coroutine must not run')
+
+    active_coro, queued_coro = active(), queued()
+    task = asyncio.create_task(semaphore_gather(active_coro, queued_coro, max_coroutines=1))
+    try:
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert closed.is_set()
+        assert inspect.getcoroutinestate(queued_coro) == inspect.CORO_CLOSED
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        active_coro.close()
+        queued_coro.close()
+
+
+async def test_results_preserve_order_and_concurrency_limit():
+    active = 0
+    peak = 0
+
+    async def worker(index):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        try:
+            await asyncio.sleep(0)
+            return index
+        finally:
+            active -= 1
+
+    assert await semaphore_gather(*(worker(i) for i in range(5)), max_coroutines=2) == list(
+        range(5)
+    )
+    assert peak == 2
+    assert active == 0


### PR DESCRIPTION
## Summary

When one hybrid-search query fails or raises `CancelledError`, `Graphiti.search()` can return while sibling queries are still running. A cancelled bounded gather also leaves input coroutines that never acquired a semaphore slot unclosed.

Track the wrapper tasks, cancel and await them before propagating an error, and close the input coroutines after they have settled. This preserves the original exception, result ordering, and concurrency limit. It does not roll back database work that already completed.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective

Keep the lifetime of owned parallel operations within the call that started them, so callers can handle a failed search without leaving its queries running in the background. No public signature, database schema, or configuration changes.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

Python 3.13.14 on Windows:

- Original implementation: 3 failing regressions and 1 passing success case. Two regressions call the public `Graphiti.search()` with event-controlled fulltext/vector query replacements; the third checks closure of an input waiting for a semaphore slot.
- Focused helper/search/request-scope tests: **41 passed**.
- The no-database unit command from `.github/workflows/unit_tests.yml`, with all four database drivers disabled and the same ignore list: **386 passed, 11 skipped**.
- Whole-core Ruff and changed-file formatting/type checks pass.
- Full-project Pyright reports the same five diagnostics on unchanged main with this environment: missing optional sentence-transformers/Kuzu types and an Anthropic SDK overload mismatch. No live database or model-provider tests were run; the full lint/integration checkboxes therefore remain unchecked.

## Breaking Changes
- [ ] This PR contains breaking changes

Failure cleanup now waits for sibling coroutines to settle before re-raising the original error. Successful execution retains the existing behavior.

## Checklist
- [ ] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

The helper docstring documents error cleanup; public interfaces are unchanged. The full lint limitation is described above.

## Related Issues
Closes #1860
