### PR TITLE
fix(bulk): collapse exact-fact duplicates across episodes in dedupe_edges_bulk

### DIFF
--- a/graphiti_core/utils/bulk_utils.py
+++ b/graphiti_core/utils/bulk_utils.py
@@ -558,8 +558,17 @@ async def dedupe_edges_bulk(
 
     # For now we won't track edge invalidation
     duplicate_pairs: list[tuple[str, str]] = []
-    for i, (_, _, duplicates) in enumerate(bulk_edge_resolutions):
+    for i, (resolved, _, duplicates) in enumerate(bulk_edge_resolutions):
         episode, edge, candidates = dedupe_tuples[i]
+        # resolve_extracted_edge signals a duplicate in two ways: the LLM path
+        # lists the matched candidates as `duplicates`, while the exact-fact
+        # fast path returns the matched candidate itself as `resolved` with an
+        # EMPTY duplicates list. resolve_extracted_edges treats
+        # `resolved.uuid != edge.uuid` as "duplicate of an existing edge";
+        # mirror that here, or two episodes in one batch that yield the same
+        # fact between the same nodes both survive as distinct edges.
+        if resolved.uuid != edge.uuid:
+            duplicate_pairs.append((edge.uuid, resolved.uuid))
         for duplicate in duplicates:
             duplicate_pairs.append((edge.uuid, duplicate.uuid))
 
@@ -569,6 +578,19 @@ async def dedupe_edges_bulk(
     edge_uuid_map: dict[str, EntityEdge] = {
         edge.uuid: edge for edges in extracted_edges for edge in edges
     }
+
+    # The surviving edge of a collapsed group must carry every contributing
+    # episode. The fast path only appends the episode to the first matching
+    # candidate, so with three or more identical edges the provenance is
+    # spread unevenly across the group and the survivor (the lexicographically
+    # smallest uuid) can hold a partial list.
+    for uuid, canonical_uuid in compressed_map.items():
+        if uuid == canonical_uuid:
+            continue
+        canonical = edge_uuid_map[canonical_uuid]
+        for episode_uuid in edge_uuid_map[uuid].episodes:
+            if episode_uuid not in canonical.episodes:
+                canonical.episodes.append(episode_uuid)
 
     edges_by_episode: dict[str, list[EntityEdge]] = {}
     for i, edges in enumerate(extracted_edges):

--- a/tests/utils/maintenance/test_bulk_utils.py
+++ b/tests/utils/maintenance/test_bulk_utils.py
@@ -563,3 +563,71 @@ async def test_extract_nodes_and_edges_bulk_custom_instructions_multiple_episode
 
     for call in extract_edges_calls:
         assert call['custom_extraction_instructions'] == custom_instructions
+
+
+def _identical_edge(episode: EpisodicNode, fact: str = 'Alice works at Acme') -> EntityEdge:
+    return EntityEdge(
+        name='WORKS_AT',
+        fact=fact,
+        group_id='group',
+        source_node_uuid='alice-uuid',
+        target_node_uuid='acme-uuid',
+        created_at=utc_now(),
+        episodes=[episode.uuid],
+    )
+
+
+async def _run_bulk_dedupe_through_real_resolver(monkeypatch, edges_per_episode):
+    """Drive dedupe_edges_bulk through the REAL resolve_extracted_edge so the
+    exact-fact fast path (which returns the matched candidate as `resolved`
+    with an EMPTY duplicates list) is exercised, not a mock of it (#1872)."""
+    clients = _make_clients()
+    clients.llm_client.generate_response = AsyncMock(
+        side_effect=AssertionError('exact-fact duplicates must not reach the LLM')
+    )
+
+    async def mock_create_embeddings(embedder, edges):
+        for edge in edges:
+            edge.fact_embedding = [1.0, 0.0]
+
+    monkeypatch.setattr(bulk_utils, 'create_entity_edge_embeddings', mock_create_embeddings)
+
+    episodes = [_make_episode(str(i)) for i in range(len(edges_per_episode))]
+    extracted = [
+        [_identical_edge(episode) for _ in range(count)]
+        for episode, count in zip(episodes, edges_per_episode, strict=True)
+    ]
+    episode_tuples = [(episode, []) for episode in episodes]
+
+    result = await bulk_utils.dedupe_edges_bulk(clients, extracted, episode_tuples, [], {}, {})
+    return episodes, extracted, result
+
+
+@pytest.mark.asyncio
+async def test_dedupe_edges_bulk_collapses_identical_facts_across_episodes(monkeypatch):
+    """Two episodes in one batch yielding the same fact between the same nodes
+    end up sharing ONE edge that records both episodes (#1872). Before the fix
+    the fast path's empty duplicates list hid the match from compress_uuid_map
+    and both edges survived as distinct uuids."""
+    episodes, extracted, result = await _run_bulk_dedupe_through_real_resolver(monkeypatch, [1, 1])
+
+    surviving = {edge.uuid for edges in result.values() for edge in edges}
+    assert len(surviving) == 1, surviving
+    survivor = result[episodes[0].uuid][0]
+    assert result[episodes[1].uuid][0] is survivor
+    assert set(survivor.episodes) == {episodes[0].uuid, episodes[1].uuid}
+
+
+@pytest.mark.asyncio
+async def test_dedupe_edges_bulk_survivor_carries_every_episode(monkeypatch):
+    """With three identical edges the fast path appends each episode to the
+    first matching candidate only, so provenance is spread unevenly across
+    the group; the surviving edge must still end up with all three episodes."""
+    episodes, extracted, result = await _run_bulk_dedupe_through_real_resolver(
+        monkeypatch, [1, 1, 1]
+    )
+
+    surviving = {edge.uuid for edges in result.values() for edge in edges}
+    assert len(surviving) == 1, surviving
+    survivor = next(iter(result.values()))[0]
+    assert set(survivor.episodes) == {episode.uuid for episode in episodes}


### PR DESCRIPTION
## Summary

Fixes #1872.

`add_episode_bulk` wrote two distinct `RELATES_TO` edges when two episodes in the same batch yielded the same fact between the same nodes, while sequential `add_episode` calls produce one. `resolve_extracted_edge` reports a duplicate in two ways: the LLM path lists the matched candidates in the third tuple element, but the exact-fact fast path (#929) returns the matched candidate itself as `resolved` with an **empty** duplicates list. `dedupe_edges_bulk` only read the duplicates list, so fast-path matches never reached `compress_uuid_map`, and each edge additionally got the other episode appended in place.

## Change

`graphiti_core/utils/bulk_utils.py`, `dedupe_edges_bulk` only (no change to `resolve_extracted_edge`):

- a `resolved` edge whose uuid differs from the input edge is recorded as a duplicate pair, in addition to the explicit duplicates list, mirroring the `resolved_edge.uuid == extracted_edge.uuid` convention in `resolve_extracted_edges`; the union-find is idempotent, so a pair reported both ways is harmless;
- after `compress_uuid_map`, every collapsed edge's `episodes` are folded into its canonical edge, so the survivor carries the full provenance (the fast path appends the episode to the first matching candidate only, which left three identical edges with `[ep0, ep1, ep2]`, `[ep1, ep0]`, `[ep2]`).

## Tests

`tests/utils/maintenance/test_bulk_utils.py`, driven through the **real** `resolve_extracted_edge` (the existing within-episode test mocks it to return the duplicate in the third element, i.e. the opposite of the fast path, which is why it did not catch this); the LLM client is an `AsyncMock` that fails if called:

- two episodes with an identical fact → one surviving uuid, both episodes reference the same edge object, and it records both episode uuids (fails on `main`: 2 uuids);
- three episodes → the survivor carries all three episode uuids (fails on `main`).

`pytest tests/utils/maintenance/test_bulk_utils.py` → 16 passed; `ruff format` / `ruff check` clean; pyright reports the same two pre-existing environment import errors on the module as on `main`.
