### PR TITLE
fix: stop nested attribute values from aborting property-graph writes

### DIFF
--- a/graphiti_core/edges.py
+++ b/graphiti_core/edges.py
@@ -28,7 +28,7 @@ from typing_extensions import LiteralString
 from graphiti_core.driver.driver import GraphDriver, GraphProvider
 from graphiti_core.embedder import EmbedderClient
 from graphiti_core.errors import EdgeNotFoundError, GroupsEdgesNotFoundError
-from graphiti_core.helpers import parse_db_date
+from graphiti_core.helpers import merge_attributes_into_properties, parse_db_date
 from graphiti_core.models.edges.edge_db_queries import (
     COMMUNITY_EDGE_RETURN,
     EPISODIC_EDGE_RETURN,
@@ -362,9 +362,7 @@ class EntityEdge(Edge):
                 **edge_data,
             )
         else:
-            for k, v in (self.attributes or {}).items():
-                if k not in edge_data:
-                    edge_data[k] = v
+            merge_attributes_into_properties(edge_data, self.attributes)
             result = await driver.execute_query(
                 get_entity_edge_save_query(driver.provider),
                 edge_data=edge_data,

--- a/graphiti_core/helpers.py
+++ b/graphiti_core/helpers.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import asyncio
+import json
 import os
 import re
 from collections.abc import Coroutine
@@ -29,6 +30,7 @@ from pydantic import BaseModel
 
 from graphiti_core.driver.driver import GraphProvider
 from graphiti_core.errors import GroupIdValidationError, NodeLabelValidationError
+from graphiti_core.utils.datetime_utils import convert_datetimes_to_strings
 
 load_dotenv()
 
@@ -218,3 +220,39 @@ def validate_excluded_entity_types(
         )
 
     return True
+
+
+def merge_attributes_into_properties(
+    payload: dict[str, Any],
+    attributes: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Merge ``attributes`` into a save payload for property-graph providers.
+
+    Neo4j, FalkorDB and Neptune store each attribute as its own property, and a
+    property value must be a primitive or an array of primitives. A nested value
+    therefore aborts the whole write with a driver-level type error:
+    ``Property values can only be of primitive types or arrays thereof``.
+
+    Two real inputs produce a nested value, and neither should be able to fail an
+    ingestion run: a legitimately nested extraction, and an LLM that echoed a
+    JSON Schema field definition instead of filling it in. Both are preserved
+    here by JSON-encoding only the offending values, which keeps the data
+    readable and queryable as text rather than dropping it.
+
+    Keys already present in ``payload`` are never overwritten, because attributes
+    may carry stale string copies of typed fields such as ``reference_time``.
+    """
+    for key, value in (attributes or {}).items():
+        if key in payload:
+            continue
+        payload[key] = _as_storable_property(value)
+    return payload
+
+
+def _as_storable_property(value: Any) -> Any:
+    """Return ``value`` if a property graph can store it, else a JSON encoding."""
+    if isinstance(value, dict):
+        return json.dumps(convert_datetimes_to_strings(value), ensure_ascii=False)
+    if isinstance(value, list) and any(isinstance(item, (dict, list)) for item in value):
+        return json.dumps(convert_datetimes_to_strings(value), ensure_ascii=False)
+    return value

--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -32,7 +32,11 @@ from graphiti_core.driver.driver import (
 )
 from graphiti_core.embedder import EmbedderClient
 from graphiti_core.errors import NodeNotFoundError
-from graphiti_core.helpers import parse_db_date, validate_node_labels
+from graphiti_core.helpers import (
+    merge_attributes_into_properties,
+    parse_db_date,
+    validate_node_labels,
+)
 from graphiti_core.models.nodes.node_db_queries import (
     COMMUNITY_NODE_RETURN,
     COMMUNITY_NODE_RETURN_NEPTUNE,
@@ -567,9 +571,7 @@ class EntityNode(Node):
                 **entity_data,
             )
         else:
-            for k, v in (self.attributes or {}).items():
-                if k not in entity_data:
-                    entity_data[k] = v
+            merge_attributes_into_properties(entity_data, self.attributes)
             labels = ':'.join(self.labels + ['Entity'])
 
             result = await driver.execute_query(

--- a/graphiti_core/utils/bulk_utils.py
+++ b/graphiti_core/utils/bulk_utils.py
@@ -31,7 +31,11 @@ from graphiti_core.driver.driver import (
 from graphiti_core.edges import Edge, EntityEdge, EpisodicEdge, create_entity_edge_embeddings
 from graphiti_core.embedder import EmbedderClient
 from graphiti_core.graphiti_types import GraphitiClients
-from graphiti_core.helpers import normalize_l2, semaphore_gather
+from graphiti_core.helpers import (
+    merge_attributes_into_properties,
+    normalize_l2,
+    semaphore_gather,
+)
 from graphiti_core.models.edges.edge_db_queries import (
     get_entity_edge_save_bulk_query,
     get_episodic_edge_save_bulk_query,
@@ -182,9 +186,7 @@ async def add_nodes_and_edges_bulk_tx(
             attributes = convert_datetimes_to_strings(node.attributes) if node.attributes else {}
             entity_data['attributes'] = json.dumps(attributes)
         else:
-            for k, v in (node.attributes or {}).items():
-                if k not in entity_data:
-                    entity_data[k] = v
+            merge_attributes_into_properties(entity_data, node.attributes)
 
         nodes.append(entity_data)
 
@@ -216,9 +218,7 @@ async def add_nodes_and_edges_bulk_tx(
             # Attributes may contain stale string versions of typed fields
             # (e.g. reference_time as ISO string) that would replace the
             # datetime values set above.
-            for k, v in (edge.attributes or {}).items():
-                if k not in edge_data:
-                    edge_data[k] = v
+            merge_attributes_into_properties(edge_data, edge.attributes)
 
         edges.append(edge_data)
 

--- a/tests/test_nested_attribute_storage.py
+++ b/tests/test_nested_attribute_storage.py
@@ -1,0 +1,132 @@
+"""Attribute values written to a graph store must be storable by that store.
+
+Neo4j (like FalkorDB and Neptune) rejects a property whose value is a Map or a
+list of Maps: ``Neo.ClientError.Statement.TypeError - Property values can only be
+of primitive types or arrays thereof``. Kuzu already avoids this by serialising
+``attributes`` to a JSON string, but the other providers spread each attribute
+into its own property, so a nested value reaches the driver unchanged and the
+whole episode fails.
+
+Two distinct real-world inputs produce a nested value, and both must survive:
+
+* A legitimately nested extraction — the model correctly returned an object.
+* A schema echo — the model returned the JSON Schema field definition instead of
+  a value. This is malformed, but it must not take down the ingestion pipeline.
+
+These tests assert the storage invariant (no Map-valued property reaches the
+driver), not any particular encoding, so an implementation may satisfy them by
+serialising, flattening, or rejecting the value as long as the write is safe.
+"""
+
+from typing import Any
+
+import pytest
+
+from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.edges import EntityEdge
+from graphiti_core.nodes import EntityNode
+from graphiti_core.utils.datetime_utils import utc_now
+
+# A value the model extracted correctly; the source data really is nested.
+LEGITIMATE_NESTED_ATTRIBUTE: dict[str, Any] = {
+    'document': {
+        'title': 'compose.yml.bak.qworkers.*',
+        'description': 'Compose file backup used for rolling back the queue worker patch.',
+    }
+}
+
+# A value where the model echoed the JSON Schema field definition back instead of
+# filling it in. Malformed, but it must not crash the write path.
+SCHEMA_ECHO_ATTRIBUTE: dict[str, Any] = {
+    'description': {
+        'description': 'Brief description of the object. Only use information mentioned in the context.',
+        'title': 'Description',
+        'type': 'string',
+    }
+}
+
+NESTED_LIST_ATTRIBUTE: dict[str, Any] = {
+    'contacts': [{'kind': 'email', 'value': 'a@example.com'}],
+}
+
+PROPERTY_SAFE_PROVIDERS = [
+    GraphProvider.NEO4J,
+    GraphProvider.FALKORDB,
+    GraphProvider.NEPTUNE,
+]
+
+
+def _assert_property_values_are_storable(payload: dict[str, Any]) -> None:
+    """Fail if any property value is a Map or an array containing a Map."""
+    for key, value in payload.items():
+        assert not isinstance(value, dict), (
+            f'property {key!r} is a Map; the store accepts only primitives or arrays of them'
+        )
+        if isinstance(value, list):
+            assert not any(isinstance(item, dict) for item in value), (
+                f'property {key!r} is an array containing a Map'
+            )
+
+
+class _RecordingDriver:
+    """Capture the parameters a save would send without touching a database."""
+
+    def __init__(self, provider: GraphProvider) -> None:
+        self.provider = provider
+        self.graph_operations_interface = None
+        self.captured: dict[str, Any] = {}
+
+    async def execute_query(self, query: str, **kwargs: Any) -> Any:
+        self.captured = kwargs
+        return None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('provider', PROPERTY_SAFE_PROVIDERS)
+@pytest.mark.parametrize(
+    'attributes',
+    [LEGITIMATE_NESTED_ATTRIBUTE, SCHEMA_ECHO_ATTRIBUTE, NESTED_LIST_ATTRIBUTE],
+    ids=['legitimate_nested', 'schema_echo', 'nested_list'],
+)
+async def test_entity_node_save_never_sends_map_valued_property(provider, attributes):
+    node = EntityNode(
+        name='Alice',
+        group_id='group',
+        labels=['Entity'],
+        summary='summary',
+        attributes=dict(attributes),
+    )
+    node.name_embedding = [0.1, 0.2]
+    driver = _RecordingDriver(provider)
+
+    await node.save(driver)  # type: ignore[arg-type]
+
+    entity_data = driver.captured.get('entity_data', driver.captured)
+    _assert_property_values_are_storable(entity_data)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('provider', PROPERTY_SAFE_PROVIDERS)
+@pytest.mark.parametrize(
+    'attributes',
+    [LEGITIMATE_NESTED_ATTRIBUTE, SCHEMA_ECHO_ATTRIBUTE, NESTED_LIST_ATTRIBUTE],
+    ids=['legitimate_nested', 'schema_echo', 'nested_list'],
+)
+async def test_entity_edge_save_never_sends_map_valued_property(provider, attributes):
+    edge = EntityEdge(
+        source_node_uuid='source-uuid',
+        target_node_uuid='target-uuid',
+        name='RELATES_TO',
+        group_id='group',
+        fact='a fact',
+        episodes=[],
+        created_at=utc_now(),
+        attributes=dict(attributes),
+    )
+    edge.fact_embedding = [0.1, 0.2]
+    driver = _RecordingDriver(provider)
+
+    await edge.save(driver)  # type: ignore[arg-type]
+
+    edge_data = driver.captured.get('edge_data', driver.captured)
+    _assert_property_values_are_storable(edge_data)


### PR DESCRIPTION
### Summary

Route attribute merging for Neo4j, FalkorDB and Neptune through a shared helper that JSON-encodes only values a property graph cannot store. Kuzu already does this via `json.dumps(attributes)`; the other providers spread attributes into individual properties, so one nested value aborts the whole episode with `Property values can only be of primitive types or arrays thereof`.

Failure analysis, measured sub-class split and a database-free reproduction are in #1885.

### Why encode rather than drop

Of 83 dead-lettered episodes carrying this error in a production deployment, 40 held correctly extracted nested data and 43 held a JSON Schema echoed back by the model. Dropping non-primitive values would silently discard the first group, so both are preserved as JSON text, which stays readable and queryable.

### Changes

- `graphiti_core/helpers.py` — add `merge_attributes_into_properties()` and `_as_storable_property()`. Encode only `dict` values and lists containing `dict`/`list`, leave flat values untouched, never overwrite keys already present on the payload.
- `graphiti_core/nodes.py`, `graphiti_core/edges.py`, `graphiti_core/utils/bulk_utils.py` — use the helper at the four call sites that previously spread attributes inline.

Behaviour is unchanged for flat attributes and for Kuzu.

### Testing

`tests/test_nested_attribute_storage.py` asserts the storage invariant — no Map-valued property reaches the driver — rather than a specific encoding, so it stays valid if maintainers prefer a different remedy. It covers all three affected providers across three payload shapes: legitimate nesting, schema echo, and a list of objects.

- Without the production change: **18 failed**
- With it: **18 passed**
- `ruff format --check` and `ruff check` on changed files: clean
- Integration tests requiring a live Neo4j on `localhost:7687` error identically with and without this change; they are environment preconditions, not regressions.

### Note on overlapping PRs

#440 and #1109 address the same class. I opened this because both have been open for a long time and neither is currently mergeable as-is, but I have no attachment to this particular shape — if either is revived, or if maintainers prefer flattening or rejection over encoding, the invariant-based tests here should still be useful.
