### PR TITLE
fix: preserve disjoint temporal occurrences and finalize edge intervals

### DIFF
--- a/graphiti_core/utils/maintenance/edge_operations.py
+++ b/graphiti_core/utils/maintenance/edge_operations.py
@@ -342,7 +342,9 @@ async def resolve_extracted_edges(
         - new_edges: Only edges that are new to the graph (not duplicates of existing edges)
     """
     # Fast path: deduplicate exact matches within the extracted edges before parallel processing
-    seen: dict[tuple[str, str, str], EntityEdge] = {}
+    seen: dict[
+        tuple[str, str, str, datetime | None, datetime | None, datetime | None], EntityEdge
+    ] = {}
     deduplicated_edges: list[EntityEdge] = []
 
     for edge in extracted_edges:
@@ -350,6 +352,12 @@ async def resolve_extracted_edges(
             edge.source_node_uuid,
             edge.target_node_uuid,
             _normalize_string_exact(edge.fact),
+            ensure_utc(edge.valid_at),
+            ensure_utc(edge.invalid_at),
+            # Unresolved dates still depend on the source episode's clock.
+            ensure_utc(edge.reference_time)
+            if edge.valid_at is None and edge.invalid_at is None
+            else None,
         )
         if key not in seen:
             seen[key] = edge
@@ -587,12 +595,13 @@ async def _extract_edge_timestamps(
     if edge.valid_at is not None or edge.invalid_at is not None:
         return
 
-    if episode is None or episode.valid_at is None:
+    reference_time = edge.reference_time or (episode.valid_at if episode is not None else None)
+    if reference_time is None:
         return
 
     context = {
         'fact': edge.fact,
-        'reference_time': episode.valid_at.isoformat(),
+        'reference_time': reference_time.isoformat(),
     }
     try:
         llm_response = await llm_client.generate_response(
@@ -618,6 +627,23 @@ async def _extract_edge_timestamps(
                 logger.debug(f'Error parsing invalid_at: {timestamps.invalid_at}')
     except Exception:
         logger.warning('Failed to extract timestamps for edge %s', edge.uuid, exc_info=True)
+
+
+def _can_share_temporal_identity(left: EntityEdge, right: EntityEdge) -> bool:
+    """Reject duplicate identities for separate or unplaceable bounded intervals.
+
+    Facts occupy half-open valid-time intervals. Equal wording does not make
+    two occurrences separated by a known end the same occurrence. An unknown
+    start cannot establish overlap with an ended fact. Overlapping and wholly
+    undated facts retain the existing semantic duplicate-detection behavior.
+    """
+    left_start, left_end = ensure_utc(left.valid_at), ensure_utc(left.invalid_at)
+    right_start, right_end = ensure_utc(right.valid_at), ensure_utc(right.invalid_at)
+    if (left_start, left_end) == (right_start, right_end):
+        return True
+    if left_end is not None and (right_start is None or left_end <= right_start):
+        return False
+    return not (right_end is not None and (left_start is None or right_end <= left_start))
 
 
 async def resolve_extracted_edge(
@@ -648,7 +674,7 @@ async def resolve_extracted_edge(
     Returns
     -------
     tuple[EntityEdge, list[EntityEdge], list[EntityEdge]]
-        The resolved edge, any duplicates, and edges to invalidate.
+        The resolved edge, edges to invalidate, and any duplicates.
     """
     if len(related_edges) == 0 and len(existing_edges) == 0:
         # Still extract custom attributes and timestamps even when no dedup needed
@@ -679,7 +705,21 @@ async def resolve_extracted_edge(
 
         await _extract_edge_timestamps(llm_client, extracted_edge, episode)
 
+        if extracted_edge.invalid_at is not None and extracted_edge.expired_at is None:
+            extracted_edge.expired_at = utc_now()
+
         return extracted_edge, [], []
+
+    # Resolve missing dates before deciding whether an ended occurrence can be
+    # reused. Keep the undated/open-interval fast path free of extra model calls.
+    timestamps_extracted = False
+    if (
+        extracted_edge.valid_at is None
+        and extracted_edge.invalid_at is None
+        and any(edge.invalid_at is not None for edge in related_edges)
+    ):
+        await _extract_edge_timestamps(llm_client, extracted_edge, episode)
+        timestamps_extracted = True
 
     # Fast path: if the fact text and endpoints already exist verbatim, reuse the matching edge.
     normalized_fact = _normalize_string_exact(extracted_edge.fact)
@@ -688,6 +728,7 @@ async def resolve_extracted_edge(
             edge.source_node_uuid == extracted_edge.source_node_uuid
             and edge.target_node_uuid == extracted_edge.target_node_uuid
             and _normalize_string_exact(edge.fact) == normalized_fact
+            and _can_share_temporal_identity(edge, extracted_edge)
         ):
             resolved = edge
             if episode is not None and episode.uuid not in resolved.episodes:
@@ -741,7 +782,12 @@ async def resolve_extracted_edge(
             len(related_edges) - 1,
         )
 
-    duplicate_fact_ids: list[int] = [i for i in duplicate_facts if 0 <= i < len(related_edges)]
+    duplicate_fact_ids: list[int] = [
+        i
+        for i in duplicate_facts
+        if 0 <= i < len(related_edges)
+        and _can_share_temporal_identity(related_edges[i], extracted_edge)
+    ]
 
     resolved_edge = extracted_edge
     for duplicate_fact_id in duplicate_fact_ids:
@@ -809,7 +855,7 @@ async def resolve_extracted_edge(
         resolved_edge.attributes = {}
 
     # Extract timestamps for new edges (duplicated edges retain their existing timestamps)
-    if resolved_edge.uuid == extracted_edge.uuid:
+    if resolved_edge.uuid == extracted_edge.uuid and not timestamps_extracted:
         await _extract_edge_timestamps(llm_client, resolved_edge, episode)
 
     end = time()
@@ -822,21 +868,25 @@ async def resolve_extracted_edge(
     if resolved_edge.invalid_at and not resolved_edge.expired_at:
         resolved_edge.expired_at = now
 
-    # Determine if the new_edge needs to be expired
-    if resolved_edge.expired_at is None:
-        invalidation_candidates.sort(key=lambda c: (c.valid_at is None, ensure_utc(c.valid_at)))
-        for candidate in invalidation_candidates:
-            candidate_valid_at_utc = ensure_utc(candidate.valid_at)
-            resolved_edge_valid_at_utc = ensure_utc(resolved_edge.valid_at)
-            if (
-                candidate_valid_at_utc is not None
-                and resolved_edge_valid_at_utc is not None
-                and candidate_valid_at_utc > resolved_edge_valid_at_utc
-            ):
-                # Expire new edge since we have information about more recent events
-                resolved_edge.invalid_at = candidate.valid_at
-                resolved_edge.expired_at = now
-                break
+    # Event-time bounds can be tightened even if this fact was already expired
+    # in transaction time. Never extend an existing validity interval.
+    invalidation_candidates.sort(key=lambda c: (c.valid_at is None, ensure_utc(c.valid_at)))
+    for candidate in invalidation_candidates:
+        candidate_valid_at_utc = ensure_utc(candidate.valid_at)
+        resolved_edge_valid_at_utc = ensure_utc(resolved_edge.valid_at)
+        resolved_edge_invalid_at_utc = ensure_utc(resolved_edge.invalid_at)
+        if (
+            candidate_valid_at_utc is not None
+            and resolved_edge_valid_at_utc is not None
+            and candidate_valid_at_utc > resolved_edge_valid_at_utc
+            and (
+                resolved_edge_invalid_at_utc is None
+                or candidate_valid_at_utc < resolved_edge_invalid_at_utc
+            )
+        ):
+            resolved_edge.invalid_at = candidate.valid_at
+            resolved_edge.expired_at = resolved_edge.expired_at or now
+            break
 
     # Determine which contradictory edges need to be expired
     invalidated_edges: list[EntityEdge] = resolve_edge_contradictions(

--- a/tests/utils/maintenance/test_edge_temporal_identity.py
+++ b/tests/utils/maintenance/test_edge_temporal_identity.py
@@ -1,0 +1,150 @@
+"""Repeated wording must not erase a distinct occurrence of a fact."""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from graphiti_core.edges import EntityEdge
+from graphiti_core.nodes import EntityNode, EpisodicNode
+from graphiti_core.search.search_config import SearchResults
+from graphiti_core.utils.maintenance import edge_operations as ops
+
+START = datetime(2026, 1, 1, tzinfo=timezone.utc)
+FACT = 'Kiran is assigned to Payments.'
+
+
+def fact(start, end=None, *, wording=FACT, reference=None):
+    return EntityEdge(
+        source_node_uuid='person',
+        target_node_uuid='project',
+        name='ASSIGNED',
+        group_id='temporal-test',
+        fact=wording,
+        episodes=['source-episode'],
+        created_at=START + timedelta(days=30),
+        valid_at=START + timedelta(days=start) if start is not None else None,
+        invalid_at=START + timedelta(days=end) if end is not None else None,
+        expired_at=START + timedelta(days=20) if end is not None else None,
+        reference_time=reference,
+    )
+
+
+@pytest.fixture
+def episode():
+    return EpisodicNode(
+        uuid='new-episode',
+        name='Temporal evidence',
+        content='Supplied temporal fixture.',
+        group_id='temporal-test',
+        source='message',
+        source_description='unit test',
+        valid_at=START + timedelta(days=30),
+    )
+
+
+@pytest.mark.parametrize(
+    'old_window,new_window',
+    [
+        ((0, 5), (10, None)),
+        ((10, None), (0, 5)),
+        ((0, 10), (10, None)),
+        ((10, None), (0, 10)),
+    ],
+)
+@pytest.mark.parametrize('exact_wording', [False, True])
+async def test_duplicate_decision_cannot_erase_disjoint_occurrence(
+    episode,
+    old_window,
+    new_window,
+    exact_wording,
+):
+    old = fact(*old_window)
+    incoming = fact(*new_window, wording=FACT if exact_wording else 'Kiran works on Payments.')
+    before = old.model_dump()
+    client = MagicMock()
+    client.generate_response = AsyncMock(
+        return_value={'duplicate_facts': [0], 'contradicted_facts': []}
+    )
+
+    resolved, invalidated, duplicates = await ops.resolve_extracted_edge(
+        client,
+        incoming,
+        [old],
+        [],
+        episode,
+    )
+
+    assert resolved is incoming
+    assert old.model_dump() == before
+    assert resolved.valid_at == incoming.valid_at
+    assert resolved.invalid_at == incoming.invalid_at
+    assert invalidated == duplicates == []
+
+
+@pytest.mark.parametrize(
+    'old_window,new_window',
+    [
+        ((0, None), (5, None)),
+        ((0, 10), (5, 8)),
+        ((None, None), (None, None)),
+    ],
+)
+async def test_overlapping_restatement_retains_existing_fast_path(episode, old_window, new_window):
+    old, incoming = fact(*old_window), fact(*new_window)
+    client = MagicMock()
+    client.generate_response = AsyncMock(side_effect=AssertionError('Unexpected model call'))
+
+    resolved, invalidated, duplicates = await ops.resolve_extracted_edge(
+        client,
+        incoming,
+        [old],
+        [],
+        episode,
+    )
+
+    assert resolved is old
+    assert resolved.episodes.count(episode.uuid) == 1
+    assert invalidated == duplicates == []
+    client.generate_response.assert_not_awaited()
+
+
+@pytest.mark.parametrize('windows', [((0, 5), (10, None)), ((0, 10), (10, None))])
+@pytest.mark.parametrize('reverse', [False, True])
+async def test_batch_retains_separate_validity_periods(monkeypatch, episode, windows, reverse):
+    edges = [fact(*window) for window in windows]
+    if reverse:
+        edges.reverse()
+    result = await run_batch(monkeypatch, episode, edges)
+    assert [edge.uuid for edge in result[0]] == [edge.uuid for edge in edges]
+    assert [edge.uuid for edge in result[2]] == [edge.uuid for edge in edges]
+    assert result[1] == []
+
+
+@pytest.mark.parametrize('dated', [False, True])
+async def test_batch_preserves_reference_until_dates_are_known(monkeypatch, episode, dated):
+    # Combined extraction may leave dates unresolved while retaining the source
+    # episode's reference clock. Different clocks must reach timestamp extraction.
+    start, end = (0, 5) if dated else (None, None)
+    edges = [
+        fact(start, end, reference=START),
+        fact(start, end, reference=START + timedelta(days=10)),
+    ]
+    resolved, invalidated, new = await run_batch(monkeypatch, episode, edges)
+    assert len(resolved) == len(new) == (1 if dated else 2)
+    assert invalidated == []
+
+
+async def run_batch(monkeypatch, episode, edges):
+    client = MagicMock()
+    client.generate_response = AsyncMock(return_value={'valid_at': None, 'invalid_at': None})
+    clients = SimpleNamespace(driver=MagicMock(), llm_client=client, embedder=MagicMock())
+    nodes = [
+        EntityNode(uuid='person', name='Kiran', group_id='temporal-test'),
+        EntityNode(uuid='project', name='Payments', group_id='temporal-test'),
+    ]
+    monkeypatch.setattr(EntityEdge, 'get_between_nodes', AsyncMock(return_value=[]))
+    monkeypatch.setattr(ops, 'search', AsyncMock(return_value=SearchResults()))
+    monkeypatch.setattr(ops, 'create_entity_edge_embeddings', AsyncMock(return_value=None))
+    return await ops.resolve_extracted_edges(clients, edges, episode, nodes, {}, {})

--- a/tests/utils/maintenance/test_edge_temporal_resolution.py
+++ b/tests/utils/maintenance/test_edge_temporal_resolution.py
@@ -1,0 +1,247 @@
+"""Temporal bookkeeping regressions with deterministic, already classified facts."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from graphiti_core.edges import EntityEdge
+from graphiti_core.nodes import EpisodicNode
+from graphiti_core.utils.maintenance import edge_operations
+
+START = datetime(2026, 1, 1, tzinfo=timezone.utc)
+NOW = START + timedelta(days=10)
+
+
+def make_edge(fact, *, valid_at=START, invalid_at=None, expired_at=None):
+    return EntityEdge(
+        source_node_uuid='person',
+        target_node_uuid='project',
+        name='ASSIGNED_TO',
+        group_id='temporal-test',
+        fact=fact,
+        created_at=NOW,
+        valid_at=valid_at,
+        invalid_at=invalid_at,
+        expired_at=expired_at,
+    )
+
+
+@pytest.fixture
+def episode():
+    return EpisodicNode(
+        uuid='episode',
+        name='Retrospective update',
+        content='Known dates are supplied directly by the regression fixture.',
+        group_id='temporal-test',
+        source='message',
+        source_description='unit test',
+        valid_at=NOW,
+    )
+
+
+@pytest.fixture
+def llm_client():
+    client = MagicMock()
+    client.generate_response = AsyncMock(
+        return_value={'duplicate_facts': [], 'contradicted_facts': []}
+    )
+    return client
+
+
+@pytest.mark.parametrize('with_context', [False, True])
+@pytest.mark.parametrize('previous_expiration', [None, START + timedelta(days=7)])
+async def test_ended_fact_expiration_does_not_depend_on_unrelated_context(
+    monkeypatch, episode, llm_client, with_context, previous_expiration
+):
+    monkeypatch.setattr(edge_operations, 'utc_now', lambda: NOW)
+    end = START + timedelta(days=5)
+    incoming = make_edge('The assignment ended.', invalid_at=end, expired_at=previous_expiration)
+    context = [make_edge('The project has a website.')] if with_context else []
+
+    resolved, invalidated, duplicates = await edge_operations.resolve_extracted_edge(
+        llm_client, incoming, [], context, episode
+    )
+
+    assert resolved is incoming
+    assert resolved.valid_at == START
+    assert resolved.invalid_at == end
+    assert resolved.expired_at == (previous_expiration or NOW)
+    assert invalidated == []
+    assert duplicates == []
+    assert llm_client.generate_response.await_count == int(with_context)
+
+
+@pytest.mark.parametrize('previous_expiration', [None, START + timedelta(days=7)])
+async def test_finite_older_fact_is_clipped_at_known_later_contradiction(
+    monkeypatch, episode, llm_client, previous_expiration
+):
+    monkeypatch.setattr(edge_operations, 'utc_now', lambda: NOW)
+    incoming = make_edge(
+        'Kiran was assigned to Payments.',
+        invalid_at=START + timedelta(days=5),
+        expired_at=previous_expiration,
+    )
+    replacement = make_edge('Kiran was released from Payments.', valid_at=START + timedelta(days=3))
+    llm_client.generate_response.return_value['contradicted_facts'] = [0]
+
+    resolved, invalidated, duplicates = await edge_operations.resolve_extracted_edge(
+        llm_client, incoming, [], [replacement], episode
+    )
+
+    assert resolved is incoming
+    assert resolved.valid_at == START
+    assert resolved.invalid_at == replacement.valid_at
+    assert resolved.expired_at == (previous_expiration or NOW)
+    assert replacement.invalid_at is None
+    assert replacement.expired_at is None
+    assert invalidated == []
+    assert duplicates == []
+    llm_client.generate_response.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    'replacement_start', [START + timedelta(days=5), START + timedelta(days=6)]
+)
+async def test_later_contradiction_cannot_extend_a_closed_interval(
+    monkeypatch, episode, llm_client, replacement_start
+):
+    monkeypatch.setattr(edge_operations, 'utc_now', lambda: NOW)
+    end = START + timedelta(days=5)
+    incoming = make_edge('Kiran was assigned to Payments.', invalid_at=end)
+    replacement = make_edge('Kiran was released from Payments.', valid_at=replacement_start)
+    llm_client.generate_response.return_value['contradicted_facts'] = [0]
+
+    resolved, invalidated, duplicates = await edge_operations.resolve_extracted_edge(
+        llm_client, incoming, [], [replacement], episode
+    )
+
+    assert resolved.invalid_at == end
+    assert resolved.expired_at == NOW
+    assert replacement.invalid_at is None
+    assert replacement.expired_at is None
+    assert invalidated == []
+    assert duplicates == []
+
+
+async def test_unknown_later_fact_start_does_not_supply_an_invalidation_boundary(
+    monkeypatch, episode, llm_client
+):
+    monkeypatch.setattr(edge_operations, 'utc_now', lambda: NOW)
+    end = START + timedelta(days=5)
+    incoming = make_edge('Kiran was assigned to Payments.', invalid_at=end)
+    unknown_start = make_edge(
+        'Kiran was released from Payments.', valid_at=None, invalid_at=START + timedelta(days=3)
+    )
+    llm_client.generate_response.return_value['contradicted_facts'] = [0]
+
+    resolved, invalidated, duplicates = await edge_operations.resolve_extracted_edge(
+        llm_client, incoming, [], [unknown_start], episode
+    )
+
+    assert resolved.invalid_at == end
+    assert resolved.expired_at == NOW
+    assert unknown_start.valid_at is None
+    assert unknown_start.invalid_at == START + timedelta(days=3)
+    assert invalidated == []
+    assert duplicates == []
+
+
+@pytest.mark.parametrize('same_wording', [False, True])
+async def test_timestamp_fallback_can_confirm_an_existing_historical_occurrence(
+    monkeypatch, episode, llm_client, same_wording
+):
+    monkeypatch.setattr(edge_operations, 'utc_now', lambda: NOW)
+    end = START + timedelta(days=5)
+    existing = make_edge('Kiran was assigned to Payments.', invalid_at=end, expired_at=NOW)
+    incoming = make_edge(
+        existing.fact if same_wording else 'Kiran worked on Payments.', valid_at=None
+    )
+    calls = []
+
+    async def respond(*args, **kwargs):
+        calls.append(kwargs['prompt_name'])
+        if kwargs['prompt_name'] == 'extract_edges.extract_timestamps':
+            return {'valid_at': START.isoformat(), 'invalid_at': end.isoformat()}
+        assert kwargs['prompt_name'] == 'dedupe_edges.resolve_edge'
+        return {'duplicate_facts': [0], 'contradicted_facts': []}
+
+    llm_client.generate_response.side_effect = respond
+
+    resolved, invalidated, duplicates = await edge_operations.resolve_extracted_edge(
+        llm_client, incoming, [existing], [], episode
+    )
+
+    assert resolved is existing
+    assert resolved.valid_at == START
+    assert resolved.invalid_at == end
+    assert resolved.expired_at == NOW
+    assert invalidated == []
+    assert duplicates == ([] if same_wording else [existing])
+    assert calls.count('extract_edges.extract_timestamps') == 1
+    assert calls.count('dedupe_edges.resolve_edge') == int(not same_wording)
+
+
+async def test_unresolved_timestamp_fallback_is_not_repeated_or_treated_as_overlap(
+    episode, llm_client
+):
+    end = START + timedelta(days=5)
+    existing = make_edge('Kiran was assigned to Payments.', invalid_at=end, expired_at=NOW)
+    incoming = make_edge(existing.fact, valid_at=None)
+    calls = []
+
+    async def respond(*args, **kwargs):
+        calls.append(kwargs['prompt_name'])
+        if kwargs['prompt_name'] == 'extract_edges.extract_timestamps':
+            return {'valid_at': None, 'invalid_at': None}
+        assert kwargs['prompt_name'] == 'dedupe_edges.resolve_edge'
+        return {'duplicate_facts': [0], 'contradicted_facts': []}
+
+    llm_client.generate_response.side_effect = respond
+
+    resolved, invalidated, duplicates = await edge_operations.resolve_extracted_edge(
+        llm_client, incoming, [existing], [], episode
+    )
+
+    assert resolved is incoming
+    assert resolved.valid_at is None
+    assert resolved.invalid_at is None
+    assert resolved.expired_at is None
+    assert existing.invalid_at == end
+    assert existing.expired_at == NOW
+    assert invalidated == []
+    assert duplicates == []
+    assert calls.count('extract_edges.extract_timestamps') == 1
+    assert calls.count('dedupe_edges.resolve_edge') == 1
+
+
+@pytest.mark.parametrize(
+    ('edge_reference', 'with_episode', 'expected_reference'),
+    [
+        (START + timedelta(days=2), True, START + timedelta(days=2)),
+        (None, True, NOW),
+        (START + timedelta(days=2), False, START + timedelta(days=2)),
+        (None, False, None),
+    ],
+)
+async def test_timestamp_fallback_uses_the_attributed_episode_reference(
+    episode, llm_client, edge_reference, with_episode, expected_reference
+):
+    incoming = make_edge('Kiran is assigned to Payments.', valid_at=None)
+    incoming.reference_time = edge_reference
+    llm_client.generate_response.return_value = {'valid_at': None, 'invalid_at': None}
+
+    await edge_operations._extract_edge_timestamps(
+        llm_client, incoming, episode if with_episode else None
+    )
+
+    assert incoming.valid_at is None
+    assert incoming.invalid_at is None
+    if expected_reference is None:
+        llm_client.generate_response.assert_not_awaited()
+    else:
+        llm_client.generate_response.assert_awaited_once()
+        actual_prompt = str(llm_client.generate_response.await_args.args[0])
+        assert expected_reference.isoformat() in actual_prompt
+        if expected_reference != NOW:
+            assert NOW.isoformat() not in actual_prompt


### PR DESCRIPTION
## Summary

Repeating an assignment after its earlier occurrence ended can return the expired historical edge and discard the new interval. Preserve distinct temporal occurrences through exact matching, semantic duplicate selection and batch deduplication, including the source reference clock while dates remain unresolved.

The resolver now enriches missing dates before historical identity selection, finalizes expiration metadata without requiring unrelated context, and clips an older finite interval at a known later contradiction. Clipping preserves prior transaction expiration and cannot extend the interval. Compatible duplicates and unavailable-date controls remain covered. The runnable before/after example and scope are in #1865.

## Type of Change

- [x] Bug fix
- [x] Documentation/Tests

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass

Added 33 regression cases covering identity, recurrence, touching/disjoint intervals, batch ordering, finite clipping, expiration and timestamp references. All 33 pass. Facts, timestamps and model decisions are supplied fixtures; this does not test natural-language extraction.

The published branch at `1e6289c1ee40c42dc588791217e3ee0efc175826` independently passes the repository's no-database unit gate: **415 passed, 11 skipped**. Imports were verified against that checkout. Core + new-test Ruff, formatting of the three changed files, and resolver Pyright pass (0 errors/warnings). Windows/Python 3.12.14 with a fresh workspace-local pytest temporary directory.

Focused regression command:

```sh
pytest tests/utils/maintenance/test_edge_temporal_identity.py tests/utils/maintenance/test_edge_temporal_resolution.py -q
```

Additional combined-candidate validation, with the independent Neo4j datetime correction in #1866 also applied: 430 unit tests passed, 11 skipped; 26/26 declared valid-time query assertions passed across two real query paths on Neo4j 5.26.30, versus 16/26 on baseline. These are 13 fixture timepoints, not model accuracy or isolated PR results.

Follow-up [Linux / Neo4j 5.26.30 validation](https://github.com/thantiklermcirony/graphiti/actions/runs/34410688322) completes all four declared database cases, including the previously blocked fulltext-dependent batch case: baseline failures reproduce and the combined candidate containing this PR and #1866 passes. These remain combined-candidate database results, not isolated evidence for this PR or an LLM-quality benchmark. Upstream PR CI is a separate gate.

## Breaking Changes

- [ ] This PR contains breaking changes

No schema or public API change. Unknown starts remain unknown; this is not complete interval algebra. The end-only RELEASED extraction report in #1841 remains unresolved. This PR is independent of #1866 and does not change database timestamp parsing.

## Checklist

- [ ] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [x] Documentation updated where necessary
- [x] No secrets or sensitive information committed

Full-core Pyright has seven identical optional-integration diagnostics on the original baseline and combined candidate; a complete `make lint` pass is not claimed. Upstream main advanced to `6a412ae` during submission with only container-release workflow/server README changes; the touched source and contribution guidelines are unchanged and GitHub reports this branch mergeable.

## Related Issues

Closes #1865
