### PR TITLE
Add pevans to the CLA allowlist [ZEPAI-3570]

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,7 +28,7 @@ jobs:
           private-key: ${{ secrets.CLA_APP_PRIVATE_KEY }}
 
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        if: (github.event.comment.body == 'recheck' || startsWith(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')) || github.event_name == 'pull_request_target'
         # Maintained node24 fork of the (archived) contributor-assistant/github-action.
         # Pinned to a commit SHA because the fork publishes no semver tags.
         uses: SiliconLabsSoftware/action-cla-assistant@89980ac6cfe974ea7703b4ccfbaeb1b2cc6065d2 # silabs_flavour_v2 (node24)

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -38,7 +38,7 @@ jobs:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/getzep/graphiti/blob/main/Zep-CLA.md" # e.g. a CLA or a DCO document
           branch: "main"
-          allowlist: paul-paliychuk,prasmussen15,danielchalef,dependabot[bot],ellipsis-dev,Claude[bot],claude[bot]
+          allowlist: paul-paliychuk,prasmussen15,danielchalef,pevans,dependabot[bot],ellipsis-dev,Claude[bot],claude[bot]
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)


### PR DESCRIPTION
## Summary
Add `pevans` to the `allowlist` of the CLA Assistant workflow. PRs authored by this maintainer account then pass the `CLAAssistant` required check without a signature comment, the same as the other maintainers in the list.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation/Tests

## Objective
The `CLAAssistant` check fails on #1881 and #1882 because the commit author is not in the allowlist.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

Workflow config change only.

## Breaking Changes
- [ ] This PR contains breaking changes

## Checklist
- [x] Code follows project style guidelines (`make lint` passes)
- [x] Self-review completed
- [ ] Documentation updated where necessary
- [x] No secrets or sensitive information committed

## Related Issues
Tracked in ZEPAI-3570.


## Signature comment fix
The bot's default prompt tells contributors to post `I have read the CLA Document and I hereby sign the CLA behalf on myself, e-mail: ...`, but the step's `if:` accepted only the exact short sentence, so the documented comment did nothing. The condition now uses `startsWith(...)`, so both forms trigger the signing run.
