### PR TITLE
fix(communities): skip empty clusters in the generic build path

### DIFF
--- a/graphiti_core/utils/maintenance/community_operations.py
+++ b/graphiti_core/utils/maintenance/community_operations.py
@@ -79,13 +79,19 @@ async def get_community_clusters(
 
         cluster_uuids = label_propagation(projection)
 
-        community_clusters.extend(
-            list(
-                await semaphore_gather(
-                    *[EntityNode.get_by_uuids(driver, cluster) for cluster in cluster_uuids]
-                )
-            )
+        # Mirror the driver-specific implementations, which skip empty clusters
+        # (see e.g. driver/neo4j/operations/graph_ops.py). This fallback path
+        # skipped neither an empty uuid list nor a cluster whose nodes all
+        # failed to resolve -- get_by_uuids returns whatever it finds without
+        # erroring, so a node deleted or filtered out after label propagation
+        # yields an empty cluster. build_community then raises IndexError on
+        # summaries[0], and because semaphore_gather uses asyncio.gather
+        # without return_exceptions, that one empty cluster fails the whole
+        # batch and discards every community already built alongside it.
+        resolved_clusters = await semaphore_gather(
+            *[EntityNode.get_by_uuids(driver, cluster) for cluster in cluster_uuids if cluster]
         )
+        community_clusters.extend([cluster for cluster in resolved_clusters if cluster])
 
     return community_clusters
 
@@ -175,6 +181,8 @@ async def build_community(
     llm_client: LLMClient, community_cluster: list[EntityNode]
 ) -> tuple[CommunityNode, list[CommunityEdge]]:
     summaries = [entity.summary for entity in community_cluster]
+    if not summaries:
+        raise ValueError('build_community requires a non-empty community_cluster')
     length = len(summaries)
     while length > 1:
         odd_one_out: str | None = None

--- a/tests/utils/maintenance/test_build_communities.py
+++ b/tests/utils/maintenance/test_build_communities.py
@@ -1,0 +1,132 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graphiti_core.nodes import EntityNode
+from graphiti_core.utils.maintenance.community_operations import (
+    build_community,
+    get_community_clusters,
+)
+
+
+def _mock_driver():
+    driver = MagicMock()
+    driver.graph_operations_interface = None
+    driver.graph_ops = None
+    driver.execute_query = AsyncMock(return_value=([], None, None))
+    return driver
+
+
+def _entity(name: str) -> EntityNode:
+    return EntityNode(name=name, group_id='g1', labels=['Entity'], summary=f'{name} summary')
+
+
+@pytest.mark.asyncio
+async def test_get_community_clusters_skips_empty_clusters():
+    """An unresolvable cluster must not reach build_community.
+
+    ``EntityNode.get_by_uuids`` returns only the nodes it finds and does not
+    error on the rest, so a node deleted or filtered out between label
+    propagation and this fetch yields an empty cluster. The driver-specific
+    implementations already skip those (see
+    ``driver/neo4j/operations/graph_ops.py``); this fallback path did not, and
+    ``build_community`` raises ``IndexError`` on ``summaries[0]`` for one.
+    """
+    driver = _mock_driver()
+
+    with (
+        patch.object(
+            EntityNode, 'get_by_group_ids', new=AsyncMock(return_value=[_entity('alice')])
+        ),
+        patch.object(
+            EntityNode,
+            'get_by_uuids',
+            new=AsyncMock(side_effect=[[], [_entity('bob')]]),
+        ),
+        patch(
+            'graphiti_core.utils.maintenance.community_operations.label_propagation',
+            return_value=[['missing-uuid'], ['bob-uuid']],
+        ),
+    ):
+        clusters = await get_community_clusters(driver, ['g1'])
+
+    assert all(cluster for cluster in clusters), (
+        f'an empty cluster survived into the result: {clusters}'
+    )
+    assert len(clusters) == 1
+    assert clusters[0][0].name == 'bob'
+
+
+@pytest.mark.asyncio
+async def test_get_community_clusters_skips_empty_uuid_lists():
+    """An empty uuid list is not even worth a fetch."""
+    driver = _mock_driver()
+    get_by_uuids = AsyncMock(return_value=[_entity('bob')])
+
+    with (
+        patch.object(
+            EntityNode, 'get_by_group_ids', new=AsyncMock(return_value=[_entity('alice')])
+        ),
+        patch.object(EntityNode, 'get_by_uuids', new=get_by_uuids),
+        patch(
+            'graphiti_core.utils.maintenance.community_operations.label_propagation',
+            return_value=[[], ['bob-uuid']],
+        ),
+    ):
+        clusters = await get_community_clusters(driver, ['g1'])
+
+    assert get_by_uuids.await_count == 1, 'the empty uuid list should not be fetched'
+    assert len(clusters) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_community_clusters_keeps_healthy_clusters_intact():
+    """The healthy path is unchanged: every resolvable cluster is returned."""
+    driver = _mock_driver()
+
+    with (
+        patch.object(
+            EntityNode, 'get_by_group_ids', new=AsyncMock(return_value=[_entity('alice')])
+        ),
+        patch.object(
+            EntityNode,
+            'get_by_uuids',
+            new=AsyncMock(side_effect=[[_entity('a'), _entity('b')], [_entity('c')]]),
+        ),
+        patch(
+            'graphiti_core.utils.maintenance.community_operations.label_propagation',
+            return_value=[['a', 'b'], ['c']],
+        ),
+    ):
+        clusters = await get_community_clusters(driver, ['g1'])
+
+    assert [len(c) for c in clusters] == [2, 1]
+
+
+@pytest.mark.asyncio
+async def test_build_community_rejects_an_empty_cluster():
+    """Called directly, build_community reports the contract it needs.
+
+    ``semaphore_gather`` wraps ``asyncio.gather`` without
+    ``return_exceptions``, so a bare IndexError here fails the entire
+    ``build_communities`` batch and discards the communities already built
+    alongside it. A named error beats an index crash for whoever reads the log.
+    """
+    with pytest.raises(ValueError, match='non-empty community_cluster'):
+        await build_community(MagicMock(), [])


### PR DESCRIPTION
## The bug

`get_community_clusters`' generic fallback path passed every result of
`EntityNode.get_by_uuids` straight into `build_community`, including empty ones:

```python
community_clusters.extend(
    list(
        await semaphore_gather(
            *[EntityNode.get_by_uuids(driver, cluster) for cluster in cluster_uuids]
        )
    )
)
```

`get_by_uuids` returns only the nodes it finds and does not error on the rest
(`nodes = [get_entity_node_from_record(record, ...) for record in records]`), so
a node deleted or filtered out between label propagation and this fetch yields
an empty cluster. `build_community` then raises `IndexError` on `summaries[0]`.

## The blast radius is the whole batch

`semaphore_gather` wraps `asyncio.gather` without `return_exceptions`
(`graphiti_core/helpers.py:133`), so a single empty cluster fails
`build_communities` outright — every community already built alongside it is
discarded, and `Graphiti.build_communities` surfaces a bare `IndexError` with
nothing pointing at the cluster that caused it.

## This is already guarded elsewhere

All four driver-specific implementations skip empty clusters:

- `driver/neo4j/operations/graph_ops.py:132`
- `driver/falkordb/operations/graph_ops.py:163`
- `driver/kuzu/operations/graph_ops.py:138`
- `driver/neptune/operations/graph_ops.py:138`

each with `if not cluster: continue`. Only the generic fallback was missing it —
and unlike those, it also did nothing for a cluster whose uuids all failed to
resolve, which is the case that actually produces an empty *node* list.

## Reproduction on `4bd7287`

```python
await build_community(llm_client, [])
# IndexError: list index out of range
```

## The change

Filter at both points: empty uuid lists before the fetch (matching the drivers),
and empty node lists after it (the case the drivers do not have to handle,
because they build clusters from records directly).

`build_community` additionally raises `ValueError` naming the requirement when
called with an empty cluster. It is reachable as a public helper, and given the
`asyncio.gather` behaviour above, a named error beats an index crash for whoever
reads the log.

The healthy path is unchanged — one of the tests pins that every resolvable
cluster is still returned, with its nodes intact.

## Tests

New file `tests/utils/maintenance/test_build_communities.py`, alongside the
existing `test_remove_communities.py`:

- `test_get_community_clusters_skips_empty_clusters` — a cluster whose nodes do
  not resolve never reaches `build_community`
- `test_get_community_clusters_skips_empty_uuid_lists` — asserts on
  `await_count`, so an empty uuid list is not even fetched
- `test_get_community_clusters_keeps_healthy_clusters_intact` — the healthy path
- `test_build_community_rejects_an_empty_cluster` — the direct-call contract

Reverting `community_operations.py` alone turns 3 of the 4 red, the first with
the original `IndexError: list index out of range` at
`community_operations.py:199`. The healthy-path test passes either way by
design.

## Verification

- `pytest tests/utils/maintenance/test_build_communities.py` — **4 passed**
- `pytest tests/utils/` — **213 passed**
- `pytest tests/utils/ tests/test_text_utils.py tests/test_edge_db_queries.py` — **233 passed**
- `ruff check` and `ruff format --check` on both changed files — clean
- `pyright graphiti_core/utils/maintenance/community_operations.py` — **0 errors**

The remaining top-level tests require a live Neo4j at `localhost:7687`, which is
not available in my environment, so they were excluded rather than reported as
passing.

## AI disclosure

This pull request was prepared with AI assistance. The change was reviewed,
tested, and verified locally by the contributor.
