### PR TITLE
fix(falkordb): read endpoints off the yielded relationship in search_ops edge fulltext search

### DIFF
--- a/graphiti_core/driver/falkordb/operations/search_ops.py
+++ b/graphiti_core/driver/falkordb/operations/search_ops.py
@@ -238,13 +238,20 @@ class FalkorSearchOperations(SearchOperations):
         if filter_queries:
             filter_query = ' WHERE ' + (' AND '.join(filter_queries))
 
+        # FalkorDB plans a re-match of the endpoints by uuid as a full :Entity label
+        # scan for EVERY row the fulltext index yields, so the cost becomes
+        # O(hits x entities). The relationship the index already returned knows its
+        # own endpoints, so read them directly. The label predicate keeps the result
+        # set identical to the pattern's.
         cypher = (
             get_relationships_query(
                 'edge_name_and_fact', limit=limit, provider=GraphProvider.FALKORDB
             )
             + """
             YIELD relationship AS rel, score
-            MATCH (n:Entity)-[e:RELATES_TO {uuid: rel.uuid}]->(m:Entity)
+            WITH rel AS e, score, startNode(rel) AS n, endNode(rel) AS m
+            WHERE n:Entity AND m:Entity
+            WITH e, score, n, m
             """
             + filter_query
             + """

--- a/tests/utils/search/test_falkordb_search_ops_query_shape.py
+++ b/tests/utils/search/test_falkordb_search_ops_query_shape.py
@@ -1,0 +1,82 @@
+"""Query-shape regression tests for FalkorSearchOperations (no live database).
+
+``edge_fulltext_search`` must read a matched relationship's endpoints off the
+relationship the fulltext index already returned (``startNode``/``endNode``)
+instead of re-matching them by uuid
+(``MATCH (n:Entity)-[e:RELATES_TO {uuid: rel.uuid}]->(m:Entity)``). FalkorDB
+plans the re-match as a full ``:Entity`` label scan for every row the index
+yields, so the cost becomes O(hits x entities).
+
+The generic path in ``graphiti_core/search/search_utils.py`` was fixed for this;
+the driver-level copy here was not, and it becomes the executing path once
+search migrates onto ``driver.search_ops``.
+
+Mirrors the recording-driver approach of
+tests/utils/search/test_edge_bfs_query_shape.py: a recording executor captures
+the emitted Cypher, so no database connection is required.
+"""
+
+from typing import Any
+
+import pytest
+
+from graphiti_core.driver.falkordb.operations.search_ops import FalkorSearchOperations
+from graphiti_core.search.search_filters import SearchFilters
+
+
+class RecordingExecutor:
+    """Captures the Cypher and params a search operation emits, returning no rows."""
+
+    def __init__(self):
+        self.cypher_query = ''
+        self.params: dict[str, Any] = {}
+
+    async def execute_query(self, cypher_query_: str, **kwargs: Any):
+        self.cypher_query = cypher_query_
+        self.params = kwargs
+        return [], None, None
+
+
+@pytest.mark.asyncio
+async def test_edge_fulltext_search_resolves_endpoints_without_re_matching():
+    executor = RecordingExecutor()
+
+    await FalkorSearchOperations().edge_fulltext_search(
+        executor,  # pyright: ignore[reportArgumentType]
+        'anything',
+        SearchFilters(),
+        group_ids=['group-a'],
+        limit=10,
+    )
+
+    cypher = executor.cypher_query
+
+    # The endpoints come from the yielded relationship.
+    assert 'startNode(rel)' in cypher
+    assert 'endNode(rel)' in cypher
+
+    # And are never re-matched by uuid, which is what triggers the label scan.
+    assert 'RELATES_TO {uuid: rel.uuid}' not in cypher
+
+    # The label predicate must survive, so the result set stays identical to the
+    # pattern's: the old MATCH required both endpoints to be :Entity.
+    assert 'n:Entity' in cypher
+    assert 'm:Entity' in cypher
+
+
+@pytest.mark.asyncio
+async def test_edge_fulltext_search_still_applies_group_and_limit():
+    executor = RecordingExecutor()
+
+    await FalkorSearchOperations().edge_fulltext_search(
+        executor,  # pyright: ignore[reportArgumentType]
+        'anything',
+        SearchFilters(),
+        group_ids=['group-a'],
+        limit=7,
+    )
+
+    assert 'e.group_id IN $group_ids' in executor.cypher_query
+    assert 'ORDER BY score DESC' in executor.cypher_query
+    assert executor.params['group_ids'] == ['group-a']
+    assert executor.params['limit'] == 7


### PR DESCRIPTION
Applies the #1711 fix to the second copy of the query, in `graphiti_core/driver/falkordb/operations/search_ops.py`.

Fixes #1875.

## Problem

`FalkorSearchOperations.edge_fulltext_search` resolves a matched relationship's endpoints by re-matching them:

```cypher
YIELD relationship AS rel, score
MATCH (n:Entity)-[e:RELATES_TO {uuid: rel.uuid}]->(m:Entity)
```

FalkorDB plans that as a full `:Entity` label scan for every row the fulltext index yields, so the cost is O(hits × entities). #1711 removed this from `graphiti_core/search/search_utils.py` and left the driver-level copy unchanged.

The copy is unreachable today: `FalkorDriver` sets `search_ops` but leaves the legacy `search_interface` unset, and `search_utils.edge_fulltext_search` only delegates when `driver.search_interface` is truthy. It becomes the executing path once search migrates onto `driver.search_ops`, which `spec/driver-operations-redesign.md` marks as planned. At that point #1506, #1272 and #1592 all return, silently — results stay correct, only latency changes.

## Change

Read the endpoints off the relationship the index already returned, matching what `search_utils.py` now does:

```cypher
YIELD relationship AS rel, score
WITH rel AS e, score, startNode(rel) AS n, endNode(rel) AS m
WHERE n:Entity AND m:Entity
WITH e, score, n, m
```

The label predicate is retained, so the result set stays identical to the pattern's — the old `MATCH` required both endpoints to be `:Entity`.

The episode path in this file has the same shape and is not touched here; #1826 covers it.

## Verification

**Result-set equivalence on a real FalkorDB** (`falkordb/falkordb:v4.18.10`), on a graph built with graphiti's own index definition and seeded with 400 `:Entity`-to-`:Entity` edges plus 20 `:Other`-to-`:Other` edges carrying the same searchable text, to exercise the label predicate:

| Fulltext query | Old shape | New shape | Identical | Non-`:Entity` edges returned |
| --- | --- | --- | --- | --- |
| `alpha` | 134 | 134 | yes | 0 / 0 |
| `beta` | 133 | 133 | yes | 0 / 0 |
| `alpha\|beta\|gamma` | 400 | 400 | yes | 0 / 0 |

Both shapes exclude all 20 non-`:Entity` edges, so the predicate still does its job.

**Cost, measured separately on the same image** with the two shapes on identical graphs:

| Graph | Fulltext hits | Old shape | New shape |
| --- | --- | --- | --- |
| 2,500 entities / 4,500 edges | 4,500 | timeout, >30 s | 5.1 ms |
| 5,000 / 20,000 | 200 | 4,524 ms | 0.5 ms |
| 5,000 / 20,000 | 20,000 | timeout, >30 s | 22.9 ms |
| 20,000 / 100,000 | 1,000 | timeout, >30 s | 1.9 ms |

Note the narrow-query rows: the old shape scales with entity count, not just hit count, so even a 200-hit query is affected.

**Tests.** `tests/utils/search/test_falkordb_search_ops_query_shape.py` asserts the emitted Cypher uses `startNode`/`endNode`, never re-matches by uuid, and keeps the label predicate, plus that the group filter and limit still apply. It uses the recording-executor approach of the neighbouring `test_edge_bfs_query_shape.py`, so it needs no database. Both tests fail on the unpatched file and pass with the change, and they sit under `tests/utils/search/` so the existing unit-tests job collects them.

The no-database unit gate is green: 382 passed, 11 skipped. `ruff check` and `ruff format --check` are clean.
