### PR TITLE
fix(gemini): default thinking_budget=0 for gemini-2.5 when unset

### DIFF
--- a/graphiti_core/llm_client/gemini_client.py
+++ b/graphiti_core/llm_client/gemini_client.py
@@ -69,6 +69,28 @@ GEMINI_MODEL_MAX_TOKENS = {
 DEFAULT_GEMINI_MAX_TOKENS = 8192
 
 
+def _is_gemini_2_5_model(model: str | None) -> bool:
+    """Return True for Gemini 2.5 models, which enable thinking when unset."""
+    return bool(model) and 'gemini-2.5-' in model
+
+
+def _resolve_thinking_config(
+    thinking_config: types.ThinkingConfig | None, model: str | None
+) -> types.ThinkingConfig | None:
+    """Resolve thinking_config, defaulting gemini-2.5-* to thinking off.
+
+    Gemini 2.5 treats ``thinking_config=None`` as thinking ON, and thinking
+    tokens share the output budget with the structured JSON answer. When the
+    caller does not pass a config, disable thinking so extraction is not
+    truncated mid-object. An explicit ``thinking_config`` always wins.
+    """
+    if thinking_config is not None:
+        return thinking_config
+    if _is_gemini_2_5_model(model):
+        return types.ThinkingConfig(thinking_budget=0)
+    return None
+
+
 class GeminiClient(LLMClient):
     """
     GeminiClient is a client class for interacting with Google's Gemini language models.
@@ -107,7 +129,9 @@ class GeminiClient(LLMClient):
             config (LLMConfig | None): The configuration for the LLM client, including API key, model, temperature, and max tokens.
             cache (bool): Whether to use caching for responses. Defaults to False.
             thinking_config (types.ThinkingConfig | None): Optional thinking configuration for models that support it.
-                Only use with models that support thinking (gemini-2.5+). Defaults to None.
+                For gemini-2.5-* models, None defaults to ThinkingConfig(thinking_budget=0) so
+                thinking does not consume the structured-output budget. Pass an explicit
+                ThinkingConfig to enable thinking. Other models leave thinking_config unset.
             client (genai.Client | None): An optional async client instance to use. If not provided, a new genai.Client is created.
         """
         if config is None:
@@ -123,7 +147,7 @@ class GeminiClient(LLMClient):
             self.client = client
 
         self.max_tokens = max_tokens
-        self.thinking_config = thinking_config
+        self.thinking_config = _resolve_thinking_config(thinking_config, self.model)
 
     def _check_safety_blocks(self, response) -> None:
         """Check if response was blocked for safety reasons and raise appropriate exceptions."""
@@ -289,14 +313,15 @@ class GeminiClient(LLMClient):
             # Resolve max_tokens using precedence rules (see _resolve_max_tokens for details)
             resolved_max_tokens = self._resolve_max_tokens(max_tokens, model)
 
-            # Create generation config
+            # Create generation config. Re-resolve so a gemini-2.5-* small model
+            # still gets thinking off when the constructor model was not 2.5.
             generation_config = types.GenerateContentConfig(
                 temperature=self.temperature,
                 max_output_tokens=resolved_max_tokens,
                 response_mime_type='application/json' if response_model else None,
                 response_schema=response_model if response_model else None,
                 system_instruction=system_prompt,
-                thinking_config=self.thinking_config,
+                thinking_config=_resolve_thinking_config(self.thinking_config, model),
             )
 
             # Generate content using the simple string approach

--- a/tests/llm_client/test_gemini_client.py
+++ b/tests/llm_client/test_gemini_client.py
@@ -98,6 +98,40 @@ class TestGeminiClientInitialization:
             client = GeminiClient(thinking_config=thinking_config)
             assert client.thinking_config == thinking_config
 
+    @patch('google.genai.Client')
+    def test_init_defaults_thinking_budget_zero_for_gemini_2_5(self, mock_client):
+        """Unset thinking_config on gemini-2.5-* disables thinking (budget=0)."""
+        from google.genai import types
+
+        for model in ('gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite'):
+            config = LLMConfig(api_key='test_api_key', model=model)
+            client = GeminiClient(config=config, cache=False)
+
+            assert client.thinking_config is not None, model
+            assert isinstance(client.thinking_config, types.ThinkingConfig)
+            assert client.thinking_config.thinking_budget == 0, model
+
+    @patch('google.genai.Client')
+    def test_init_does_not_default_thinking_config_for_non_2_5_models(self, mock_client):
+        """Non-2.5 models keep thinking_config unset when the caller omits it."""
+        for model in ('gemini-2.0-flash', 'gemini-3-flash-preview', 'gemini-1.5-pro', None):
+            config = LLMConfig(api_key='test_api_key', model=model)
+            client = GeminiClient(config=config, cache=False)
+
+            assert client.thinking_config is None, model
+
+    @patch('google.genai.Client')
+    def test_init_explicit_thinking_config_wins_for_gemini_2_5(self, mock_client):
+        """An explicit thinking_config is preserved, including enabling thinking."""
+        from google.genai import types
+
+        thinking_config = types.ThinkingConfig(thinking_budget=1024)
+        config = LLMConfig(api_key='test_api_key', model='gemini-2.5-flash')
+        client = GeminiClient(config=config, cache=False, thinking_config=thinking_config)
+
+        assert client.thinking_config is thinking_config
+        assert client.thinking_config.thinking_budget == 1024
+
 
 class TestGeminiClientGenerateResponse:
     """Tests for GeminiClient generate_response method."""
@@ -383,6 +417,32 @@ class TestGeminiClientGenerateResponse:
         config = call_args[1]['config']
         # Explicit parameter should override everything else
         assert config.max_output_tokens == 500
+
+    @pytest.mark.asyncio
+    async def test_generate_defaults_thinking_budget_for_gemini_2_5_small_model(
+        self, mock_gemini_client
+    ):
+        """Resolved gemini-2.5-* models get thinking_budget=0 even if the ctor model is not 2.5."""
+        config = LLMConfig(api_key='test_api_key', model='gemini-3-flash-preview')
+        client = GeminiClient(config=config, cache=False, client=mock_gemini_client)
+        assert client.thinking_config is None
+
+        mock_response = MagicMock()
+        mock_response.text = 'Test response'
+        mock_response.candidates = []
+        mock_response.prompt_feedback = None
+        mock_gemini_client.aio.models.generate_content.return_value = mock_response
+
+        await client.generate_response(
+            [Message(role='user', content='Test message')],
+            model_size=ModelSize.small,
+        )
+
+        call_args = mock_gemini_client.aio.models.generate_content.call_args
+        gen_config = call_args[1]['config']
+        assert call_args[1]['model'] == DEFAULT_SMALL_MODEL
+        assert gen_config.thinking_config is not None
+        assert gen_config.thinking_config.thinking_budget == 0
 
     @pytest.mark.asyncio
     async def test_max_tokens_precedence_fallback(self, mock_gemini_client):


### PR DESCRIPTION
Fixes #1868

## Summary

When `thinking_config` is left unset, Gemini 2.5 models can spend output budget on thinking and truncate structured JSON mid-object.

## Changes

- If the caller did not pass `thinking_config`, default `gemini-2.5-*` to `ThinkingConfig(thinking_budget=0)`.
- Explicit `thinking_config` from the caller still wins (including enabling thinking).
- Constructor docstring updated; small unit coverage for the default.
- Separate from #1869.

## Tests

- `tests/llm_client/test_gemini_client.py` (incl. new default cases)
- Full no-DB unit gate green locally in the agent run
